### PR TITLE
#106 - Adding URLs found in data-settings of Elementor

### DIFF
--- a/src/class-ss-url-extractor.php
+++ b/src/class-ss-url-extractor.php
@@ -468,7 +468,7 @@ class Url_Extractor {
 	 *
 	 * @return string An updated string for the text that was originally matched
 	 */
-	private function css_matches( $matches ) {
+	public function css_matches( $matches ) {
 		$full_match    = $matches[0];
 		$extracted_url = $matches[1];
 

--- a/src/integrations/class-elementor-integration.php
+++ b/src/integrations/class-elementor-integration.php
@@ -2,6 +2,8 @@
 
 namespace Simply_Static;
 
+use voku\helper\HtmlDomParser;
+
 class Elementor_Integration extends Integration {
     /**
      * Given plugin handler ID.
@@ -26,6 +28,26 @@ class Elementor_Integration extends Integration {
      */
     public function run() {
         add_action( 'ss_after_setup_task', [ $this, 'register_assets' ] );
+        add_action( 'ss_after_extract_and_replace_urls_in_html', [ $this, 'extract_elementor_settings' ], 20, 2 );
+    }
+
+    /**
+     * @param HtmlDomParser $dom DOM object.
+     * @param Url_Extractor $extractor Extractor.
+     * @return void
+     */
+    public function extract_elementor_settings( $dom, $extractor ) {
+        $settings = $dom->find('[data-settings]');
+        $pattern  = '/"url":"(https?:\/\/\S+?)"/i';
+        foreach ( $settings as $node ) {
+            $json = $node->{'data-settings'};
+            $decoded = html_entity_decode( wp_unslash( $json ) );
+            $json = preg_replace_callback( $pattern, array( $extractor, 'css_matches' ), $decoded );
+            $json = json_decode( $json );
+            $node->{'data-settings'} = esc_attr( wp_json_encode( $json ) );
+
+
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #106 

### Changes

Before the HTML page is saved, we're trying to find elements with [data-settings] in the HTML. If it's there, we're finding URLs in it and replacing them if appropriate.

### Testing

- [x] Have Elementor plugin installed 
- [x] Edit a page using Elementor
- [x] On a section, go to Style > Background and choose the slider option
- [x] Add 2 or more images
- [x] Generate Static Page
- [x] Check if such images are in the wp-content/uploads folder of the static site (in correct subfolder)
- [x] Test if the carousel works and images are changing