### PR TITLE
#136 - Fixing URL extraction. Making sure valid URLs are changed.

### DIFF
--- a/src/class-ss-url-extractor.php
+++ b/src/class-ss-url-extractor.php
@@ -294,8 +294,14 @@ class Url_Extractor {
 					}
 				}
 
+                $strict_url_validation = apply_filters( 'simply_static_strict_url_validation', false );
+
 				foreach ( $extracted_urls as $extracted_url ) {
-					if ( filter_var( $extracted_url, FILTER_VALIDATE_URL ) ) {
+                    if ( $strict_url_validation && ! filter_var( $extracted_url, FILTER_VALIDATE_URL ) ) {
+                        continue;
+                    }
+
+                    if ( $extracted_url !== '' ) {
 						$updated_extracted_url = $this->add_to_extracted_urls( $extracted_url );
 						$attribute_value       = str_replace( $extracted_url, $updated_extracted_url, $attribute_value );
 					}

--- a/src/class-ss-util.php
+++ b/src/class-ss-util.php
@@ -167,6 +167,15 @@ class Util {
 		return $contents;
 	}
 
+    public static function is_valid_scheme( $scheme ) {
+        $valid_schemes = apply_filters( 'simply_static_valid_schemes', [
+           'http',
+           'https',
+        ]);
+
+        return in_array( $scheme, $valid_schemes );
+    }
+
 	/**
 	 * Given a URL extracted from a page, return an absolute URL
 	 *
@@ -220,6 +229,9 @@ class Util {
 
 		// if no path, check for an ending slash; if there isn't one, add one
 		if ( ! isset( $parsed_extracted_url['path'] ) ) {
+            if ( isset( $parsed_extracted_url['scheme'] ) && ! self::is_valid_scheme( $parsed_extracted_url['scheme'] ) ) {
+                return $extracted_url;
+            }
 			$clean_url     = self::remove_params_and_fragment( $extracted_url );
 			$fragment      = substr( $extracted_url, strlen( $clean_url ) );
 			$extracted_url = trailingslashit( $clean_url ) . $fragment;


### PR DESCRIPTION
Closes #136 

### Changes

Reverted the change done in #128 
Added another way to check if it's a valid URL or CSS.

If `parse_url` gives an invalid scheme (in #128 it was background-color as scheme), we return the extracted URL. 
This will be checked if there is no path set, but there is a scheme (relative URLs don't have a scheme).

Added also a filter for strict URL validation.

If set `add_filter( 'simply_static_strict_url_validation', '__return_true' );` (somewhere in a plugin or theme) it will use the solution done in #128.

### Testing

1. Install https://wordpress.org/plugins/sassy-social-share/ and activate it
2. Generate static site
3. Check the social sharing style attributes where the background-color should be correct, without a forward slash
4. Check other URLs to be sure everything is still correctly extracted.