### PR TITLE
#133 - Adding message parameter to cancel method & public method to get static page

### DIFF
--- a/src/class-ss-archive-creation-job.php
+++ b/src/class-ss-archive-creation-job.php
@@ -198,7 +198,7 @@ class Archive_Creation_Job extends \WP_Background_Process {
 	 * Cancel the currently running job
 	 * @return void
 	 */
-	public function cancel() {
+	public function cancel( $message = '' ) {
 		if ( ! $this->is_job_done() ) {
 			Util::debug_log( "Cancelling job; job is not done" );
 
@@ -220,6 +220,10 @@ class Archive_Creation_Job extends \WP_Background_Process {
 				$batch->data = array( 'cancel' );
 				$this->update( $batch->key, $batch->data );
 			}
+
+            if ( $message ) {
+                $this->save_status_message( $message );
+            }
 
 			$this->dispatch();
 		} else {

--- a/src/class-ss-plugin.php
+++ b/src/class-ss-plugin.php
@@ -43,7 +43,7 @@ class Plugin {
 
 	/**
 	 * Archive creation process
-	 * @var Simply_Static\Archive_Creation_Job
+	 * @var \Simply_Static\Archive_Creation_Job
 	 */
 	protected $archive_creation_job = null;
 
@@ -418,6 +418,13 @@ class Plugin {
 		wp_send_json( array(
 			'html' => $content
 		) );
+	}
+
+	/**
+	 * @return Archive_Creation_Job|null
+	 */
+	public function get_archive_creation_job() {
+		return $this->archive_creation_job;
 	}
 
 	/**

--- a/src/class-ss-url-extractor.php
+++ b/src/class-ss-url-extractor.php
@@ -153,6 +153,15 @@ class Url_Extractor {
 		return file_put_contents( $this->options->get_archive_dir() . $this->static_page->file_path, $content );
 	}
 
+    /**
+     * Get the Static Page.
+     *
+     * @return \Simply_Static\Page|string
+     */
+    public function get_static_page() {
+        return $this->static_page;
+    }
+
 	/**
 	 * Extracts URLs from the static_page and update them based on the dest. type
 	 *


### PR DESCRIPTION
Closes #133 

### Changes

Refactoring the code a bit so others can hook into and have more control over what they can do before the HTML is saved.

With that, the scenario from #133 should be able with:

```
add_action( 'ss_after_extract_and_replace_urls_in_html', 'cancel_if_invalid_html', 20, 2 );

function cancel_if_invalid_html( $dom, $extractor ) {
  if ( invalid_html( $dom->innerHtml ) {
    $message = 'Invalid HTML on URL ' . $extractor->get_static_page()->url;

     \Simply_Static\Plugin::instance()->get_archive_creation_job()->cancel( $message );
  }
}

```