### PR TITLE
Including Elementor Files

### DIFF
--- a/src/integrations/class-elementor-integration.php
+++ b/src/integrations/class-elementor-integration.php
@@ -27,7 +27,6 @@ class Elementor_Integration extends Integration {
      * @return void
      */
     public function run() {
-        add_action( 'ss_finished_fetching_pages', [ $this, 'move_files' ] );
         add_action( 'ss_after_setup_task', [ $this, 'register_assets' ] );
         add_action( 'ss_after_extract_and_replace_urls_in_html', [ $this, 'extract_elementor_settings' ], 20, 2 );
     }
@@ -46,74 +45,78 @@ class Elementor_Integration extends Integration {
             $json = preg_replace_callback( $pattern, array( $extractor, 'css_matches' ), $decoded );
             $json = json_decode( $json );
             $node->{'data-settings'} = esc_attr( wp_json_encode( $json ) );
-
-
         }
     }
-
-
 
     /**
      * Move Elementor Files to make sure all assets that might be required are there.
-     * @return void
+     * @return array
      */
-    public function move_files() {
-        $lib_assets   = trailingslashit( ELEMENTOR_PATH ) . 'assets/lib/';
-        $options      = Options::instance();
-        $archive_dir  = $options->get_archive_dir();
-        $relative_dir = str_replace( trailingslashit( ABSPATH ), '', $lib_assets );
-        $destination  = trailingslashit( $archive_dir ) . $relative_dir;
-
-        $this->recurseCopy( $lib_assets, $destination );
+    public function get_lib_files() {
+        return $this->get_files_in_url( 'lib' );
     }
 
-    protected function recurseCopy(
-        string $sourceDirectory,
-        string $destinationDirectory,
-        string $childFolder = ''
-    ): void {
-        $directory = opendir($sourceDirectory);
+    /**
+     * Move Elementor Files to make sure all assets that might be required are there.
+     * @return array
+     */
+    public function get_files_in_url( $asset_dir ) {
+        $dir   = trailingslashit( ELEMENTOR_PATH ) . 'assets/' . $asset_dir;
+        $files = $this->get_files_in_dir( $dir );
+        $urls  = [];
 
-        if (is_dir($destinationDirectory) === false) {
-            mkdir($destinationDirectory);
+        foreach ( $files as $file ) {
+            $urls[] = str_replace( trailingslashit( ELEMENTOR_PATH ), trailingslashit( ELEMENTOR_URL ), $file );
         }
 
-        if ($childFolder !== '') {
-            if (is_dir("$destinationDirectory/$childFolder") === false) {
-                mkdir("$destinationDirectory/$childFolder");
-            }
+        return $urls;
+    }
 
-            while (($file = readdir($directory)) !== false) {
-                if ($file === '.' || $file === '..') {
-                    continue;
-                }
-
-                if (is_dir("$sourceDirectory/$file") === true) {
-                    $this->recurseCopy("$sourceDirectory/$file", "$destinationDirectory/$childFolder/$file");
-                } else {
-                    copy("$sourceDirectory/$file", "$destinationDirectory/$childFolder/$file");
-                }
-            }
-
-            closedir($directory);
-
-            return;
-        }
+    /**
+     * Get fields in directory
+     *
+     * @param string $source_dir Directory path.
+     * @param array  $files
+     * @return array
+     */
+    public function get_files_in_dir(
+        string $source_dir,
+        array $files = []
+    ) {
+        $directory = opendir($source_dir);
 
         while (($file = readdir($directory)) !== false) {
             if ($file === '.' || $file === '..') {
                 continue;
             }
 
-            if (is_dir("$sourceDirectory/$file") === true) {
-                $this->recurseCopy("$sourceDirectory/$file", "$destinationDirectory/$file");
+            if (is_dir("$source_dir/$file") === true) {
+               $files = $this->get_files_in_dir("$source_dir/$file", $files );
             }
             else {
-                copy("$sourceDirectory/$file", "$destinationDirectory/$file");
+                $files[] = "$source_dir/$file";
             }
         }
 
         closedir($directory);
+        return $files;
+    }
+
+
+    protected function get_bundle_files() {
+        $js_bundles_folder = trailingslashit( ELEMENTOR_PATH ) . 'assets/js/';
+        $files             = scandir( $js_bundles_folder );
+        $only_bundle_min   = array_filter( $files, function( $file ) {
+            return strpos( $file, 'bundle.min.js' );
+        });
+
+        $urls = [];
+
+        foreach ( $only_bundle_min as $minified_file ) {
+            $urls[] = trailingslashit( ELEMENTOR_URL ) . 'assets/js/' . $minified_file;
+        }
+
+        return $urls;
     }
 
     /**
@@ -122,14 +125,19 @@ class Elementor_Integration extends Integration {
      * @return void
      */
     public function register_assets() {
-        $js_bundles_folder = trailingslashit( ELEMENTOR_PATH ) . 'assets/js/';
-        $files             = scandir( $js_bundles_folder );
-        $only_bundle_min   = array_filter( $files, function( $file ) {
-            return strpos( $file, 'bundle.min.js' );
-        });
 
-        foreach ( $only_bundle_min as $minified_file ) {
-            $url = trailingslashit( ELEMENTOR_URL ) . 'assets/js/' . $minified_file;
+        $file_urls   = [];
+        $bundle_urls = $this->get_bundle_files();
+        $lib_urls    = $this->get_lib_files();
+        $file_urls   = array_merge( $file_urls, $bundle_urls );
+        $file_urls   = array_merge( $file_urls, $lib_urls );
+        $file_urls   = array_merge( $file_urls, $this->get_files_in_url( 'images' ) );
+        $file_urls   = array_merge( $file_urls, $this->get_files_in_url( 'shapes' ) );
+        $file_urls   = array_merge( $file_urls, $this->get_files_in_url( 'mask-shapes' ) );
+        $file_urls   = array_merge( $file_urls, $this->get_files_in_url( 'svg-paths' ) );
+        $file_urls   = array_merge( $file_urls, $this->get_files_in_url( 'data' ) );
+
+        foreach ( $file_urls as $url ) {
             Util::debug_log( 'Adding elementor bundle asset to queue: ' . $url );
             /** @var \Simply_Static\Page $static_page */
             $static_page = Page::query()->find_or_initialize_by( 'url', $url );

--- a/src/integrations/class-elementor-pro-integration.php
+++ b/src/integrations/class-elementor-pro-integration.php
@@ -32,20 +32,32 @@ class Elementor_Pro_Integration extends Integration {
     }
 
     /**
+     * Move Elementor Files to make sure all assets that might be required are there.
+     * @return array
+     */
+    public function get_lib_files() {
+        return $this->get_files_in_url( 'lib' );
+    }
+
+    /**
      * Register Elementor Assets to be added that are loaded conditionally
      *
      * @return void
      */
     public function register_assets() {
-        $js_bundles_folder = trailingslashit( ELEMENTOR_PRO_PATH ) . 'assets/js/';
-        $files             = scandir( $js_bundles_folder );
-        $only_bundle_min   = array_filter( $files, function( $file ) {
-            return strpos( $file, 'bundle.min.js' );
-        });
+        $file_urls   = [];
+        $bundle_urls = $this->get_bundle_files();
+        $lib_urls    = $this->get_lib_files();
+        $file_urls   = array_merge( $file_urls, $bundle_urls );
+        $file_urls   = array_merge( $file_urls, $lib_urls );
+        $file_urls   = array_merge( $file_urls, $this->get_files_in_url( 'css' ) );
+        $file_urls   = array_merge( $file_urls, $this->get_files_in_url( 'images' ) );
+        $file_urls   = array_merge( $file_urls, $this->get_files_in_url( 'mask-shapes' ) );
+        $file_urls   = array_merge( $file_urls, $this->get_files_in_url( 'svg-paths' ) );
+        $file_urls   = array_merge( $file_urls, $this->get_files_in_url( 'data' ) );
 
-        foreach ( $only_bundle_min as $minified_file ) {
-            $url = trailingslashit( ELEMENTOR_PRO_URL ) . 'assets/js/' . $minified_file;
-            Util::debug_log( 'Adding elementor pro bundle asset to queue: ' . $url );
+        foreach ( $file_urls as $url ) {
+            Util::debug_log( 'Adding elementor bundle asset to queue: ' . $url );
             /** @var \Simply_Static\Page $static_page */
             $static_page = Page::query()->find_or_initialize_by( 'url', $url );
             $static_page->set_status_message( __( 'Elementor Pro Asset', 'simply-static' ) );
@@ -53,6 +65,70 @@ class Elementor_Pro_Integration extends Integration {
             $static_page->save();
         }
     }
+
+    protected function get_bundle_files() {
+        $js_bundles_folder = trailingslashit( ELEMENTOR_PRO_PATH ) . 'assets/js/';
+        $files             = scandir( $js_bundles_folder );
+        $only_bundle_min   = array_filter( $files, function( $file ) {
+            return strpos( $file, 'bundle.min.js' );
+        });
+
+        $urls = [];
+
+        foreach ( $only_bundle_min as $minified_file ) {
+            $urls[] = trailingslashit( ELEMENTOR_PRO_URL ) . 'assets/js/' . $minified_file;
+        }
+
+        return $urls;
+    }
+
+    /**
+     * Move Elementor Files to make sure all assets that might be required are there.
+     * @return array
+     */
+    public function get_files_in_url( $asset_dir ) {
+        $dir   = trailingslashit( ELEMENTOR_PRO_PATH ) . 'assets/' . $asset_dir;
+        $files = $this->get_files_in_dir( $dir );
+        $urls  = [];
+
+        foreach ( $files as $file ) {
+            $urls[] = str_replace( trailingslashit( ELEMENTOR_PRO_PATH ), trailingslashit( ELEMENTOR_PRO_URL ), $file );
+        }
+
+        return $urls;
+    }
+
+    /**
+     * Get fields in directory
+     *
+     * @param string $source_dir Directory path.
+     * @param array  $files
+     * @return array
+     */
+    public function get_files_in_dir(
+        string $source_dir,
+        array $files = []
+    ) {
+        $directory = opendir($source_dir);
+
+        while (($file = readdir($directory)) !== false) {
+            if ($file === '.' || $file === '..') {
+                continue;
+            }
+
+            if (is_dir("$source_dir/$file") === true) {
+                $files = $this->get_files_in_dir("$source_dir/$file", $files );
+            }
+            else {
+                $files[] = "$source_dir/$file";
+            }
+        }
+
+        closedir($directory);
+        return $files;
+    }
+
+
 
     /**
      * Register Elementor Assets to be added that are loaded conditionally


### PR DESCRIPTION
Closes #144

### Changes

Adds a way to register all files (CSS, SVG, Images, JS, Data) before fetching all URLs.

### Tests

- [ ] Have Elementor Installed & Activated
- [ ] Generate an export
- [ ] Check in the exported site folder if Elementor files in asset folder match what the plugin has
- [ ] Repeat all that with Elementor Pro as well.