### PR TITLE
Add missing error message

### DIFF
--- a/src/tasks/class-ss-setup-task.php
+++ b/src/tasks/class-ss-setup-task.php
@@ -33,7 +33,7 @@ class Setup_Task extends Task {
 			Util::debug_log( 'Creating archive directory: ' . $archive_dir );
 			$create_dir = wp_mkdir_p( $archive_dir );
 			if ( $create_dir === false ) {
-				return new \WP_Error( 'cannot_create_archive_dir' );
+				return new \WP_Error( 'cannot_create_archive_dir', sprintf(__('Cannot create archive directory %s'), $archive_dir) );
 			}
 		}
 


### PR DESCRIPTION
I got "An error occurred: " in my activity log. No error message. This instance of `WP_Error` turned out to be the problem.