### PR TITLE
Add add_status_message to Simply_Static\Options for SSP wp_cli

### DIFF
--- a/src/class-ss-archive-creation-job.php
+++ b/src/class-ss-archive-creation-job.php
@@ -307,17 +307,13 @@ class Archive_Creation_Job extends \WP_Background_Process {
 	 *
 	 * @return void
 	 */
-	protected function save_status_message( $message, $key = null ) {
-		$task_name = $key ?: $this->get_current_task();
-		$messages  = $this->options->get( 'archive_status_messages' );
-		Util::debug_log( 'Status message: [' . $task_name . '] ' . $message );
-
-		$messages = Util::add_archive_status_message( $messages, $task_name, $message );
-
-		$this->options
-			->set( 'archive_status_messages', $messages )
-			->save();
-	}
+    protected function save_status_message( $message, $key = null ) {
+        $task_name = $key ?: $this->get_current_task();
+        $this->options
+            ->add_status_message($message, $task_name)
+            ->save();
+        Util::debug_log( 'Status message: [' . $task_name . '] ' . $message );
+    }
 
 	/**
 	 * Add a status message about the exception and cancel the job

--- a/src/class-ss-options.php
+++ b/src/class-ss-options.php
@@ -182,4 +182,17 @@ class Options {
 
 		return './';
 	}
+
+    /**
+     * Add status message
+     * @param $message
+     * @param $task_name
+     * @return $this
+     */
+    public function add_status_message( $message, $task_name ) : self
+    {
+        $messages = $this->get( 'archive_status_messages' );
+        $messages = Util::add_archive_status_message( $messages, $task_name, $message );
+        return $this->set( 'archive_status_messages', $messages );
+    }
 }


### PR DESCRIPTION
@patrickposner Little refactor: Move add_status_message to Simply_Static\Options, so this can be re-used.

This refactor is needed due to a fix for simply-static-pro, see my other PR for simply-static-pro: https://github.com/Simply-Static/simply-static-pro/pull/55.