### PR TITLE
Adding "Generate 404 Page" feature

### DIFF
--- a/src/admin/build/index.asset.php
+++ b/src/admin/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => 'c85870339473036a86da');
+<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => '9352f7c84c77b643b8e4');

--- a/src/admin/build/index.js
+++ b/src/admin/build/index.js
@@ -800,7 +800,8 @@ function SettingsContextProvider(props) {
     'minify_css': false,
     'minify_inline_css': false,
     'minify_js': false,
-    'minify_inline_js': false
+    'minify_inline_js': false,
+    'generate_404': false
   };
   const [isRunning, setIsRunning] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
   const [settingsSaved, setSettingsSaved] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
@@ -1710,6 +1711,7 @@ function GeneralSettings() {
   const [host, setHost] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('');
   const [path, setPath] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('/');
   const [hasCopied, setHasCopied] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [generate404, setGenerate404] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
   const setSavingSettings = () => {
     saveSettings();
     setSettingsSaved(true);
@@ -1729,6 +1731,9 @@ function GeneralSettings() {
     }
     if (settings.relative_path) {
       setPath(settings.relative_path);
+    }
+    if (settings.generate_404) {
+      setGenerate404(settings.generate_404);
     }
   }, [settings]);
   return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
@@ -1819,7 +1824,17 @@ function GeneralSettings() {
     text: options.home_path,
     onCopy: () => setHasCopied(true),
     onFinishCopy: () => setHasCopied(false)
-  }, hasCopied ? __('Copied home path', 'simply-static') : __('Copy home path', 'simply-static')))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+  }, hasCopied ? __('Copied home path', 'simply-static') : __('Copy home path', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Generate 404 Page?', 'simply-static'),
+    help: generate404 ? __('Generate a 404 page.', 'simply-static') : __('Don\'t generate a 404 page.', 'simply-static'),
+    checked: generate404,
+    onChange: value => {
+      setGenerate404(value);
+      updateSetting('generate_404', value);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
     margin: 5
   }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Exclude', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextareaControl, {
     label: __('Urls and Patterns to exclude', 'simply-static'),

--- a/src/admin/src/settings/context/SettingsContext.jsx
+++ b/src/admin/src/settings/context/SettingsContext.jsx
@@ -84,6 +84,7 @@ function SettingsContextProvider(props) {
         'minify_inline_css': false,
         'minify_js': false,
         'minify_inline_js': false,
+        'generate_404': false
     }
     const [isRunning, setIsRunning] = useState(false);
     const [settingsSaved, setSettingsSaved] = useState(false);

--- a/src/admin/src/settings/pages/GeneralSettings.jsx
+++ b/src/admin/src/settings/pages/GeneralSettings.jsx
@@ -7,7 +7,7 @@ import {
     __experimentalSpacer as Spacer,
     Notice,
     Animate,
-    TextControl, SelectControl, Flex, FlexItem, TextareaControl,
+    TextControl, SelectControl, Flex, FlexItem, TextareaControl, ToggleControl,
 } from "@wordpress/components";
 import {useContext, useEffect, useState} from '@wordpress/element';
 import {SettingsContext} from "../context/SettingsContext";
@@ -21,6 +21,7 @@ function GeneralSettings() {
     const [host, setHost] = useState('');
     const [path, setPath] = useState('/');
     const [hasCopied, setHasCopied] = useState(false);
+    const [generate404, setGenerate404] = useState(false);
 
     const setSavingSettings = () => {
         saveSettings();
@@ -46,6 +47,10 @@ function GeneralSettings() {
 
         if (settings.relative_path) {
             setPath(settings.relative_path);
+        }
+
+        if (settings.generate_404) {
+            setGenerate404(settings.generate_404);
         }
 
     }, [settings]);
@@ -165,6 +170,20 @@ function GeneralSettings() {
                 >
                     {hasCopied ? __('Copied home path', 'simply-static') : __('Copy home path', 'simply-static')}
                 </ClipboardButton>
+                <Spacer margin={5}/>
+                <ToggleControl
+                    label={__('Generate 404 Page?', 'simply-static')}
+                    help={
+                        generate404
+                            ? __('Generate a 404 page.', 'simply-static')
+                            : __('Don\'t generate a 404 page.', 'simply-static')
+                    }
+                    checked={generate404}
+                    onChange={(value) => {
+                        setGenerate404(value);
+                        updateSetting('generate_404', value);
+                    }}
+                />
             </CardBody>
         </Card>
         <Spacer margin={5}/>

--- a/src/class-page-handlers.php
+++ b/src/class-page-handlers.php
@@ -28,6 +28,7 @@ class Page_Handlers {
 	public function includes() {
 		$path = plugin_dir_path( dirname( __FILE__ ) ) . 'src/handlers/';
 		require_once $path . 'class-ss-page-handler.php';
+		require_once $path . 'class-ss-handler-404.php';
 	}
 
 	/**

--- a/src/class-ss-plugin.php
+++ b/src/class-ss-plugin.php
@@ -142,6 +142,7 @@ class Plugin {
 		require_once $path . 'src/tasks/class-ss-create-zip-archive.php';
 		require_once $path . 'src/tasks/class-ss-wrapup-task.php';
 		require_once $path . 'src/tasks/class-ss-cancel-task.php';
+		require_once $path . 'src/tasks/class-ss-generate-404-task.php';
 		require_once $path . 'src/handlers/class-ss-page-handler.php';
 		require_once $path . 'src/class-ss-query.php';
 		require_once $path . 'src/models/class-ss-model.php';

--- a/src/class-ss-plugin.php
+++ b/src/class-ss-plugin.php
@@ -315,6 +315,13 @@ class Plugin {
 	public function filter_task_list( $task_list, $delivery_method ): array {
 		array_push( $task_list, 'setup', 'fetch_urls' );
 
+		$generate_404 = $this->options->get('generate_404');
+
+		// Add 404 task
+		if ( $generate_404 ) {
+			$task_list[] = 'generate_404';
+		}
+
 		if ( 'zip' === $delivery_method ) {
 			$task_list[] = 'create_zip_archive';
 		} elseif ( 'local' === $delivery_method ) {

--- a/src/class-ss-url-fetcher.php
+++ b/src/class-ss-url-fetcher.php
@@ -119,7 +119,7 @@ class Url_Fetcher {
 			Util::debug_log( "http_status_code: " . $static_page->http_status_code . " | content_type: " . $static_page->content_type );
 
 			$relative_filename = null;
-			if ( $static_page->http_status_code == 200 ) {
+			if ( $this->can_create_directories_for_page( $static_page ) ) {
 				// pclzip doesn't like 0 byte files (fread error), so we're
 				// going to fix that by putting a single space into the file
 				if ( $filesize === 0 ) {
@@ -152,6 +152,24 @@ class Url_Fetcher {
 
 			return true;
 		}
+	}
+
+	/**
+	 * @param Page $static_page
+	 *
+	 * @return boolean
+	 */
+	protected function can_create_directories_for_page( $static_page ) {
+		if ( $static_page->http_status_code == 200 ) {
+			return true;
+		}
+
+		$page_handler = $static_page->get_handler();
+		if ( $static_page->http_status_code === 404 && $page_handler && is_a( $page_handler, Handler_404::class ) ) {
+			return true;
+		}
+
+		return apply_filters( 'simply_static_can_create_directories_for_page', false, $static_page );
 	}
 
 	/**

--- a/src/handlers/class-ss-handler-404.php
+++ b/src/handlers/class-ss-handler-404.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Simply_Static;
+
+class Handler_404 extends Page_Handler {
+
+
+	public function get_relative_dir( $dir ) {
+		return '404/';
+	}
+}

--- a/src/tasks/class-ss-generate-404-task.php
+++ b/src/tasks/class-ss-generate-404-task.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Simply_Static;
+
+/**
+ * Class which handles fetch url task.
+ */
+class Generate_404_Task extends Task {
+
+	/**
+	 * Task name.
+	 *
+	 * @var string
+	 */
+	public static $task_name = 'generate_404';
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->archive_dir        = $this->options->get_archive_dir();
+		$this->archive_start_time = $this->options->get( 'archive_start_time' );
+	}
+
+	/**
+	 * Fetch and save pages for the static archive
+	 *
+	 * @return boolean|WP_Error true if done, false if not done, WP_Error if error.
+	 */
+	public function perform() {
+
+		$found_404   = false;
+		$static_page = null;
+		$slug        = time();
+		$count       = 1;
+
+		$message = __( 'Generating 404 Page.', 'simply-static' );
+		$this->save_status_message( $message );
+
+
+		do {
+			$page_slug             = $slug + $count;
+			$static_page           = new Page();
+			$static_page->post_id  = 0;
+			$static_page->id  = 0;
+			$static_page->build_id = 0;
+			$static_page->url      = home_url( (string) $page_slug );
+			$static_page->handler  = Handler_404::class;
+			$static_page->error_message = '';
+			$static_page->found_on_id = 0;
+			$static_page->redirect_url = '';
+			$static_page->status_message = '';
+			$static_page->content_type = 'text/html';
+			$static_page->content_hash = '';
+			$static_page->last_checked_at = current_time('mysql');
+			$static_page->last_transferred_at = current_time('mysql');
+			$static_page->last_modified_at = current_time('mysql');
+			$static_page->updated_at = current_time('mysql');
+			$static_page->created_at = current_time('mysql');
+			$static_page->site_id = 0;
+			$static_page->file_path = 'index.html';
+
+			$success = Url_Fetcher::instance()->fetch( $static_page );
+
+			$count++;
+
+			if ( ! $success ) {
+				continue;
+			}
+
+			if ( $static_page->http_status_code !== 404 ) {
+				continue;
+			}
+
+
+			$this->handle_response( $static_page );
+
+			$found_404 = true;
+
+			$message = __( 'Page 404 generated.', 'simply-static' );
+
+			$this->save_status_message( $message );
+
+
+		} while( ! $found_404 );
+
+
+		return true;
+	}
+
+
+	/**
+	 * Process the response for a 200 response (success)
+	 *
+	 * @param Simply_Static\Page $static_page Record to update.
+	 * @param boolean $save_file Save a static copy of the page.
+	 * @param boolean $follow_urls Save found URLs to database.
+	 *
+	 * @return void
+	 */
+	public function handle_response( $static_page ) {
+
+		$file = $this->archive_dir . $static_page->file_path;
+
+		Util::debug_log( "We're saving this URL; keeping the static file" );
+		$sha1 = sha1_file( $file );
+
+		// if the content is identical, move on to the next file
+		if ( $static_page->is_content_identical( $sha1 ) ) {
+			// continue;
+		} else {
+			$static_page->set_content_hash( $sha1 );
+		}
+
+
+		$static_page->save();
+	}
+}


### PR DESCRIPTION
Closes #100 

### Changes

Added a new Task to generate 404 page when the feature is toggled under settings.

<img width="1363" alt="Screenshot 2023-10-05 at 01 00 18" src="https://github.com/Simply-Static/simply-static/assets/1537130/ef598cfd-cbab-4892-a72e-e8a38fb354fb">

### Test

- [x] Toggle "Generate 404  Page" under Simply Static > Settings > General
- [x] Run Export
- [x] Check if there is a 404 folder with index.html containing the contents of a 404 page