### PR TITLE
Feature/jochem add ss user capability parameter

### DIFF
--- a/src/admin/inc/class-ss-admin-settings.php
+++ b/src/admin/inc/class-ss-admin-settings.php
@@ -46,7 +46,7 @@ class Admin_Settings {
 		add_menu_page(
 			__( 'Simply Static', 'simply-static' ),
 			__( 'Simply Static', 'simply-static' ),
-            apply_filters( 'ss_user_capability', 'manage_options' , 'generate'),
+            apply_filters( 'ss_user_capability', 'publish_pages' , 'generate'),
 			'simply-static-generate',
 			array( $this, 'render_settings' ),
 			SIMPLY_STATIC_URL . '/assets/simply-static-icon.svg',
@@ -56,7 +56,7 @@ class Admin_Settings {
 			'simply-static-generate',
 			__( 'Generate', 'simply-static' ),
 			__( 'Generate', 'simply-static' ),
-            apply_filters( 'ss_user_capability', 'manage_options' , 'generate'),
+            apply_filters( 'ss_user_capability', 'publish_pages' , 'generate'),
 			'simply-static-generate',
 			array( $this, 'render_settings' )
 		);
@@ -205,7 +205,7 @@ class Admin_Settings {
 			'methods'             => 'GET',
 			'callback'            => [ $this, 'get_pages' ],
 			'permission_callback' => function () {
-				return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'generate') );
+				return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'settings') );
 			},
 		) );
 
@@ -253,7 +253,7 @@ class Admin_Settings {
 			'methods'             => 'POST',
 			'callback'            => [ $this, 'start_export' ],
 			'permission_callback' => function () {
-                return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'generate') );
+                return current_user_can( apply_filters( 'ss_user_capability', 'publish_pages', 'generate') );
 			},
 		) );
 
@@ -261,7 +261,7 @@ class Admin_Settings {
 			'methods'             => 'POST',
 			'callback'            => [ $this, 'cancel_export' ],
 			'permission_callback' => function () {
-                return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'generate') );
+                return current_user_can( apply_filters( 'ss_user_capability', 'publish_pages', 'generate') );
 			},
 		) );
 
@@ -269,7 +269,7 @@ class Admin_Settings {
 			'methods'             => 'GET',
 			'callback'            => [ $this, 'is_running' ],
 			'permission_callback' => function () {
-                return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'generate') );
+                return current_user_can( apply_filters( 'ss_user_capability', 'publish_pages', 'generate') );
 			},
 		) );
 	}

--- a/src/admin/inc/class-ss-admin-settings.php
+++ b/src/admin/inc/class-ss-admin-settings.php
@@ -46,7 +46,7 @@ class Admin_Settings {
 		add_menu_page(
 			__( 'Simply Static', 'simply-static' ),
 			__( 'Simply Static', 'simply-static' ),
-			apply_filters( 'ss_user_capability', 'manage_options' ),
+            apply_filters( 'ss_user_capability', 'manage_options' , 'generate'),
 			'simply-static-generate',
 			array( $this, 'render_settings' ),
 			SIMPLY_STATIC_URL . '/assets/simply-static-icon.svg',
@@ -56,7 +56,7 @@ class Admin_Settings {
 			'simply-static-generate',
 			__( 'Generate', 'simply-static' ),
 			__( 'Generate', 'simply-static' ),
-			apply_filters( 'ss_user_capability', 'manage_options' ),
+            apply_filters( 'ss_user_capability', 'manage_options' , 'generate'),
 			'simply-static-generate',
 			array( $this, 'render_settings' )
 		);
@@ -67,7 +67,7 @@ class Admin_Settings {
 			'simply-static-generate',
 			__( 'Settings', 'simply-static' ),
 			__( 'Settings', 'simply-static' ),
-			apply_filters( 'ss_user_capability', 'manage_options' ),
+            apply_filters( 'ss_user_capability', 'manage_options' , 'settings'),
 			'simply-static-settings',
 			array( $this, 'render_settings' )
 		);
@@ -181,7 +181,7 @@ class Admin_Settings {
 			'methods'             => 'GET',
 			'callback'            => [ $this, 'get_settings' ],
 			'permission_callback' => function () {
-				return current_user_can( apply_filters( 'ss_user_capability', 'manage_options' ) );
+				return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'settings' ) );
 			},
 		) );
 
@@ -189,7 +189,7 @@ class Admin_Settings {
 			'methods'             => 'POST',
 			'callback'            => [ $this, 'save_settings' ],
 			'permission_callback' => function () {
-				return current_user_can( apply_filters( 'ss_user_capability', 'manage_options' ) );
+                return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'settings' ) );
 			},
 		) );
 
@@ -197,7 +197,7 @@ class Admin_Settings {
 			'methods'             => 'POST',
 			'callback'            => [ $this, 'reset_settings' ],
 			'permission_callback' => function () {
-				return current_user_can( apply_filters( 'ss_user_capability', 'manage_options' ) );
+                return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'settings' ) );
 			},
 		) );
 
@@ -205,7 +205,7 @@ class Admin_Settings {
 			'methods'             => 'GET',
 			'callback'            => [ $this, 'get_pages' ],
 			'permission_callback' => function () {
-				return current_user_can( apply_filters( 'ss_user_capability', 'manage_options' ) );
+				return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'generate') );
 			},
 		) );
 
@@ -213,7 +213,7 @@ class Admin_Settings {
 			'methods'             => 'POST',
 			'callback'            => [ $this, 'migrate_settings' ],
 			'permission_callback' => function () {
-				return current_user_can( apply_filters( 'ss_user_capability', 'manage_options' ) );
+                return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'settings') );
 			},
 		) );
 
@@ -221,7 +221,7 @@ class Admin_Settings {
 			'methods'             => 'GET',
 			'callback'            => [ $this, 'get_system_status' ],
 			'permission_callback' => function () {
-				return current_user_can( apply_filters( 'ss_user_capability', 'manage_options' ) );
+                return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'diagnostics') );
 			},
 		) );
 
@@ -229,7 +229,7 @@ class Admin_Settings {
 			'methods'             => 'POST',
 			'callback'            => [ $this, 'clear_log' ],
 			'permission_callback' => function () {
-				return current_user_can( apply_filters( 'ss_user_capability', 'manage_options' ) );
+                return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'activity-log') );
 			},
 		) );
 
@@ -237,7 +237,7 @@ class Admin_Settings {
 			'methods'             => 'GET',
 			'callback'            => [ $this, 'get_activity_log' ],
 			'permission_callback' => function () {
-				return current_user_can( apply_filters( 'ss_user_capability', 'manage_options' ) );
+                return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'activity-log') );
 			},
 		) );
 
@@ -245,7 +245,7 @@ class Admin_Settings {
 			'methods'             => 'GET',
 			'callback'            => [ $this, 'get_export_log' ],
 			'permission_callback' => function () {
-				return current_user_can( apply_filters( 'ss_user_capability', 'manage_options' ) );
+                return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'activity-log') );
 			},
 		) );
 
@@ -253,7 +253,7 @@ class Admin_Settings {
 			'methods'             => 'POST',
 			'callback'            => [ $this, 'start_export' ],
 			'permission_callback' => function () {
-				return current_user_can( apply_filters( 'ss_user_capability', 'manage_options' ) );
+                return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'generate') );
 			},
 		) );
 
@@ -261,7 +261,7 @@ class Admin_Settings {
 			'methods'             => 'POST',
 			'callback'            => [ $this, 'cancel_export' ],
 			'permission_callback' => function () {
-				return current_user_can( apply_filters( 'ss_user_capability', 'manage_options' ) );
+                return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'generate') );
 			},
 		) );
 
@@ -269,7 +269,7 @@ class Admin_Settings {
 			'methods'             => 'GET',
 			'callback'            => [ $this, 'is_running' ],
 			'permission_callback' => function () {
-				return current_user_can( apply_filters( 'ss_user_capability', 'manage_options' ) );
+                return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'generate') );
 			},
 		) );
 	}


### PR DESCRIPTION
@patrickposner Please check per commit.

First commit:
- Added an extra parameter to `ss_user_capability` filter, so that you have more control of giving access per functionality.
- For now I divided this into: `generate`, `settings`, `diagnostics`, `activity-log`. Maybe you want this different or more fine-grained.

Second commit:
- I've set `publish_pages` as default capability for all `generate` functionalities, because editors can already generate a single page or delete it, it seems logical to me that they have full access to all generate functionality by default.

Also, I see in SSP there is a different filter called `ss_settings_capability`. I would suggest to use the same filter (`ss_user_capability` but then use 'build' as a parameter i.e.: `apply_filters( 'ss_user_capability', 'edit_posts', 'builds' )`, so you can enable or disable builds in total.
