### PR TITLE
Move default debug.txt location to uploads dir

### DIFF
--- a/src/admin/inc/class-ss-admin-settings.php
+++ b/src/admin/inc/class-ss-admin-settings.php
@@ -145,7 +145,8 @@ class Admin_Settings {
 		$debug_file = Util::get_debug_log_filename();
 
 		if ( file_exists( $debug_file ) ) {
-			$args['log_file'] = SIMPLY_STATIC_URL . '/debug.txt';
+            $uploadsDir = wp_upload_dir();
+			$args['log_file'] = $uploadsDir['baseurl'] . '/simply-static-debug.txt';
 		}
 
 		// Maybe show migration notice.

--- a/src/class-ss-util.php
+++ b/src/class-ss-util.php
@@ -144,7 +144,8 @@ class Util {
 	 * @return string Filename for the debug log
 	 */
 	public static function get_debug_log_filename() {
-		return plugin_dir_path( dirname( __FILE__ ) ) . 'debug.txt';
+        $uploadsDir = wp_upload_dir();
+        return $uploadsDir['basedir'] . '/simply-static-debug.txt';
 	}
 
 	/**


### PR DESCRIPTION
@patrickposner I've moved the default debug.txt to the uploads folder, because when you do a deployments the debug.txt file will be overwritten and all debug history will be lost.

Please note: Maybe you want to update this as a configurable setting in `MiscSettings.jsx`, but then an extra check should be supplied that the debug file is accessible via an url / api. The uploads-dir has this functionality by default, so that's why this change. Anyhow, curious what you think of this.
