### PR TITLE
Excluded fix when empty row

### DIFF
--- a/src/tasks/class-ss-fetch-urls-task.php
+++ b/src/tasks/class-ss-fetch-urls-task.php
@@ -275,6 +275,10 @@ class Fetch_Urls_Task extends Task {
 			}
 		}
 
+		if ( $excluded ) {
+			$excluded = array_filter( $excluded );
+		}
+
 		if ( ! empty( $excluded ) ) {
 			foreach ( $excluded as $excludable ) {
 				$url = $static_page->url;


### PR DESCRIPTION
Fixes when there is an empty row in "Urls to exclude" option.

When that's there, even the origin URL will be a "No Save & No Follow"