### PR TITLE
Incremental export

### DIFF
--- a/src/admin/build/index.asset.php
+++ b/src/admin/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => 'be030895be21ddf0945d');
+<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => 'c0e7650b715b817cfdcf');

--- a/src/admin/build/index.asset.php
+++ b/src/admin/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => '38d2b0773e9e7214e3bc');
+<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => 'be030895be21ddf0945d');

--- a/src/admin/build/index.css
+++ b/src/admin/build/index.css
@@ -1,1 +1,202 @@
-#wpcontent{padding-left:0}#wpbody-content{padding-bottom:0}#wpfooter{display:none}toplevel_page_simply-static img{width:100%}.settings-error.notice.notice-warning{display:none}.plugin-settings-container{background:#f0f0f1}.plugin-settings-container .components-flex-item{margin-left:0}.plugin-settings-container .inner-settings>*{max-width:800px}.plugin-settings-container .settings-wide>*{max-width:90%}.plugin-settings-container .migrate-notice.components-notice.is-warning,.plugin-settings-container .upgrade-network-notice{margin:0 0 10px}.plugin-settings-container .plugin-nav{height:100vh;margin:0;max-width:260px;padding:25px 40px}.plugin-settings-container .plugin-nav button:focus,.plugin-settings-container .plugin-nav button:focus-visible,.plugin-settings-container .plugin-nav button:hover{box-shadow:none;color:#6804cc}.plugin-settings-container .plugin-nav .generate-container{margin-top:30px}.plugin-settings-container .plugin-nav .generate-container button{background:#6804cc;border:1px solid #50059b;color:#fff;max-width:200px;padding:20px;text-decoration:none}.plugin-settings-container .plugin-nav .generate-container .cancel-button{color:#6804cc;cursor:pointer;display:block;margin:10px 0;max-width:200px;text-align:center;text-decoration:underline}.plugin-settings-container .plugin-nav .components-button{padding:0;text-align:left;width:100%}.plugin-settings-container .plugin-nav .components-card__body{padding:20px 0}.plugin-settings-container .plugin-nav .components-button.is-primary{margin:10px 0;padding:10px 15px;width:auto}.plugin-settings-container .plugin-nav .dashicon.dashicons.dashicons-admin-links{font-size:15px;position:relative;top:2px}.plugin-settings-container .plugin-nav .components-button>.dashicon{margin-right:10px}.plugin-settings-container .plugin-nav .plugin-logo{max-width:150px}.plugin-settings-container .plugin-nav .is-active-item{color:#6804cc}.plugin-settings-container .plugin-nav h4.settings-headline{text-transform:uppercase}.plugin-settings-container .plugin-settings{background:#f0f0f1;height:100vh;padding:25px 40px}.plugin-settings-container .plugin-settings table{width:100%}.plugin-settings-container .plugin-settings table th{text-align:left;text-transform:uppercase}.plugin-settings-container .plugin-settings table td.diagnostics-icon{width:15%}.plugin-settings-container .plugin-settings table td.diagnostics-test{width:30%}.plugin-settings-container .plugin-settings table td.diagnostics-result{width:55%}.plugin-settings-container .plugin-settings .components-notice{box-sizing:border-box;margin:15px 0 0}.plugin-settings-container .plugin-settings .inline-tooltip{display:inline;margin-left:5px;position:relative;top:-2px}.plugin-settings-container .plugin-settings .dashicons-no.icon-no,.plugin-settings-container .plugin-settings .dashicons-yes.icon-yes{border:1px solid;border-radius:50%;padding:2px}.plugin-settings-container .plugin-settings .dashicons-yes.icon-yes{color:#51aa51}.plugin-settings-container .plugin-settings .dashicons-no.icon-no{color:#ca4242}.plugin-settings-container .plugin-settings .formatted-label{display:block;font-size:11px;font-weight:500;margin-bottom:10px;text-transform:uppercase}.plugin-settings-container .plugin-settings .simplycdn-connect{position:relative;top:-7px}.plugin-settings-container .plugin-settings .react-terminal-line{margin-bottom:10px}.plugin-settings-container .plugin-settings .react-terminal-line a{color:#6fa4df}.plugin-settings-container .plugin-settings .ss-theme-style-name .components-base-control__help{margin-bottom:10px}.plugin-settings-container .plugin-settings .ss-theme-style-name .components-input-control__container{width:200px}.plugin-settings-container .plugin-settings .ss-theme-style-name .components-input-control__container .components-input-control__input{text-align:right}.plugin-settings-container .plugin-settings .ss-theme-style-name .components-input-control__container .components-input-control__suffix{background:rgba(0,0,0,.05);padding-left:5px;padding-right:10px}.dashicons.spin{animation:dashicons-spin 2s infinite;animation-timing-function:linear}@keyframes dashicons-spin{0%{transform:rotate(0deg)}to{transform:rotate(1turn)}}
+/*!***************************************************************************************************************************************************************************************************************************************************!*\
+  !*** css ./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[4].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[4].use[2]!./node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[4].use[3]!./src/settings/settings.scss ***!
+  \***************************************************************************************************************************************************************************************************************************************************/
+#wpcontent {
+  padding-left: 0;
+}
+
+#wpbody-content {
+  padding-bottom: 0;
+}
+
+#wpfooter {
+  display: none;
+}
+
+toplevel_page_simply-static img {
+  width: 100%;
+}
+
+.settings-error.notice.notice-warning {
+  display: none;
+}
+
+/* Start plugin settings */
+.plugin-settings-container {
+  background: #f0f0f1;
+  /* Navigation */
+  /* Settings */
+}
+.plugin-settings-container .components-flex-item {
+  margin-left: 0;
+}
+.plugin-settings-container .inner-settings > * {
+  max-width: 800px;
+}
+.plugin-settings-container .settings-wide > * {
+  max-width: 90%;
+}
+.plugin-settings-container .migrate-notice.components-notice.is-warning {
+  margin: 0 0 10px 0;
+}
+.plugin-settings-container .upgrade-network-notice {
+  margin: 0 0 10px 0;
+}
+.plugin-settings-container .plugin-nav {
+  padding: 25px 40px;
+  height: 100vh;
+  max-width: 260px;
+  margin: 0;
+}
+.plugin-settings-container .plugin-nav button:focus, .plugin-settings-container .plugin-nav button:focus-visible, .plugin-settings-container .plugin-nav button:hover {
+  box-shadow: none;
+  color: rgb(104, 4, 204);
+}
+.plugin-settings-container .plugin-nav .generate-container {
+  margin-top: 30px;
+}
+.plugin-settings-container .plugin-nav .generate-container .generate-type {
+  height: 40px;
+  line-height: 40px;
+  max-width: 200px;
+}
+.plugin-settings-container .plugin-nav .generate-container button {
+  background: #6804cc;
+  border: solid 1px #50059b;
+  color: white;
+  text-decoration: none;
+  padding: 20px;
+  max-width: 200px;
+}
+.plugin-settings-container .plugin-nav .generate-container .cancel-button {
+  text-align: center;
+  display: block;
+  max-width: 200px;
+  margin: 10px 0;
+  cursor: pointer;
+  color: rgb(104, 4, 204);
+  text-decoration: underline;
+}
+.plugin-settings-container .plugin-nav .components-button {
+  width: 100%;
+  text-align: left;
+  padding: 0;
+}
+.plugin-settings-container .plugin-nav .components-card__body {
+  padding: 20px 0;
+}
+.plugin-settings-container .plugin-nav .components-button.is-primary {
+  width: auto;
+  padding: 10px 15px;
+  margin: 10px 0;
+}
+.plugin-settings-container .plugin-nav .dashicon.dashicons.dashicons-admin-links {
+  font-size: 15px;
+  top: 2px;
+  position: relative;
+}
+.plugin-settings-container .plugin-nav .components-button > .dashicon {
+  margin-right: 10px;
+}
+.plugin-settings-container .plugin-nav .plugin-logo {
+  max-width: 150px;
+}
+.plugin-settings-container .plugin-nav .is-active-item {
+  color: rgb(104, 4, 204);
+}
+.plugin-settings-container .plugin-nav h4.settings-headline {
+  text-transform: uppercase;
+}
+.plugin-settings-container .plugin-settings {
+  padding: 25px 40px;
+  height: 100vh;
+  background: #f0f0f1;
+  /* Tables */
+  /* Notices */
+  /* Tooltips */
+  /* Terminal */
+}
+.plugin-settings-container .plugin-settings table {
+  width: 100%;
+}
+.plugin-settings-container .plugin-settings table th {
+  text-align: left;
+  text-transform: uppercase;
+}
+.plugin-settings-container .plugin-settings table td.diagnostics-icon {
+  width: 15%;
+}
+.plugin-settings-container .plugin-settings table td.diagnostics-test {
+  width: 30%;
+}
+.plugin-settings-container .plugin-settings table td.diagnostics-result {
+  width: 55%;
+}
+.plugin-settings-container .plugin-settings .components-notice {
+  margin: 15px 0 0 0;
+  box-sizing: border-box;
+}
+.plugin-settings-container .plugin-settings .inline-tooltip {
+  display: inline;
+  top: -2px;
+  position: relative;
+  margin-left: 5px;
+}
+.plugin-settings-container .plugin-settings .dashicons-yes.icon-yes, .plugin-settings-container .plugin-settings .dashicons-no.icon-no {
+  border: solid 1px;
+  border-radius: 50%;
+  padding: 2px 2px;
+}
+.plugin-settings-container .plugin-settings .dashicons-yes.icon-yes {
+  color: #51aa51;
+}
+.plugin-settings-container .plugin-settings .dashicons-no.icon-no {
+  color: #ca4242;
+}
+.plugin-settings-container .plugin-settings .formatted-label {
+  margin-bottom: 10px;
+  display: block;
+  font-weight: 500;
+  text-transform: uppercase;
+  font-size: 11px;
+}
+.plugin-settings-container .plugin-settings .simplycdn-connect {
+  position: relative;
+  top: -7px;
+}
+.plugin-settings-container .plugin-settings .react-terminal-line {
+  margin-bottom: 10px;
+}
+.plugin-settings-container .plugin-settings .react-terminal-line a {
+  color: #6fa4df;
+}
+.plugin-settings-container .plugin-settings .ss-theme-style-name .components-base-control__help {
+  margin-bottom: 10px;
+}
+.plugin-settings-container .plugin-settings .ss-theme-style-name .components-input-control__container {
+  width: 200px;
+}
+.plugin-settings-container .plugin-settings .ss-theme-style-name .components-input-control__container .components-input-control__input {
+  text-align: right;
+}
+.plugin-settings-container .plugin-settings .ss-theme-style-name .components-input-control__container .components-input-control__suffix {
+  padding-right: 10px;
+  background: rgba(0, 0, 0, 0.05);
+  padding-left: 5px;
+}
+
+.dashicons.spin {
+  animation: dashicons-spin 2s infinite;
+  animation-timing-function: linear;
+}
+
+@keyframes dashicons-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+/*# sourceMappingURL=index.css.map*/

--- a/src/admin/build/index.js
+++ b/src/admin/build/index.js
@@ -545,6 +545,15 @@ function SettingsPage() {
   (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
     setDisabledButton(isRunning);
   }, [isRunning]);
+  let buildOptions = '';
+  if (Object.keys(options.builds).length) {
+    const builds = Object.keys(options.builds).map(id => (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("option", {
+      value: id
+    }, options.builds[id]));
+    buildOptions = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("optgroup", {
+      label: "Builds"
+    }, builds);
+  }
   return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
     className: "plugin-settings-container"
   }, 'yes' === options.need_upgrade ? (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Animate, {
@@ -572,17 +581,14 @@ function SettingsPage() {
     className: "generate-container"
   }, 'pro' === options.plan && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.SelectControl, {
     value: selectedExportType,
-    options: [{
-      label: __('Export', 'simply-static'),
-      value: 'export'
-    }, {
-      label: __('Update', 'simply-static'),
-      value: 'update'
-    }],
     onChange: value => {
       setSelectedExportType(value);
     }
-  })), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Button, {
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("option", {
+    value: "export"
+  }, __('Export', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("option", {
+    value: "update"
+  }, __('Update', 'simply-static')), buildOptions)), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Button, {
     onClick: () => {
       startExport();
     },
@@ -626,17 +632,14 @@ function SettingsPage() {
   }, 'pro' === options.plan && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.SelectControl, {
     className: 'generate-type',
     value: selectedExportType,
-    options: [{
-      label: __('Export', 'simply-static'),
-      value: 'export'
-    }, {
-      label: __('Update', 'simply-static'),
-      value: 'update'
-    }],
     onChange: value => {
       setSelectedExportType(value);
     }
-  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Button, {
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("option", {
+    value: "export"
+  }, __('Export', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("option", {
+    value: "update"
+  }, __('Update', 'simply-static')), buildOptions), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Button, {
     onClick: () => {
       startExport();
     },
@@ -857,6 +860,7 @@ function SettingsContextProvider(props) {
     'clear_directory_before_export': false,
     'ssh_security_token': '',
     'ssh_use_forms': true,
+    'iframe_urls': '',
     'ssh_404_page_id': '',
     'ssh_thank_you_page_id': '',
     'tiiny_email': options.admin_email,
@@ -935,7 +939,12 @@ function SettingsContextProvider(props) {
     'disable_embed': false,
     'disable_db_debug': false,
     'disable_wlw_manifest': false,
-    'incremental_export': false
+    'incremental_export': false,
+    'sftp_host': '',
+    'sftp_user': '',
+    'sftp_pass': '',
+    'sftp_folder': '',
+    'sftp_port': 22
   };
   const [isRunning, setIsRunning] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
   const [settingsSaved, setSettingsSaved] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
@@ -1160,6 +1169,9 @@ function DeploymentSettings() {
     }, {
       label: __('Digital Ocean Spaces', 'simply-static'),
       value: 'digitalocean'
+    }, {
+      label: __('SFTP', 'simply-static'),
+      value: 'sftp'
     }],
     onChange: method => {
       setDeliveryMethod(method);
@@ -1614,7 +1626,51 @@ function DeploymentSettings() {
   }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, settings.digitalocean_bucket && settings.digitalocean_region && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
     status: "warning",
     isDismissible: false
-  }, __('Your endpoint will be', 'simply-static'), " :", 'https://' + settings.digitalocean_bucket + '.' + settings.digitalocean_region + '.digitaloceanspaces.com'))))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+  }, __('Your endpoint will be', 'simply-static'), " :", 'https://' + settings.digitalocean_bucket + '.' + settings.digitalocean_region + '.digitaloceanspaces.com')))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), deliveryMethod === 'sftp' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('SFTP', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Host', 'simply-static'),
+    type: "text",
+    help: __('Enter your SFTP host.', 'simply-static'),
+    value: settings.sftp_host,
+    onChange: host => {
+      updateSetting('sftp_host', host);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Port', 'simply-static'),
+    type: "number",
+    help: __('Enter your SFTP port.', 'simply-static'),
+    value: settings.sftp_port,
+    onChange: port => {
+      updateSetting('sftp_port', port);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('SFTP username', 'simply-static'),
+    help: __('Enter your SFTP username.', 'simply-static'),
+    type: "text",
+    placeholder: "username",
+    value: settings.sftp_user,
+    onChange: user => {
+      updateSetting('sftp_user', user);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('SFTP password', 'simply-static'),
+    type: "password",
+    help: __('Enter your SFTP password.', 'simply-static'),
+    value: settings.sftp_pass,
+    onChange: pass => {
+      updateSetting('sftp_pass', pass);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('SFTP folder', 'simply-static'),
+    help: __('Leave empty to upload to the default SFTP folder. Enter a folder path where you want the static files to be uploaded to (example: "uploads" will upload to uploads folder. "uploads/new-folder" will upload files to "new-folder"). ', 'simply-static'),
+    type: "text",
+    placeholder: "",
+    value: settings.sftp_folder,
+    onChange: folder => {
+      updateSetting('sftp_folder', folder);
+    }
+  })))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
     margin: 5
   }), settingsSaved && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
     type: "slide-in",
@@ -1812,6 +1868,21 @@ function FormSettings() {
     onChange: method => {
       setCorsMethod(method);
       updateSetting('fix_cors', method);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('iFrame', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('We replace the HTML of the URLs with an iFrame that embeds the content directly from your WordPress website.', 'simply-static'), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), __('This way you can use dynamic elements on your static website without the need of a specific integration.', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "warning",
+    isDismissible: false
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('This requires your WordPress website to be online all the time.', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextareaControl, {
+    label: __('URLs to embed as an iFrame', 'simply-static'),
+    placeholder: options.home + "/my-form-page/",
+    help: __('If you want to embed specific pages from your WordPress website into your static website, add the URLs here (one per line).', 'simply-static'),
+    value: settings.iframe_urls,
+    onChange: value => {
+      updateSetting('iframe_urls', value);
     }
   }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
     margin: 5
@@ -2336,8 +2407,8 @@ function Optimize() {
     if (settings.wp_plugins_directory) {
       setWpPluginsDirectory(settings.wp_plugins_directory);
     }
-    if (settings.rename_plugin_directories) {
-      setRenamePluginDirectorys(settings.rename_plugin_directories);
+    if (settings.rename_plugins) {
+      setRenamePlugin(settings.rename_plugins);
     }
     if (settings.wp_themes_directory) {
       setWpThemesDirectory(settings.wp_themes_directory);

--- a/src/admin/build/index.js
+++ b/src/admin/build/index.js
@@ -1,7 +1,2984 @@
-(()=>{var e={44:(e,t,n)=>{"use strict";var a=n(196),l=n(331);function i(e){return e&&"object"==typeof e&&"default"in e?e:{default:e}}var r,o=function(e){if(e&&e.__esModule)return e;var t=Object.create(null);return e&&Object.keys(e).forEach((function(n){if("default"!==n){var a=Object.getOwnPropertyDescriptor(e,n);Object.defineProperty(t,n,a.get?a:{enumerable:!0,get:function(){return e[n]}})}})),t.default=e,Object.freeze(t)}(a),s=i(a),c=i(l);function u(e,t){return e[t]}function d(e=[],t,n=0){return[...e.slice(0,n),t,...e.slice(n)]}function p(e=[],t,n="id"){const a=e.slice(),l=u(t,n);return l?a.splice(a.findIndex((e=>u(e,n)===l)),1):a.splice(a.findIndex((e=>e===t)),1),a}function m(e){return e.map(((e,t)=>{const n=Object.assign(Object.assign({},e),{sortable:e.sortable||!!e.sortFunction||void 0});return e.id||(n.id=t+1),n}))}function g(e,t){return Math.ceil(e/t)}function h(e,t){return Math.min(e,t)}!function(e){e.ASC="asc",e.DESC="desc"}(r||(r={}));const y=()=>null;function f(e,t=[],n=[]){let a={},l=[...n];return t.length&&t.forEach((t=>{if(!t.when||"function"!=typeof t.when)throw new Error('"when" must be defined in the conditional style object and must be function');t.when(e)&&(a=t.style||{},t.classNames&&(l=[...l,...t.classNames]),"function"==typeof t.style&&(a=t.style(e)||{}))})),{conditionalStyle:a,classNames:l.join(" ")}}function b(e,t=[],n="id"){const a=u(e,n);return a?t.some((e=>u(e,n)===a)):t.some((t=>t===e))}function v(e,t){return t?e.findIndex((e=>E(e.id,t))):-1}function E(e,t){return e==t}function w(e,t){const n=!e.toggleOnSelectedRowsChange;switch(t.type){case"SELECT_ALL_ROWS":{const{keyField:n,rows:a,rowCount:l,mergeSelections:i}=t,r=!e.allSelected,o=!e.toggleOnSelectedRowsChange;if(i){const t=r?[...e.selectedRows,...a.filter((t=>!b(t,e.selectedRows,n)))]:e.selectedRows.filter((e=>!b(e,a,n)));return Object.assign(Object.assign({},e),{allSelected:r,selectedCount:t.length,selectedRows:t,toggleOnSelectedRowsChange:o})}return Object.assign(Object.assign({},e),{allSelected:r,selectedCount:r?l:0,selectedRows:r?a:[],toggleOnSelectedRowsChange:o})}case"SELECT_SINGLE_ROW":{const{keyField:a,row:l,isSelected:i,rowCount:r,singleSelect:o}=t;return o?i?Object.assign(Object.assign({},e),{selectedCount:0,allSelected:!1,selectedRows:[],toggleOnSelectedRowsChange:n}):Object.assign(Object.assign({},e),{selectedCount:1,allSelected:!1,selectedRows:[l],toggleOnSelectedRowsChange:n}):i?Object.assign(Object.assign({},e),{selectedCount:e.selectedRows.length>0?e.selectedRows.length-1:0,allSelected:!1,selectedRows:p(e.selectedRows,l,a),toggleOnSelectedRowsChange:n}):Object.assign(Object.assign({},e),{selectedCount:e.selectedRows.length+1,allSelected:e.selectedRows.length+1===r,selectedRows:d(e.selectedRows,l),toggleOnSelectedRowsChange:n})}case"SELECT_MULTIPLE_ROWS":{const{keyField:a,selectedRows:l,totalRows:i,mergeSelections:r}=t;if(r){const t=[...e.selectedRows,...l.filter((t=>!b(t,e.selectedRows,a)))];return Object.assign(Object.assign({},e),{selectedCount:t.length,allSelected:!1,selectedRows:t,toggleOnSelectedRowsChange:n})}return Object.assign(Object.assign({},e),{selectedCount:l.length,allSelected:l.length===i,selectedRows:l,toggleOnSelectedRowsChange:n})}case"CLEAR_SELECTED_ROWS":{const{selectedRowsFlag:n}=t;return Object.assign(Object.assign({},e),{allSelected:!1,selectedCount:0,selectedRows:[],selectedRowsFlag:n})}case"SORT_CHANGE":{const{sortDirection:a,selectedColumn:l,clearSelectedOnSort:i}=t;return Object.assign(Object.assign(Object.assign({},e),{selectedColumn:l,sortDirection:a,currentPage:1}),i&&{allSelected:!1,selectedCount:0,selectedRows:[],toggleOnSelectedRowsChange:n})}case"CHANGE_PAGE":{const{page:a,paginationServer:l,visibleOnly:i,persistSelectedOnPageChange:r}=t,o=l&&r,s=l&&!r||i;return Object.assign(Object.assign(Object.assign(Object.assign({},e),{currentPage:a}),o&&{allSelected:!1}),s&&{allSelected:!1,selectedCount:0,selectedRows:[],toggleOnSelectedRowsChange:n})}case"CHANGE_ROWS_PER_PAGE":{const{rowsPerPage:n,page:a}=t;return Object.assign(Object.assign({},e),{currentPage:a,rowsPerPage:n})}}}const _=l.css`
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ "./node_modules/@emotion/is-prop-valid/dist/emotion-is-prop-valid.esm.js":
+/*!*******************************************************************************!*\
+  !*** ./node_modules/@emotion/is-prop-valid/dist/emotion-is-prop-valid.esm.js ***!
+  \*******************************************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (/* binding */ isPropValid)
+/* harmony export */ });
+/* harmony import */ var _emotion_memoize__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @emotion/memoize */ "./node_modules/@emotion/memoize/dist/emotion-memoize.esm.js");
+
+
+var reactPropsRegex = /^((children|dangerouslySetInnerHTML|key|ref|autoFocus|defaultValue|defaultChecked|innerHTML|suppressContentEditableWarning|suppressHydrationWarning|valueLink|abbr|accept|acceptCharset|accessKey|action|allow|allowUserMedia|allowPaymentRequest|allowFullScreen|allowTransparency|alt|async|autoComplete|autoPlay|capture|cellPadding|cellSpacing|challenge|charSet|checked|cite|classID|className|cols|colSpan|content|contentEditable|contextMenu|controls|controlsList|coords|crossOrigin|data|dateTime|decoding|default|defer|dir|disabled|disablePictureInPicture|download|draggable|encType|enterKeyHint|form|formAction|formEncType|formMethod|formNoValidate|formTarget|frameBorder|headers|height|hidden|high|href|hrefLang|htmlFor|httpEquiv|id|inputMode|integrity|is|keyParams|keyType|kind|label|lang|list|loading|loop|low|marginHeight|marginWidth|max|maxLength|media|mediaGroup|method|min|minLength|multiple|muted|name|nonce|noValidate|open|optimum|pattern|placeholder|playsInline|poster|preload|profile|radioGroup|readOnly|referrerPolicy|rel|required|reversed|role|rows|rowSpan|sandbox|scope|scoped|scrolling|seamless|selected|shape|size|sizes|slot|span|spellCheck|src|srcDoc|srcLang|srcSet|start|step|style|summary|tabIndex|target|title|translate|type|useMap|value|width|wmode|wrap|about|datatype|inlist|prefix|property|resource|typeof|vocab|autoCapitalize|autoCorrect|autoSave|color|incremental|fallback|inert|itemProp|itemScope|itemType|itemID|itemRef|on|option|results|security|unselectable|accentHeight|accumulate|additive|alignmentBaseline|allowReorder|alphabetic|amplitude|arabicForm|ascent|attributeName|attributeType|autoReverse|azimuth|baseFrequency|baselineShift|baseProfile|bbox|begin|bias|by|calcMode|capHeight|clip|clipPathUnits|clipPath|clipRule|colorInterpolation|colorInterpolationFilters|colorProfile|colorRendering|contentScriptType|contentStyleType|cursor|cx|cy|d|decelerate|descent|diffuseConstant|direction|display|divisor|dominantBaseline|dur|dx|dy|edgeMode|elevation|enableBackground|end|exponent|externalResourcesRequired|fill|fillOpacity|fillRule|filter|filterRes|filterUnits|floodColor|floodOpacity|focusable|fontFamily|fontSize|fontSizeAdjust|fontStretch|fontStyle|fontVariant|fontWeight|format|from|fr|fx|fy|g1|g2|glyphName|glyphOrientationHorizontal|glyphOrientationVertical|glyphRef|gradientTransform|gradientUnits|hanging|horizAdvX|horizOriginX|ideographic|imageRendering|in|in2|intercept|k|k1|k2|k3|k4|kernelMatrix|kernelUnitLength|kerning|keyPoints|keySplines|keyTimes|lengthAdjust|letterSpacing|lightingColor|limitingConeAngle|local|markerEnd|markerMid|markerStart|markerHeight|markerUnits|markerWidth|mask|maskContentUnits|maskUnits|mathematical|mode|numOctaves|offset|opacity|operator|order|orient|orientation|origin|overflow|overlinePosition|overlineThickness|panose1|paintOrder|pathLength|patternContentUnits|patternTransform|patternUnits|pointerEvents|points|pointsAtX|pointsAtY|pointsAtZ|preserveAlpha|preserveAspectRatio|primitiveUnits|r|radius|refX|refY|renderingIntent|repeatCount|repeatDur|requiredExtensions|requiredFeatures|restart|result|rotate|rx|ry|scale|seed|shapeRendering|slope|spacing|specularConstant|specularExponent|speed|spreadMethod|startOffset|stdDeviation|stemh|stemv|stitchTiles|stopColor|stopOpacity|strikethroughPosition|strikethroughThickness|string|stroke|strokeDasharray|strokeDashoffset|strokeLinecap|strokeLinejoin|strokeMiterlimit|strokeOpacity|strokeWidth|surfaceScale|systemLanguage|tableValues|targetX|targetY|textAnchor|textDecoration|textRendering|textLength|to|transform|u1|u2|underlinePosition|underlineThickness|unicode|unicodeBidi|unicodeRange|unitsPerEm|vAlphabetic|vHanging|vIdeographic|vMathematical|values|vectorEffect|version|vertAdvY|vertOriginX|vertOriginY|viewBox|viewTarget|visibility|widths|wordSpacing|writingMode|x|xHeight|x1|x2|xChannelSelector|xlinkActuate|xlinkArcrole|xlinkHref|xlinkRole|xlinkShow|xlinkTitle|xlinkType|xmlBase|xmlns|xmlnsXlink|xmlLang|xmlSpace|y|y1|y2|yChannelSelector|z|zoomAndPan|for|class|autofocus)|(([Dd][Aa][Tt][Aa]|[Aa][Rr][Ii][Aa]|x)-.*))$/; // https://esbench.com/bench/5bfee68a4cd7e6009ef61d23
+
+var isPropValid = /* #__PURE__ */(0,_emotion_memoize__WEBPACK_IMPORTED_MODULE_0__["default"])(function (prop) {
+  return reactPropsRegex.test(prop) || prop.charCodeAt(0) === 111
+  /* o */
+  && prop.charCodeAt(1) === 110
+  /* n */
+  && prop.charCodeAt(2) < 91;
+}
+/* Z+1 */
+);
+
+
+
+
+/***/ }),
+
+/***/ "./node_modules/@emotion/memoize/dist/emotion-memoize.esm.js":
+/*!*******************************************************************!*\
+  !*** ./node_modules/@emotion/memoize/dist/emotion-memoize.esm.js ***!
+  \*******************************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (/* binding */ memoize)
+/* harmony export */ });
+function memoize(fn) {
+  var cache = Object.create(null);
+  return function (arg) {
+    if (cache[arg] === undefined) cache[arg] = fn(arg);
+    return cache[arg];
+  };
+}
+
+
+
+
+/***/ }),
+
+/***/ "./node_modules/@emotion/unitless/dist/emotion-unitless.esm.js":
+/*!*********************************************************************!*\
+  !*** ./node_modules/@emotion/unitless/dist/emotion-unitless.esm.js ***!
+  \*********************************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (/* binding */ unitlessKeys)
+/* harmony export */ });
+var unitlessKeys = {
+  animationIterationCount: 1,
+  aspectRatio: 1,
+  borderImageOutset: 1,
+  borderImageSlice: 1,
+  borderImageWidth: 1,
+  boxFlex: 1,
+  boxFlexGroup: 1,
+  boxOrdinalGroup: 1,
+  columnCount: 1,
+  columns: 1,
+  flex: 1,
+  flexGrow: 1,
+  flexPositive: 1,
+  flexShrink: 1,
+  flexNegative: 1,
+  flexOrder: 1,
+  gridRow: 1,
+  gridRowEnd: 1,
+  gridRowSpan: 1,
+  gridRowStart: 1,
+  gridColumn: 1,
+  gridColumnEnd: 1,
+  gridColumnSpan: 1,
+  gridColumnStart: 1,
+  msGridRow: 1,
+  msGridRowSpan: 1,
+  msGridColumn: 1,
+  msGridColumnSpan: 1,
+  fontWeight: 1,
+  lineHeight: 1,
+  opacity: 1,
+  order: 1,
+  orphans: 1,
+  tabSize: 1,
+  widows: 1,
+  zIndex: 1,
+  zoom: 1,
+  WebkitLineClamp: 1,
+  // SVG-related properties
+  fillOpacity: 1,
+  floodOpacity: 1,
+  stopOpacity: 1,
+  strokeDasharray: 1,
+  strokeDashoffset: 1,
+  strokeMiterlimit: 1,
+  strokeOpacity: 1,
+  strokeWidth: 1
+};
+
+
+
+
+/***/ }),
+
+/***/ "./src/hooks/useInterval.js":
+/*!**********************************!*\
+  !*** ./src/hooks/useInterval.js ***!
+  \**********************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (/* binding */ useInterval)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+
+function useInterval(callback, delay) {
+  const savedCallback = (0,react__WEBPACK_IMPORTED_MODULE_0__.useRef)();
+
+  // Remember the latest callback.
+  (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  // Set up the interval.
+  (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(() => {
+    function tick() {
+      savedCallback.current();
+    }
+    if (delay !== null) {
+      let id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+  }, [delay]);
+}
+
+/***/ }),
+
+/***/ "./src/settings/Settings.js":
+/*!**********************************!*\
+  !*** ./src/settings/Settings.js ***!
+  \**********************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _components_SettingsPage__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./components/SettingsPage */ "./src/settings/components/SettingsPage.jsx");
+/* harmony import */ var _settings_scss__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./settings.scss */ "./src/settings/settings.scss");
+
+
+
+
+function Settings() {
+  return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_1__["default"], null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_SettingsPage__WEBPACK_IMPORTED_MODULE_2__["default"], null)));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (Settings);
+
+/***/ }),
+
+/***/ "./src/settings/components/ActivityLog.jsx":
+/*!*************************************************!*\
+  !*** ./src/settings/components/ActivityLog.jsx ***!
+  \*************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var react_terminal_ui__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! react-terminal-ui */ "./node_modules/react-terminal-ui/build/index.es.js");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var _hooks_useInterval__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ../../hooks/useInterval */ "./src/hooks/useInterval.js");
+
+
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function ActivityLog() {
+  const {
+    isRunning,
+    blogId
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_1__.SettingsContext);
+  const [terminalLineData, setTerminalLineData] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)([(0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(react_terminal_ui__WEBPACK_IMPORTED_MODULE_2__.TerminalOutput, null, "Waiting for new export..")]);
+  function refreshActivityLog() {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3___default()({
+      path: '/simplystatic/v1/activity-log?blog_id=' + blogId + '&is_network_admin=' + options.is_network,
+      method: 'GET'
+    }).then(resp => {
+      var json = JSON.parse(resp);
+      var terminal = [];
+      for (var message in json.data) {
+        var date = json.data[message].datetime;
+        var text = json.data[message].message;
+        terminal.push((0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(react_terminal_ui__WEBPACK_IMPORTED_MODULE_2__.TerminalOutput, null, "[", date, "] ", (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("span", {
+          dangerouslySetInnerHTML: {
+            __html: text
+          }
+        })));
+      }
+      setTerminalLineData(terminal);
+    });
+  }
+  (0,_hooks_useInterval__WEBPACK_IMPORTED_MODULE_4__["default"])(() => {
+    refreshActivityLog();
+  }, isRunning ? 2500 : null);
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useEffect)(() => {
+    if (isRunning) {
+      setTerminalLineData([(0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(react_terminal_ui__WEBPACK_IMPORTED_MODULE_2__.TerminalOutput, null, "Waiting for new export..")]);
+    }
+    refreshActivityLog();
+  }, [isRunning]);
+  return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(react_terminal_ui__WEBPACK_IMPORTED_MODULE_2__["default"], {
+    name: __('Activity Log', 'simply-static'),
+    height: "250px",
+    colorMode: react_terminal_ui__WEBPACK_IMPORTED_MODULE_2__.ColorMode.Dark
+  }, terminalLineData);
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (ActivityLog);
+
+/***/ }),
+
+/***/ "./src/settings/components/ExportLog.jsx":
+/*!***********************************************!*\
+  !*** ./src/settings/components/ExportLog.jsx ***!
+  \***********************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _hooks_useInterval__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../../hooks/useInterval */ "./src/hooks/useInterval.js");
+/* harmony import */ var react_data_table_component__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! react-data-table-component */ "./node_modules/react-data-table-component/dist/index.cjs.js");
+
+
+
+
+
+
+function ExportLog() {
+  const {
+    isRunning,
+    blogId
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_1__.SettingsContext);
+  const [exportLog, setExportLog] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)([]);
+  const [loadingExportLog, setLoadingExportLog] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [perPageExportLog, setPerPageExportLog] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(25);
+  const [exportPage, setExportPage] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(0);
+  const columns = [{
+    name: 'Code',
+    selector: row => row.code,
+    sortable: false,
+    maxWidth: '100px'
+  }, {
+    name: 'URL',
+    selector: row => (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("a", {
+      target: '_blank',
+      href: row.url
+    }, row.url),
+    sortable: false
+  }, {
+    name: 'Notes',
+    wrap: true,
+    selector: row => (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("span", {
+      dangerouslySetInnerHTML: {
+        __html: row.notes
+      }
+    })
+  }];
+  const handlePageChange = page => {
+    getExportLog(page);
+  };
+  const handlePerRowsChange = (newPerPage, page) => {
+    setPerPageExportLog(newPerPage);
+    getExportLog(page, true);
+  };
+  function getExportLog(page, force = false) {
+    var _page;
+    page = (_page = page) !== null && _page !== void 0 ? _page : 1;
+    if (page !== exportPage || force) {
+      setLoadingExportLog(true);
+    }
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default()({
+      path: `/simplystatic/v1/export-log?page=${page}&per_page=${perPageExportLog}&blog_id=${blogId}&is_network_admin=${options.is_network}`,
+      method: 'GET'
+    }).then(resp => {
+      var json = JSON.parse(resp);
+      if (page !== exportPage || force) {
+        setExportLog(json.data);
+        setLoadingExportLog(false);
+      } else {
+        exportLog.total_static_pages = json.data.total_static_pages;
+        setExportLog(exportLog);
+      }
+      setExportPage(page);
+    });
+  }
+  (0,_hooks_useInterval__WEBPACK_IMPORTED_MODULE_3__["default"])(() => {
+    getExportLog();
+  }, isRunning ? 5000 : null);
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useEffect)(() => {
+    getExportLog(1, true);
+  }, [isRunning]);
+  return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(react_data_table_component__WEBPACK_IMPORTED_MODULE_4__["default"], {
+    columns: columns,
+    data: exportLog.static_pages,
+    pagination: true,
+    paginationServer: true,
+    paginationTotalRows: exportLog.total_static_pages,
+    paginationPerPage: 25,
+    paginationRowsPerPageOptions: [25, 50, 100, 200],
+    progressPending: loadingExportLog,
+    onChangeRowsPerPage: handlePerRowsChange,
+    onChangePage: handlePageChange
+  });
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (ExportLog);
+
+/***/ }),
+
+/***/ "./src/settings/components/LogButtons.jsx":
+/*!************************************************!*\
+  !*** ./src/settings/components/LogButtons.jsx ***!
+  \************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2__);
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function LogButtons() {
+  const [logDeleted, setLogDeleted] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const deleteLog = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default()({
+      path: '/simplystatic/v1/delete-log',
+      method: 'POST'
+    });
+    setLogDeleted(true);
+    setTimeout(function () {
+      setLogDeleted(false);
+    }, 2000);
+  };
+  return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    variant: "primary",
+    href: options.log_file,
+    download: true,
+    style: {
+      marginRight: "10px"
+    }
+  }, __('Download Log', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    variant: "secondary",
+    onClick: deleteLog
+  }, __('Clear Log', 'simply-static')), logDeleted && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Log file cleared.', 'simply-static')))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (LogButtons);
+
+/***/ }),
+
+/***/ "./src/settings/components/SettingsPage.jsx":
+/*!**************************************************!*\
+  !*** ./src/settings/components/SettingsPage.jsx ***!
+  \**************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _pages_GeneralSettings__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../pages/GeneralSettings */ "./src/settings/pages/GeneralSettings.jsx");
+/* harmony import */ var _pages_Diagnostics__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../pages/Diagnostics */ "./src/settings/pages/Diagnostics.jsx");
+/* harmony import */ var _pages_Utilities__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../pages/Utilities */ "./src/settings/pages/Utilities.jsx");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__);
+/* harmony import */ var _pages_DeploymentSettings__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ../pages/DeploymentSettings */ "./src/settings/pages/DeploymentSettings.jsx");
+/* harmony import */ var _pages_FormSettings__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! ../pages/FormSettings */ "./src/settings/pages/FormSettings.jsx");
+/* harmony import */ var _pages_SearchSettings__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(/*! ../pages/SearchSettings */ "./src/settings/pages/SearchSettings.jsx");
+/* harmony import */ var _pages_MiscSettings__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(/*! ../pages/MiscSettings */ "./src/settings/pages/MiscSettings.jsx");
+/* harmony import */ var _pages_Generate__WEBPACK_IMPORTED_MODULE_9__ = __webpack_require__(/*! ../pages/Generate */ "./src/settings/pages/Generate.jsx");
+/* harmony import */ var _pages_Optimize__WEBPACK_IMPORTED_MODULE_10__ = __webpack_require__(/*! ../pages/Optimize */ "./src/settings/pages/Optimize.jsx");
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_11__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_12__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_12___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_12__);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function SettingsPage() {
+  const {
+    isRunning,
+    setIsRunning,
+    blogId,
+    migrateSettings,
+    saveSettings,
+    updateFromNetwork
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_11__.SettingsContext);
+  const [activeItem, setActiveItem] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)({
+    activeItem: "/"
+  });
+  const [initialPage, setInitialPage] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(options.initial);
+  const [initialSet, setInitialSet] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [disabledButton, setDisabledButton] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [selectedCopySite, setSelectedCopySite] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('current');
+  const [selectablesSites, setSelectableSites] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)([]);
+  const [isUpdatingFromNetwork, setIsUpdatingFromNetwork] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [selectedExportType, setSelectedExportType] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('export');
+  const runUpdateFromNetwork = blogId => {
+    // Update settings from selected blog_id.
+    updateFromNetwork(blogId);
+    setIsUpdatingFromNetwork(true);
+    setTimeout(function () {
+      setIsUpdatingFromNetwork(false);
+      window.location.reload();
+    }, 2000);
+  };
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useEffect)(() => {
+    if (!initialSet) {
+      setInitialSet(true);
+      setActiveItem(options.initial);
+      setInitialPage(options.initial);
+    }
+    if (options.selectable_sites && !options.is_network && options.is_multisite) {
+      let sites = options.selectable_sites.map(function (site) {
+        return {
+          label: `${site.name}`,
+          value: site.blog_id
+        };
+      });
+      sites.unshift({
+        label: __('Use current settings', 'simply-static'),
+        value: 'current'
+      });
+      setSelectableSites(sites);
+    }
+  }, [options]);
+  const startExport = () => {
+    setDisabledButton(true);
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_12___default()({
+      path: '/simplystatic/v1/start-export',
+      method: 'POST',
+      data: {
+        'blog_id': blogId,
+        'type': selectedExportType
+      }
+    }).then(resp => {
+      setIsRunning(true);
+    });
+  };
+  const cancelExport = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_12___default()({
+      path: '/simplystatic/v1/cancel-export',
+      method: 'POST',
+      data: {
+        'blog_id': blogId
+      }
+    }).then(resp => {
+      setIsRunning(false);
+    });
+  };
+  const runMigrateSettings = () => {
+    migrateSettings();
+    saveSettings();
+    location.reload();
+  };
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
+    setDisabledButton(isRunning);
+  }, [isRunning]);
+  return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "plugin-settings-container"
+  }, 'yes' === options.need_upgrade ? (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Notice, {
+    status: "warning",
+    isDismissible: false,
+    className: "migrate-notice"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('You have to migrate your settings to version 3.x of Simply Static to ensure everything works smoothly with the new interface.', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Button, {
+    onClick: runMigrateSettings,
+    variant: "primary"
+  }, __('Migrate settings', 'simply-static')))) : '', (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalNavigatorProvider, {
+    initialPath: initialPage
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Flex, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.FlexItem, null, options.is_network ? (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Card, {
+    className: "plugin-nav"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "plugin-logo"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("img", {
+    alt: "Logo",
+    src: options.logo
+  })), 'pro' === options.plan ? (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, "Free: ", (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), "Pro: ", (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version_pro)) : (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, "Version: ", (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version)), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "generate-container"
+  }, 'pro' === options.plan && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.SelectControl, {
+    value: selectedExportType,
+    options: [{
+      label: __('Export', 'simply-static'),
+      value: 'export'
+    }, {
+      label: __('Update', 'simply-static'),
+      value: 'update'
+    }],
+    onChange: value => {
+      setSelectedExportType(value);
+    }
+  })), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Button, {
+    onClick: () => {
+      startExport();
+    },
+    disabled: disabledButton,
+    className: activeItem === '/' ? 'is-active-item generate' : 'generate'
+  }, !disabledButton && [(0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "update"
+  }), __('Generate Static Files', 'simply-static')], disabledButton && [(0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "update spin"
+  }), __('Generating...', 'simply-static')]), disabledButton && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("span", {
+    onClick: () => {
+      cancelExport();
+    },
+    className: "cancel-button"
+  }, __('Cancel Export', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Button, {
+    href: "https://simplystatic.com/changelogs/",
+    target: "_blank"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "editor-ul"
+  }), " ", __('Changelog', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Button, {
+    href: "https://simplystatic.com/docs/",
+    target: "_blank"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "admin-links"
+  }), " ", __('Documentation', 'simply-static')), 'free' === options.plan && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Button, {
+    href: "https://simplystatic.com",
+    target: "_blank"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "admin-site-alt3"
+  }), "Simply Static Pro")) : (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Card, {
+    className: "plugin-nav"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "plugin-logo"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("img", {
+    alt: "Logo",
+    src: options.logo
+  })), 'pro' === options.plan ? (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, "Free: ", (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), "Pro: ", (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version_pro)) : (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, "Version: ", (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version)), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "generate-container"
+  }, 'pro' === options.plan && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.SelectControl, {
+    className: 'generate-type',
+    value: selectedExportType,
+    options: [{
+      label: __('Export', 'simply-static'),
+      value: 'export'
+    }, {
+      label: __('Update', 'simply-static'),
+      value: 'update'
+    }],
+    onChange: value => {
+      setSelectedExportType(value);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Button, {
+    onClick: () => {
+      startExport();
+    },
+    disabled: disabledButton,
+    className: activeItem === '/' ? 'is-active-item generate' : 'generate'
+  }, !disabledButton && [(0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "update"
+  }), __('Generate Static Files', 'simply-static')], disabledButton && [(0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "update spin"
+  }), __('Generating...', 'simply-static')]), disabledButton && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("span", {
+    onClick: () => {
+      cancelExport();
+    },
+    className: "cancel-button"
+  }, __('Cancel Export', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.CardBody, null, !options.is_network && options.is_multisite && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("h4", {
+    className: "settings-headline"
+  }, " ", __('Import', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.SelectControl, {
+    value: selectedCopySite,
+    options: selectablesSites,
+    help: __('Choose a subsite to import settings from.', 'simply-static'),
+    onChange: blog_id => {
+      setSelectedCopySite(blog_id);
+    }
+  }), selectedCopySite !== 'current' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Button, {
+    isPrimary: true,
+    onClick: () => {
+      runUpdateFromNetwork(selectedCopySite);
+    }
+  }, __('Import Settings', 'simply-static')), isUpdatingFromNetwork ? (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Notice, {
+    status: "success",
+    isDismissible: false,
+    className: "upgrade-network-notice"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings successfully imported.', 'simply-static')))) : ''), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("h4", {
+    className: "settings-headline"
+  }, " ", __('Tools', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalNavigatorButton, {
+    onClick: () => setActiveItem('/'),
+    className: activeItem === '/' ? 'is-active-item generate' : 'generate',
+    path: "/"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "update"
+  }), " ", __('Activity Log', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalNavigatorButton, {
+    onClick: () => setActiveItem('/diagnostics'),
+    className: activeItem === '/diagnostics' ? 'is-active-item' : '',
+    path: "/diagnostics"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "editor-help"
+  }), " ", __('Diagnostics', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("h4", {
+    className: "settings-headline"
+  }, " ", __('Settings', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalNavigatorButton, {
+    onClick: () => setActiveItem('/general'),
+    className: activeItem === '/general' ? 'is-active-item' : '',
+    path: "/general"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "admin-generic"
+  }), " ", __('General', 'simply-static')), !options.is_network && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalNavigatorButton, {
+    onClick: () => setActiveItem('/deployment'),
+    className: activeItem === '/deployment' ? 'is-active-item' : '',
+    path: "/deployment"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "migrate"
+  }), " ", __('Deploy', 'simply-static')), 'pro' === options.plan && !options.is_network && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalNavigatorButton, {
+    onClick: () => setActiveItem('/forms'),
+    className: activeItem === '/forms' ? 'is-active-item' : '',
+    path: "/forms"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "align-center"
+  }), " ", __('Forms', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalNavigatorButton, {
+    onClick: () => setActiveItem('/search'),
+    className: activeItem === '/search' ? 'is-active-item' : '',
+    path: "/search"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "search"
+  }), " ", __('Search', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalNavigatorButton, {
+    onClick: () => setActiveItem('/optimize'),
+    className: activeItem === '/optimize' ? 'is-active-item' : '',
+    path: "/optimize"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "dashboard"
+  }), " ", __('Optimize', 'simply-static')))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("h4", {
+    className: "settings-headline"
+  }, " ", __('Advanced', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalNavigatorButton, {
+    onClick: () => setActiveItem('/utilities'),
+    className: activeItem === '/utilities' ? 'is-active-item' : '',
+    path: "/utilities"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "admin-tools"
+  }), " ", __('Utilities', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalNavigatorButton, {
+    onClick: () => setActiveItem('/misc'),
+    className: activeItem === '/misc' ? 'is-active-item' : '',
+    path: "/misc"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "block-default"
+  }), " ", __('Misc', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("h4", {
+    className: "settings-headline"
+  }, "Simply Static"), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Button, {
+    href: "https://simplystatic.com/changelogs/",
+    target: "_blank"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "editor-ul"
+  }), " ", __('Changelog', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Button, {
+    href: "https://simplystatic.com/docs/",
+    target: "_blank"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "admin-links"
+  }), " ", __('Documentation', 'simply-static')), 'free' === options.plan && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Button, {
+    href: "https://simplystatic.com",
+    target: "_blank"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "admin-site-alt3"
+  }), "Simply Static Pro")))), activeItem === '/' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.FlexItem, {
+    isBlock: true
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalNavigatorScreen, {
+    path: "/"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "plugin-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_Generate__WEBPACK_IMPORTED_MODULE_9__["default"], null)))), activeItem === '/diagnostics' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.FlexItem, {
+    isBlock: true
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalNavigatorScreen, {
+    path: "/diagnostics"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "plugin-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_Diagnostics__WEBPACK_IMPORTED_MODULE_2__["default"], null)))), activeItem === '/general' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.FlexItem, {
+    isBlock: true
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalNavigatorScreen, {
+    path: "/general"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "plugin-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_GeneralSettings__WEBPACK_IMPORTED_MODULE_1__["default"], null)))), activeItem === '/deployment' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.FlexItem, {
+    isBlock: true
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalNavigatorScreen, {
+    path: "/deployment"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "plugin-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_DeploymentSettings__WEBPACK_IMPORTED_MODULE_5__["default"], null)))), activeItem === '/forms' && 'pro' === options.plan && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.FlexItem, {
+    isBlock: true
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalNavigatorScreen, {
+    path: "/forms"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "plugin-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_FormSettings__WEBPACK_IMPORTED_MODULE_6__["default"], null)))), activeItem === '/search' && 'pro' === options.plan && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.FlexItem, {
+    isBlock: true
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalNavigatorScreen, {
+    path: "/search"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "plugin-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_SearchSettings__WEBPACK_IMPORTED_MODULE_7__["default"], null)))), activeItem === '/optimize' && 'pro' === options.plan && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.FlexItem, {
+    isBlock: true
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalNavigatorScreen, {
+    path: "/optimize"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "plugin-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_Optimize__WEBPACK_IMPORTED_MODULE_10__["default"], null)))), activeItem === '/utilities' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.FlexItem, {
+    isBlock: true
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalNavigatorScreen, {
+    path: "/utilities"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "plugin-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_Utilities__WEBPACK_IMPORTED_MODULE_3__["default"], null)))), activeItem === '/misc' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.FlexItem, {
+    isBlock: true
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.__experimentalNavigatorScreen, {
+    path: "/misc"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "plugin-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_MiscSettings__WEBPACK_IMPORTED_MODULE_8__["default"], null)))))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (SettingsPage);
+
+/***/ }),
+
+/***/ "./src/settings/context/SettingsContext.jsx":
+/*!**************************************************!*\
+  !*** ./src/settings/context/SettingsContext.jsx ***!
+  \**************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   SettingsContext: () => (/* binding */ SettingsContext),
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _hooks_useInterval__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../../hooks/useInterval */ "./src/hooks/useInterval.js");
+
+
+
+
+const {
+  __
+} = wp.i18n;
+const SettingsContext = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createContext)();
+function SettingsContextProvider(props) {
+  const defaultSettings = {
+    'destination_scheme': 'https://',
+    'destination_host': '',
+    'temp_files_dir': options.temp_files_dir,
+    'additional_urls': '',
+    'additional_files': '',
+    'urls_to_exclude': 'wp-json\nwp-login.php',
+    'delivery_method': 'zip',
+    'local_dir': '',
+    'relative_path': '',
+    'destination_url_type': 'relative',
+    'debugging_mode': true,
+    'http_basic_auth_username': '',
+    'http_basic_auth_password': '',
+    'origin_url': '',
+    'version': options.version,
+    'force_replace_url': false,
+    'clear_directory_before_export': false,
+    'ssh_security_token': '',
+    'ssh_use_forms': true,
+    'ssh_404_page_id': '',
+    'ssh_thank_you_page_id': '',
+    'tiiny_email': options.admin_email,
+    'tiiny_subdomain': '',
+    'tiiny_domain_suffix': 'tiiny.site',
+    'tiiny_password': '',
+    'cdn_api_key': '',
+    'cdn_storage_host': 'storage.bunnycdn.com',
+    'cdn_access_key': '',
+    'cdn_pull_zone': '',
+    'cdn_storage_zone': '',
+    'cdn_directory': '',
+    'cdn_404': '',
+    'github_account_type': 'personal',
+    'github_user': '',
+    'github_email': '',
+    'github_personal_access_token': '',
+    'github_repository': '',
+    'github_repository_visibility': 'public',
+    'github_branch': 'main',
+    'github_webhook_url': '',
+    'github_folder_path': '',
+    'aws_region': 'us-east-2',
+    'aws_access_key': '',
+    'aws_access_secret': '',
+    'aws_bucket': '',
+    'aws_subdirectory': '',
+    'aws_distribution_id': '',
+    'aws_empty': false,
+    'digitalocean_key': '',
+    'digitalocean_secret': '',
+    'digitalocean_bucket': '',
+    'digitalocean_region': '',
+    'fix_cors': 'allowed_http_origins',
+    'static_url': '',
+    'use_forms': false,
+    'use_comments': false,
+    'comment_redirect': '',
+    'use_search': false,
+    'search_type': 'fuse',
+    'search_index_title': 'title',
+    'search_index_content': 'body',
+    'search_index_excerpt': '.entry-content',
+    'search_excludable': '',
+    'search_metadata': '',
+    'fuse_selector': '.search-field',
+    'algolia_app_id': '',
+    'algolia_admin_api_key': '',
+    'algolia_search_api_key': '',
+    'algolia_index': 'simply_static',
+    'algolia_selector': '.search-field',
+    'use_minify': false,
+    'minify_html': false,
+    'minify_css': false,
+    'minify_inline_css': false,
+    'minify_js': false,
+    'minify_inline_js': false,
+    'generate_404': false,
+    'wp_content_folder': '',
+    'wp_includes_folder': '',
+    'wp_uploads_folder': '',
+    'wp_plugins_folder': '',
+    'wp_themes_folder': '',
+    'theme_style_name': 'style',
+    'rename_plugin_folders': false,
+    'author_url': '',
+    'hide_rest_api': false,
+    'hide_style_id': false,
+    'hide_comments': false,
+    'hide_version': false,
+    'hide_generator': false,
+    'hide_prefetch': false,
+    'hide_rsd': false,
+    'hide_emotes': false,
+    'disable_xmlrpc': false,
+    'disable_embed': false,
+    'disable_db_debug': false,
+    'disable_wlw_manifest': false,
+    'incremental_export': false
+  };
+  const [isRunning, setIsRunning] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [settingsSaved, setSettingsSaved] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [settings, setSettings] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(defaultSettings);
+  const [configs, setConfigs] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)({});
+  const [blogId, setBlogId] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(1);
+  const getSettings = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1___default()({
+      path: '/simplystatic/v1/settings'
+    }).then(options => {
+      setSettings(options);
+    });
+  };
+  const saveSettings = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1___default()({
+      path: '/simplystatic/v1/settings',
+      method: 'POST',
+      data: settings
+    });
+  };
+  const resetSettings = () => {
+    setSettings(defaultSettings);
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1___default()({
+      path: '/simplystatic/v1/settings/reset',
+      method: 'POST',
+      data: defaultSettings
+    });
+  };
+  const updateFromNetwork = blogId => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1___default()({
+      path: '/simplystatic/v1/update-from-network',
+      method: 'POST',
+      data: {
+        'blog_id': blogId
+      }
+    });
+  };
+  const checkIfRunning = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1___default()({
+      path: '/simplystatic/v1/is-running',
+      method: 'GET'
+    }).then(resp => {
+      var json = JSON.parse(resp);
+      setIsRunning(json.running);
+    });
+  };
+  const importSettings = newSettings => {
+    setSettings(newSettings);
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1___default()({
+      path: '/simplystatic/v1/settings',
+      method: 'POST',
+      data: newSettings
+    });
+  };
+  const migrateSettings = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1___default()({
+      path: '/simplystatic/v1/migrate',
+      method: 'POST',
+      migrate: true
+    });
+  };
+  const updateSetting = (key, value) => {
+    setSettings({
+      ...settings,
+      [key]: value
+    });
+  };
+  const getStatus = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1___default()({
+      path: '/simplystatic/v1/system-status'
+    }).then(configs => {
+      setConfigs(configs);
+    });
+  };
+  (0,_hooks_useInterval__WEBPACK_IMPORTED_MODULE_2__["default"])(() => {
+    checkIfRunning();
+  }, isRunning ? 5000 : null);
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useEffect)(() => {
+    getSettings();
+    getStatus();
+    checkIfRunning();
+    setBlogId(options.blog_id);
+  }, []);
+  return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(SettingsContext.Provider, {
+    value: {
+      settings,
+      configs,
+      settingsSaved,
+      setSettingsSaved,
+      updateSetting,
+      setSettings,
+      saveSettings,
+      resetSettings,
+      updateFromNetwork,
+      importSettings,
+      migrateSettings,
+      isRunning,
+      setIsRunning,
+      blogId,
+      setBlogId
+    }
+  }, props.children);
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (SettingsContextProvider);
+
+/***/ }),
+
+/***/ "./src/settings/pages/DeploymentSettings.jsx":
+/*!***************************************************!*\
+  !*** ./src/settings/pages/DeploymentSettings.jsx ***!
+  \***************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3__);
+
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function DeploymentSettings() {
+  const {
+    settings,
+    updateSetting,
+    saveSettings,
+    settingsSaved,
+    setSettingsSaved
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__.SettingsContext);
+  const [deliveryMethod, setDeliveryMethod] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('zip');
+  const [clearDirectory, setClearDirectory] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [githubAccountType, setGithubAccountType] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('personal');
+  const [githubVisibility, setGithubVisibility] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('private');
+  const [emptyBucketBeforeExport, setEmptyBucketBeforeExport] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [useForms, setUseForms] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(true);
+  const [region, setRegion] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('us-east-2');
+  const [hasCopied, setHasCopied] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [pages, setPages] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const setSavingSettings = () => {
+    saveSettings();
+    setSettingsSaved(true);
+    setTimeout(function () {
+      setSettingsSaved(false);
+    }, 2000);
+  };
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useEffect)(() => {
+    if (settings.delivery_method) {
+      setDeliveryMethod(settings.delivery_method);
+    }
+    if (settings.clear_directory_before_export) {
+      setClearDirectory(settings.clear_directory_before_export);
+    }
+    if (settings.ssh_use_forms) {
+      setUseForms(settings.ssh_use_forms);
+    }
+    if (settings.github_account_type) {
+      setGithubAccountType(settings.github_account_type);
+    }
+    if (settings.github_repository_visibility) {
+      setGithubVisibility(settings.github_repository_visibility);
+    }
+    if (settings.github_repository_visibility) {
+      setGithubVisibility(settings.github_repository_visibility);
+    }
+    if (settings.aws_empty) {
+      setEmptyBucketBeforeExport(settings.aws_empty);
+    }
+    if (settings.aws_region) {
+      setRegion(settings.aws_region);
+    }
+
+    // Get global page selection
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3___default()({
+      path: '/simplystatic/v1/pages'
+    }).then(fetched_pages => {
+      let pages = fetched_pages;
+      pages.unshift({
+        label: __('No page selected', 'simply-static'),
+        value: 0
+      });
+      setPages(pages);
+    });
+  }, [settings]);
+  return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "inner-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Deployment Settings', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Choose from a variety of deployment methods. Depending on your selection we either provide a ZIP file, export to a local directory or send your files to a remote destination.', 'simply-static')), 'pro' === options.plan ? (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Deployment method', 'simply-static'),
+    value: deliveryMethod,
+    options: [{
+      label: __('ZIP Archive', 'simply-static'),
+      value: 'zip'
+    }, {
+      label: __('GitHub', 'simply-static'),
+      value: 'github'
+    }, {
+      label: __('AWS S3', 'simply-static'),
+      value: 'aws-s3'
+    }, {
+      label: __('Tiiny.host', 'simply-static'),
+      value: 'tiiny'
+    }, {
+      label: __('Bunny CDN', 'simply-static'),
+      value: 'cdn'
+    }, {
+      label: __('Simply CDN', 'simply-static'),
+      value: 'simply-cdn'
+    }, {
+      label: __('Local Directory', 'simply-static'),
+      value: 'local'
+    }, {
+      label: __('Digital Ocean Spaces', 'simply-static'),
+      value: 'digitalocean'
+    }],
+    onChange: method => {
+      setDeliveryMethod(method);
+      updateSetting('delivery_method', method);
+    }
+  }) : (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Deployment method', 'simply-static'),
+    value: deliveryMethod,
+    options: [{
+      label: __('ZIP Archive', 'simply-static'),
+      value: 'zip'
+    }, {
+      label: __('Local Directory', 'simply-static'),
+      value: 'local'
+    }, {
+      label: __('Simply CDN', 'simply-static'),
+      value: 'simply-cdn'
+    }],
+    onChange: method => {
+      setDeliveryMethod(method);
+      updateSetting('delivery_method', method);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), deliveryMethod === 'local' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Local Directory', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Path', 'simply-static'),
+    type: "text",
+    help: __('This is the directory where your static files will be saved. The directory must exist and be writeable by the webserver', 'simply-static'),
+    placeholder: options.home_path + "public_static/",
+    value: settings.local_dir,
+    onChange: path => {
+      updateSetting('local_dir', path);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ClipboardButton, {
+    variant: "secondary",
+    text: options.home_path,
+    onCopy: () => setHasCopied(true),
+    onFinishCopy: () => setHasCopied(false)
+  }, hasCopied ? __('Copied home path', 'simply-static') : __('Copy home path', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Clear Local Directory', 'simply-static'),
+    help: clearDirectory ? __('Clear local directory before running an export.', 'simply-static') : __('Don\'t clear local directory before running an export.', 'simply-static'),
+    checked: clearDirectory,
+    onChange: value => {
+      setClearDirectory(value);
+      updateSetting('clear_directory_before_export', value);
+    }
+  })))), deliveryMethod === 'simply-cdn' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Simply CDN', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('The fast and easy way to bring your static website online. Simply CDN handles hosting, performance, security and form submissions for your static site.', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Security Token', 'simply-static'),
+    type: "text",
+    help: __('Copy and paste the Security Token from your project.', 'simply-static'),
+    value: settings.ssh_security_token,
+    onChange: token => {
+      updateSetting('ssh_security_token', token);
+    }
+  }), settings.ssh_security_token && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Select a 404 page', 'content-protector'),
+    options: pages,
+    help: __('We will use that page as a 404 error page on your static website.', 'simply-static'),
+    value: settings.ssh_404_page_id,
+    onChange: value => {
+      updateSetting("ssh_404_page_id", value);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Use Forms?', 'simply-static'),
+    help: useForms ? __('Proxy form submissions through Simply CDN.', 'simply-static') : __('Don\'t proxy form submissions through Simply CDN.', 'simply-static'),
+    checked: useForms,
+    onChange: value => {
+      setUseForms(value);
+      updateSetting('ssh_use_forms', value);
+    }
+  }), useForms && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Select a "Thank You" page', 'simply-static'),
+    options: pages,
+    help: __('We will use that page to redirect your visitors after submitting a form on your static website.', 'simply-static'),
+    value: settings.ssh_thank_you_page_id,
+    onChange: value => {
+      updateSetting("ssh_thank_you_page_id", value);
+    }
+  })))), 'pro' === options.plan && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, deliveryMethod === 'github' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('GitHub', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('GitHub enables you to export your static website to one of the common static hosting providers like Netlify, Cloudflare Pages or GitHub Pages.', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Account Type', 'simply-static'),
+    value: githubAccountType,
+    help: __('Depending on the account type the settings fields will change.', 'simply-static'),
+    options: [{
+      label: __('Personal', 'simply-static'),
+      value: 'personal'
+    }, {
+      label: __('Organization', 'simply-static'),
+      value: 'organization'
+    }],
+    onChange: type => {
+      setGithubAccountType(type);
+      updateSetting('github_account_type', type);
+    }
+  }), githubAccountType === 'organization' ? (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Organization', 'simply-static'),
+    type: "text",
+    help: __('Enter the name of your organization.', 'simply-static'),
+    value: settings.github_user,
+    onChange: organization => {
+      updateSetting('github_user', organization);
+    }
+  }) : (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Username', 'simply-static'),
+    type: "text",
+    help: __('Enter your GitHub username.', 'simply-static'),
+    value: settings.github_user,
+    onChange: name => {
+      updateSetting('github_user', name);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('E-Mail', 'simply-static'),
+    type: "email",
+    help: __('Enter your GitHub email address. This will be used to commit files to your repository.', 'simply-static'),
+    value: settings.github_email,
+    onChange: email => {
+      updateSetting('github_email', email);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Personal Access Token', 'simply-static'),
+    type: "password",
+    help: __('You need a personal access token from GitHub.', 'simply-static'),
+    value: settings.github_personal_access_token,
+    onChange: token => {
+      updateSetting('github_personal_access_token', token);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Repository', 'simply-static'),
+    type: "text",
+    help: __('Enter a name for your repository. This should be lowercase and without any spaces or special characters.', 'simply-static'),
+    value: settings.github_repository,
+    onChange: repository => {
+      updateSetting('github_repository', repository);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Folder', 'simply-static'),
+    type: "text",
+    help: __('Enter a relative path to a folder if you want to push files under it. Example: for github.com/USER/REPOSITORY/folder1, enter folder1', 'simply-static'),
+    value: settings.github_folder_path,
+    onChange: repository => {
+      updateSetting('github_folder_path', repository);
+    }
+  }), githubAccountType === 'organization' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "warning",
+    isDismissible: false
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('You need to create the repository manually within your organization before connecting it.', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  })), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Visiblity', 'simply-static'),
+    value: githubVisibility,
+    help: __('Decide if you want to make your repository public or private.', 'simply-static'),
+    options: [{
+      label: __('Public', 'simply-static'),
+      value: 'public'
+    }, {
+      label: __('Private', 'simply-static'),
+      value: 'private'
+    }],
+    onChange: visibility => {
+      setGithubVisibility(visibility);
+      updateSetting('github_repository_visibility', visibility);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Branch', 'simply-static'),
+    type: settings.github_branch,
+    placeholder: "main",
+    help: __('Simply Static automatically uses "main" as branch. You may want to modify that for example to gh-pages. for GitHub Pages.', 'simply-static'),
+    value: settings.github_branch,
+    onChange: branch => {
+      updateSetting('github_branch', branch);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Webhook URL', 'simply-static'),
+    type: "url",
+    help: __('Enter your Webhook URL here and Simply Static will send a POST request after all files are commited to GitHub.', 'simply-static'),
+    value: settings.github_webhook_url,
+    onChange: webhook => {
+      updateSetting('github_webhook_url', webhook);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), deliveryMethod === 'tiiny' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Tiiny.host', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Deploying to Tiiny.host is the easiest and fastest deployment option available in Simply Static Pro.', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    disabled: true,
+    label: __('E-Mail', 'simply-static'),
+    type: "text",
+    help: __('This field is auto-filled with the e-mail address used for activating Simply Static Pro. An account will be created automatically on your first deployment.', 'simply-static'),
+    value: options.admin_email
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Subdomain', 'simply-static'),
+    type: "text",
+    help: __('That\'s the part before your TLD. Your full URL is the combination of the subdomain plus the domain suffix.', 'simply-static'),
+    value: settings.tiiny_subdomain,
+    onChange: subdomain => {
+      updateSetting('tiiny_subdomain', subdomain);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Domain Suffix', 'simply-static'),
+    type: "text",
+    help: __('This defaults to tiiny.site. If you have a custom domain configured in Tiiny.host, you can also use  that one.', 'simply-static'),
+    value: settings.tiiny_domain_suffix,
+    onChange: suffix => {
+      updateSetting('tiiny_domain_suffix', suffix);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Password Protection', 'simply-static'),
+    type: "password",
+    help: __('Adding a password will activate password protection on your static site. The website is only visible with the password.', 'simply-static'),
+    value: settings.tiiny_password,
+    onChange: password => {
+      updateSetting('tiiny_password', password);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), deliveryMethod === 'cdn' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Bunny CDN', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Bunny CDN is a fast and reliable CDN provider that you can run your static website on.', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Bunny CDN API Key', 'simply-static'),
+    type: "password",
+    help: __('Enter your API Key from Bunny CDN. You can find your API-Key as described here.', 'simply-static'),
+    value: settings.cdn_api_key,
+    onChange: api_key => {
+      updateSetting('cdn_api_key', api_key);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Storage Host', 'simply-static'),
+    type: "text",
+    help: __('Depending on your location, you have a different storage host. You find out which URL to use here.', 'simply-static'),
+    value: settings.cdn_storage_host,
+    onChange: storage_host => {
+      updateSetting('cdn_storage_host', storage_host);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Bunny CDN Access Key', 'simply-static'),
+    type: "password",
+    help: __('Enter your Acess Key from Bunny CDN. You will find it within your storage zone setttings within FTP & API Access -> Password.', 'simply-static'),
+    value: settings.cdn_access_key,
+    onChange: access_key => {
+      updateSetting('cdn_access_key', access_key);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Pull Zone', 'simply-static'),
+    type: "text",
+    help: __('A pull zone is the connection of your CDN to the internet. Simply Static will try to find an existing pull zone with the provided name, if there is none it creates a new pull zone.', 'simply-static'),
+    value: settings.cdn_pull_zone,
+    onChange: pull_zone => {
+      updateSetting('cdn_pull_zone', pull_zone);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Storage Zone', 'simply-static'),
+    type: "text",
+    help: __('A storage zone contains your static files. Simply Static will try to find an existing storage zone with the provided name, if there is none it creates a new storage zone.', 'simply-static'),
+    value: settings.cdn_storage_zone,
+    onChange: storage_zone => {
+      updateSetting('cdn_storage_zone', storage_zone);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Subdirectory', 'simply-static'),
+    type: "text",
+    placeholder: '/subdirectory/',
+    help: __('If you want to transfer the files to a specific subdirectory on your storage zone add the name of that directory here.', 'simply-static'),
+    value: settings.cdn_directory,
+    onChange: directory => {
+      updateSetting('cdn_directory', directory);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('404 Page', 'simply-static'),
+    type: "text",
+    placeholder: '/custom-404/',
+    help: __('Relative path to your custom 404 page.', 'simply-static'),
+    value: settings.cdn_404,
+    onChange: error_page => {
+      updateSetting('cdn_404', error_page);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), deliveryMethod === 'aws-s3' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Amazon AWS S3', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Access Key ID', 'simply-static'),
+    type: "text",
+    help: __('Enter your Access Key from AWS.', 'simply-static'),
+    value: settings.aws_access_key,
+    onChange: access_key => {
+      updateSetting('aws_access_key', access_key);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Secret Access Key', 'simply-static'),
+    type: "password",
+    help: __('Enter your Secret Key from AWS.', 'simply-static'),
+    value: settings.aws_access_secret,
+    onChange: secret => {
+      updateSetting('aws_access_secret', secret);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Region', 'simply-static'),
+    value: region,
+    options: [{
+      label: __('US East (Ohio)', 'simply-static'),
+      value: 'us-east-2'
+    }, {
+      label: __('US East (N. Virginia)', 'simply-static'),
+      value: 'us-east-1'
+    }, {
+      label: __('US West (N. California)', 'simply-static'),
+      value: 'us-west-1'
+    }, {
+      label: __('US West (Oregon)', 'simply-static'),
+      value: 'us-west-2'
+    }, {
+      label: __('Africa (Cape Town)', 'simply-static'),
+      value: 'af-south-1'
+    }, {
+      label: __('Asia Pacific (Hong Kong)', 'simply-static'),
+      value: 'ap-east-1'
+    }, {
+      label: __('Asia Pacific (Hyderabad)', 'simply-static'),
+      value: 'ap-south-2'
+    }, {
+      label: __('Asia Pacific (Jakarta)', 'simply-static'),
+      value: 'ap-southeast-3'
+    }, {
+      label: __('Asia Pacific (Melbourne)', 'simply-static'),
+      value: 'ap-southeast-4'
+    }, {
+      label: __('Asia Pacific (Mumbai)', 'simply-static'),
+      value: 'ap-south-1'
+    }, {
+      label: __('Asia Pacific (Osaka)', 'simply-static'),
+      value: 'ap-northeast-3'
+    }, {
+      label: __('Asia Pacific (Seoul)', 'simply-static'),
+      value: 'ap-northeast-2'
+    }, {
+      label: __('Asia Pacific (Singapore)', 'simply-static'),
+      value: 'ap-southeast-1'
+    }, {
+      label: __('Asia Pacific (Sydney)', 'simply-static'),
+      value: 'ap-southeast-2'
+    }, {
+      label: __('Asia Pacific (Tokyo)', 'simply-static'),
+      value: 'ap-northeast-1'
+    }, {
+      label: __('Canada (Central)', 'simply-static'),
+      value: 'ca-central-1'
+    }, {
+      label: __('Europe (Frankfurt)', 'simply-static'),
+      value: 'eu-central-1'
+    }, {
+      label: __('Europe (Ireland)', 'simply-static'),
+      value: 'eu-west-1'
+    }, {
+      label: __('Europe (London)', 'simply-static'),
+      value: 'eu-west-2'
+    }, {
+      label: __('Europe (Milan)', 'simply-static'),
+      value: 'eu-south-1'
+    }, {
+      label: __('Europe (Paris)', 'simply-static'),
+      value: 'eu-west-3'
+    }, {
+      label: __('Europe (Spain)', 'simply-static'),
+      value: 'eu-south-2'
+    }, {
+      label: __('Europe (Stockholm)', 'simply-static'),
+      value: 'eu-north-1'
+    }, {
+      label: __('Europe (Zurich)', 'simply-static'),
+      value: 'eu-central-2'
+    }, {
+      label: __('Middle East (Bahrain)', 'simply-static'),
+      value: 'me-south-1'
+    }, {
+      label: __('Middle East (UAE)', 'simply-static'),
+      value: 'me-central-1'
+    }, {
+      label: __('South America (São Paulo)', 'simply-static'),
+      value: 'sa-east-1'
+    }, {
+      label: __('AWS GovCloud (US-East)', 'simply-static'),
+      value: 'us-gov-east-1'
+    }, {
+      label: __('AWS GovCloud (US-West)', 'simply-static'),
+      value: 'us-gov-west-1'
+    }],
+    onChange: region => {
+      setRegion(region);
+      updateSetting('aws_region', region);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Bucket', 'simply-static'),
+    type: "text",
+    help: __('Add the name of your bucket here.', 'simply-static'),
+    value: settings.aws_bucket,
+    onChange: bucket => {
+      updateSetting('aws_bucket', bucket);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Subdirectory', 'simply-static'),
+    type: "text",
+    help: __('Add an optional subdirectory for your bucket', 'simply-static'),
+    value: settings.aws_subdirectory,
+    onChange: subdirectory => {
+      updateSetting('aws_subdirectory', subdirectory);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Cloudfront Distribution ID', 'simply-static'),
+    type: "text",
+    help: __('We automatically invalidate the cache after each export.', 'simply-static'),
+    value: settings.aws_distribution_id,
+    onChange: distribution_id => {
+      updateSetting('aws_distribution_id', distribution_id);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Empty bucket before new export?', 'simply-static'),
+    help: emptyBucketBeforeExport ? __('Clear bucket before new export.', 'simply-static') : __('Don\'t clear bucket before new export.', 'simply-static'),
+    checked: emptyBucketBeforeExport,
+    onChange: value => {
+      setEmptyBucketBeforeExport(value);
+      updateSetting('aws_empty', value);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), deliveryMethod === 'digitalocean' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Digital Ocean Spaces', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Spaces Key', 'simply-static'),
+    type: "text",
+    help: __('Enter your Spaces Key from Digital Ocean.', 'simply-static'),
+    value: settings.digitalocean_key,
+    onChange: api_key => {
+      updateSetting('digitalocean_key', api_key);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Secret', 'simply-static'),
+    type: "password",
+    help: __('Enter your Spaces Secret from Digital Ocean.', 'simply-static'),
+    value: settings.digitalocean_secret,
+    onChange: secret => {
+      updateSetting('digitalocean_secret', secret);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Bucket Name', 'simply-static'),
+    help: __('The bucket name for your space.', 'simply-static'),
+    type: "text",
+    placeholder: "my-bucket",
+    value: settings.digitalocean_bucket,
+    onChange: bucket => {
+      updateSetting('digitalocean_bucket', bucket);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Region', 'simply-static'),
+    type: "text",
+    help: __('The region for your space.', 'simply-static'),
+    placeholder: "ams3",
+    value: settings.digitalocean_region,
+    onChange: region => {
+      updateSetting('digitalocean_region', region);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, settings.digitalocean_bucket && settings.digitalocean_region && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "warning",
+    isDismissible: false
+  }, __('Your endpoint will be', 'simply-static'), " :", 'https://' + settings.digitalocean_bucket + '.' + settings.digitalocean_region + '.digitaloceanspaces.com'))))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), settingsSaved && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings saved successfully.', 'simply-static')))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  })), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "save-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: setSavingSettings,
+    variant: "primary"
+  }, __('Save Settings', 'simply-static'))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (DeploymentSettings);
+
+/***/ }),
+
+/***/ "./src/settings/pages/Diagnostics.jsx":
+/*!********************************************!*\
+  !*** ./src/settings/pages/Diagnostics.jsx ***!
+  \********************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+
+
+
+
+function Diagnostics() {
+  const {
+    configs
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__.SettingsContext);
+  const statusData = () => (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", null, Object.keys(configs).map(key => {
+    const items = configs[key];
+    return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+      key: key
+    }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, key)), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("table", {
+      style: {
+        width: "100%",
+        tableLayout: "fixed"
+      }
+    }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("tbody", {
+      className: "table-data"
+    }, Object.entries(items).map(item => {
+      return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("tr", {
+        className: "table-row",
+        key: item[0]
+      }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("td", {
+        className: "diagnostics-icon"
+      }, " ", item[1].test ? (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Dashicon, {
+        className: "icon-yes",
+        icon: "yes"
+      }) : (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Dashicon, {
+        className: "icon-no",
+        icon: "no"
+      })), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("td", {
+        className: "diagnostics-test"
+      }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, item[0])), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("td", null, item[1].test), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("td", {
+        className: "diagnostics-result"
+      }, " ", item[1].test ? (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, item[1].description) : (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, item[1].error)));
+    })))))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+      margin: 5
+    }));
+  }));
+  return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "inner-settings"
+  }, statusData());
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (Diagnostics);
+
+/***/ }),
+
+/***/ "./src/settings/pages/FormSettings.jsx":
+/*!*********************************************!*\
+  !*** ./src/settings/pages/FormSettings.jsx ***!
+  \*********************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function FormSettings() {
+  const {
+    settings,
+    updateSetting,
+    saveSettings,
+    settingsSaved,
+    setSettingsSaved
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__.SettingsContext);
+  const [corsMethod, setCorsMethod] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('allowed_http_origins');
+  const [useForms, setUseForms] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [useComments, setUseComments] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const setSavingSettings = () => {
+    saveSettings();
+    setSettingsSaved(true);
+    setTimeout(function () {
+      setSettingsSaved(false);
+    }, 2000);
+  };
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useEffect)(() => {
+    if (settings.fix_cors) {
+      setCorsMethod(settings.fix_cors);
+    }
+    if (settings.use_forms) {
+      setUseForms(settings.use_forms);
+    }
+    if (settings.use_comments) {
+      setUseComments(settings.use_comments);
+    }
+  }, [settings]);
+  return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "inner-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Forms', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Use forms?', 'simply-static'),
+    help: useForms ? __('Use Forms on your static website.', 'simply-static') : __('Don\'t use forms on your static website.', 'simply-static'),
+    checked: useForms,
+    onChange: value => {
+      setUseForms(value);
+      updateSetting('use_forms', value);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Comments', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Use comments?', 'simply-static'),
+    help: useComments ? __('Use comments on your static website.', 'simply-static') : __('Don\'t use comments on your static website.', 'simply-static'),
+    checked: useComments,
+    onChange: value => {
+      setUseComments(value);
+      updateSetting('use_comments', value);
+    }
+  }), useComments && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Redirect URL', 'simply-static'),
+    type: "url",
+    placeholder: 'https://static-example.com/thank-you',
+    help: __('The page will be generated and committed automatically after a comment was added, but it might take a while so its good practice to redirect the visitor.', 'simply-static'),
+    value: settings.comment_redirect,
+    onChange: redirect => {
+      updateSetting('comment_redirect', redirect);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('CORS', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('When using Forms and Comments in Simply Static Pro you may encouter CORS issues as you make requests from your static website to your original one.', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "warning",
+    isDismissible: false
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Due to the variety of server setups out there, you may need to make changes on your server.', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Static URL', 'simply-static'),
+    type: "url",
+    placeholder: 'https://static-site.com',
+    help: __('Add the URL of your static website to allow CORS from it.', 'simply-static'),
+    value: settings.static_url,
+    onChange: url => {
+      updateSetting('static_url', url);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Select CORS method', 'simply-static'),
+    value: corsMethod,
+    help: __('Choose one of the methods to allow CORS for your website.', 'simply-static'),
+    options: [{
+      label: 'allowed_http_origins',
+      value: 'allowed_http_origins'
+    }, {
+      label: 'wp_headers',
+      value: 'wp_headers'
+    }],
+    onChange: method => {
+      setCorsMethod(method);
+      updateSetting('fix_cors', method);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), settingsSaved && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings saved successfully.', 'simply-static')))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  })), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "save-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: setSavingSettings,
+    variant: "primary"
+  }, __('Save Settings', 'simply-static'))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (FormSettings);
+
+/***/ }),
+
+/***/ "./src/settings/pages/GeneralSettings.jsx":
+/*!************************************************!*\
+  !*** ./src/settings/pages/GeneralSettings.jsx ***!
+  \************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function GeneralSettings() {
+  const {
+    settings,
+    updateSetting,
+    saveSettings,
+    settingsSaved,
+    setSettingsSaved
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__.SettingsContext);
+  const [replaceType, setReplaceType] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('relative');
+  const [scheme, setScheme] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('https://');
+  const [host, setHost] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('');
+  const [path, setPath] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('/');
+  const [forceURLReplacement, setForceURLReplacement] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [hasCopied, setHasCopied] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [generate404, setGenerate404] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const setSavingSettings = () => {
+    saveSettings();
+    setSettingsSaved(true);
+    setTimeout(function () {
+      setSettingsSaved(false);
+    }, 2000);
+  };
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useEffect)(() => {
+    if (settings.destination_url_type) {
+      setReplaceType(settings.destination_url_type);
+    }
+    if (settings.destination_scheme) {
+      setScheme(settings.destination_scheme);
+    }
+    if (settings.destination_host) {
+      setHost(settings.destination_host);
+    }
+    if (settings.relative_path) {
+      setPath(settings.relative_path);
+    }
+    if (settings.force_replace_url) {
+      setForceURLReplacement(settings.force_replace_url);
+    }
+    if (settings.generate_404) {
+      setGenerate404(settings.generate_404);
+    }
+  }, [settings]);
+  return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "inner-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Replacing URLs', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('When exporting your static site, any links to your WordPress site will be replaced by one of the following: absolute URLs, relative URLs, or URLs contructed for offline use.', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Replacing URLs', 'simply-static'),
+    value: replaceType,
+    options: [{
+      label: __('Absolute URLs', 'simply-static'),
+      value: 'absolute'
+    }, {
+      label: __('Relative Path', 'simply-static'),
+      value: 'relative'
+    }, {
+      label: __('Offline Usage', 'simply-static'),
+      value: 'offline'
+    }],
+    onChange: type => {
+      setReplaceType(type);
+      updateSetting('destination_url_type', type);
+    }
+  }), replaceType === 'absolute' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, {
+    style: {
+      minWidth: "15%"
+    }
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Scheme', 'simply-static'),
+    value: scheme,
+    options: [{
+      label: 'https://',
+      value: 'https://'
+    }, {
+      label: 'http://',
+      value: 'http://'
+    }, {
+      label: '//',
+      value: '//'
+    }],
+    onChange: scheme => {
+      setScheme(scheme);
+      updateSetting('destination_scheme', scheme);
+    }
+  })), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, {
+    style: {
+      minWidth: "85%"
+    }
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Host', 'simply-static'),
+    type: "text",
+    placeholder: "example.com",
+    value: host,
+    onChange: host => {
+      setHost(host);
+      updateSetting('destination_host', host);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Convert all URLs for your WordPress site to absolute URLs at the domain specified above.', 'simply-static'))), replaceType === 'relative' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Path', 'simply-static'),
+    type: "text",
+    placeholder: "/",
+    value: path,
+    onChange: path => {
+      setPath(path);
+      updateSetting('relative_path', path);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Convert all URLs for your WordPress site to relative URLs that will work at any domain.', 'simply-static'), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), __('Optionally specify a path above if you intend to place the files in a subdirectory.', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "warning",
+    isDismissible: false
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Example', 'simply-static'), ": "), __('enter /path above if you wanted to serve your files at www.example.com/path/', 'simply-static')))), replaceType === 'offline' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Convert all URLs for your WordPress site so that you can browse the site locally on your own computer without hosting it on a web server.', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Force URL replacements', 'simply-static'),
+    help: forceURLReplacement ? __('Replace all occurrences of the WordPress URL with the static URL (includes inline CSS and JS).', 'simply-static') : __('Replace only occurrences of the WordPress URL that match our tag list.', 'simply-static'),
+    checked: forceURLReplacement,
+    onChange: value => {
+      setForceURLReplacement(value);
+      updateSetting('force_replace_url', value);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Include', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextareaControl, {
+    label: __('Additional URLs', 'simply-static'),
+    placeholder: options.home + "/hidden-page/",
+    help: __('If you want to create static copies of pages or files that aren\'t linked to, add the URLs here (one per line).', 'simply-static'),
+    value: settings.additional_urls,
+    onChange: value => {
+      updateSetting('additional_urls', value);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextareaControl, {
+    label: __('Additional Files and Directories', 'simply-static'),
+    placeholder: options.home_path + "additional-directory/\n" + options.home_path + "additional-file.html",
+    help: __('Sometimes you may want to include additional files (such as files referenced via AJAX) or directories. Add the paths to those files or directories here (one per line).', 'simply-static'),
+    value: settings.additional_files,
+    onChange: value => {
+      updateSetting('additional_files', value);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ClipboardButton, {
+    variant: "secondary",
+    text: options.home_path,
+    onCopy: () => setHasCopied(true),
+    onFinishCopy: () => setHasCopied(false)
+  }, hasCopied ? __('Copied home path', 'simply-static') : __('Copy home path', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Generate 404 Page?', 'simply-static'),
+    help: generate404 ? __('Generate a 404 page.', 'simply-static') : __('Don\'t generate a 404 page.', 'simply-static'),
+    checked: generate404,
+    onChange: value => {
+      setGenerate404(value);
+      updateSetting('generate_404', value);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Exclude', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextareaControl, {
+    label: __('Urls to exclude', 'simply-static'),
+    placeholder: "wp-json.php\nwp-login.php\n.jpg",
+    help: __('Specify URLs (or parts of URLs) you want to exclude from the processing (one per line).', 'simply-static'),
+    value: settings.urls_to_exclude,
+    onChange: value => {
+      updateSetting('urls_to_exclude', value);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), settingsSaved && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings saved successfully.', 'simply-static')))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  })), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "save-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: setSavingSettings,
+    variant: "primary"
+  }, __('Save Settings', 'simply-static'))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (GeneralSettings);
+
+/***/ }),
+
+/***/ "./src/settings/pages/Generate.jsx":
+/*!*****************************************!*\
+  !*** ./src/settings/pages/Generate.jsx ***!
+  \*****************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _components_ActivityLog__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../components/ActivityLog */ "./src/settings/components/ActivityLog.jsx");
+/* harmony import */ var _components_ExportLog__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ../components/ExportLog */ "./src/settings/components/ExportLog.jsx");
+/* harmony import */ var _components_LogButtons__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ../components/LogButtons */ "./src/settings/components/LogButtons.jsx");
+
+
+
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function Generate() {
+  const {
+    settings,
+    blogId,
+    setBlogId
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__.SettingsContext);
+  const [selectedSiteUrl, setSelectedSiteURL] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('');
+  const [selectedSiteActivityUrl, setSelectedSiteActivityUrl] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('');
+  return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "inner-settings settings-wide"
+  }, !options.is_network && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_ActivityLog__WEBPACK_IMPORTED_MODULE_3__["default"], null), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  })), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, {
+    align: "top"
+  }, options.is_network && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, {
+    isBlock: true
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Multisite', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Choose a site to export', 'simply-static'),
+    value: blogId,
+    options: options.sites.map(function (site) {
+      return {
+        label: `${site.name} (${site.url})`,
+        value: site.blog_id
+      };
+    }),
+    onChange: blog_id => {
+      setBlogId(blog_id);
+
+      // Update admin edit URL:
+      options.sites.some(item => {
+        if (item.blog_id === blog_id) {
+          setSelectedSiteURL(item.settings_url);
+          setSelectedSiteActivityUrl(item.activity_log_url);
+        }
+      });
+    }
+  }), selectedSiteUrl && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    isPrimary: true,
+    href: selectedSiteUrl
+  }, "Switch to Site settings"), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    style: {
+      marginLeft: "5px"
+    },
+    isSecondary: true,
+    href: selectedSiteActivityUrl
+  }, "Check progress"))))), settings.debugging_mode && options.log_file && !options.is_network && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, {
+    isBlock: true
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Debugging', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_LogButtons__WEBPACK_IMPORTED_MODULE_5__["default"], null))))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Export Log', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_ExportLog__WEBPACK_IMPORTED_MODULE_4__["default"], null))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (Generate);
+
+/***/ }),
+
+/***/ "./src/settings/pages/MiscSettings.jsx":
+/*!*********************************************!*\
+  !*** ./src/settings/pages/MiscSettings.jsx ***!
+  \*********************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function MiscSettings() {
+  const {
+    settings,
+    updateSetting,
+    saveSettings,
+    settingsSaved,
+    setSettingsSaved
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__.SettingsContext);
+  const [debuggingMode, setDebuggingMode] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const setSavingSettings = () => {
+    saveSettings();
+    setSettingsSaved(true);
+    setTimeout(function () {
+      setSettingsSaved(false);
+    }, 2000);
+  };
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useEffect)(() => {
+    if (settings.debugging_mode) {
+      setDebuggingMode(settings.debugging_mode);
+    }
+  }, [settings]);
+  return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "inner-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Temporary Files', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Your static files are temporarily saved to a directory before being copied to their destination or creating a ZIP.', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Temporary Files Directory', 'simply-static'),
+    type: "text",
+    placeholder: options.temp_files_dir,
+    help: __('Specify the directory to save your temporary files. This directory must exist and be writeable.', 'simply-static'),
+    value: settings.temp_files_dir,
+    onChange: temp_dir => {
+      updateSetting('temp_files_dir', temp_dir);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Basic Auth', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('If you\'ve secured WordPress with HTTP Basic Auth you can specify the username and password to use below.', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Basic Auth Username', 'simply-static'),
+    autoComplete: "off",
+    type: "text",
+    value: settings.http_basic_auth_username,
+    onChange: username => {
+      updateSetting('http_basic_auth_username', username);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Basic Auth Password', 'simply-static'),
+    type: "password",
+    autoComplete: "off",
+    value: settings.http_basic_auth_password,
+    onChange: username => {
+      updateSetting('http_basic_auth_password', username);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Debugging', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Debugging Mode', 'simply-static'),
+    help: debuggingMode ? __('Enable debugging mode.', 'simply-static') : __('Disable debugging mode.', 'simply-static'),
+    checked: debuggingMode,
+    onChange: value => {
+      setDebuggingMode(value);
+      updateSetting('debugging_mode', value);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Origin URL', 'simply-static'),
+    type: "url",
+    help: __('If the URL of your WordPress installation differs from the public-facing URL (Proxy Setup), add the public URL here.', 'simply-static'),
+    placeholder: options.home,
+    autoComplete: "off",
+    value: settings.origin_url,
+    onChange: origin_url => {
+      updateSetting('origin_url', origin_url);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), settingsSaved && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings saved successfully.', 'simply-static')))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  })), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "save-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: setSavingSettings,
+    variant: "primary"
+  }, __('Save Settings', 'simply-static'))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (MiscSettings);
+
+/***/ }),
+
+/***/ "./src/settings/pages/Optimize.jsx":
+/*!*****************************************!*\
+  !*** ./src/settings/pages/Optimize.jsx ***!
+  \*****************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function Optimize() {
+  const {
+    settings,
+    updateSetting,
+    saveSettings,
+    settingsSaved,
+    setSettingsSaved
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__.SettingsContext);
+  const [minifyFiles, setMinifyFiles] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [minifyHtml, setMinifyHtml] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [minifyCss, setMinifyCss] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [minifyInlineCss, setMinifyInlineCss] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [minifyJavascript, setMinifyJavascript] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [minifyInlineJavascript, setMinifyInlineJavascript] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [renamePlugin, setRenamePlugin] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [wpContentDirectory, setWpContentDirectory] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('wp-content');
+  const [wpIncludesDirectory, setWpIncludesDirectory] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('wp-includes');
+  const [wpUploadsDirectory, setWpUploadsDirectory] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('wp-content/uploads');
+  const [wpPluginsDirectory, setWpPluginsDirectory] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('wp-content/plugins');
+  const [wpThemesDirectory, setWpThemesDirectory] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('wp-content/themes');
+  const [themeStyleName, setThemeStyleName] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('style');
+  const [authorUrl, setAuthorUrl] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('author');
+  const [hideRESTAPI, setHideRESTAPI] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [hideStyleId, setHideStyleId] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [hideComments, setHideComments] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [hideVersion, setHideVersion] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [hidePrefetch, setHidePrefetch] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [hideGenerator, setHideGenerator] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [hideRSD, setHideRSD] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [hideEmojis, setHideEmojis] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [disableXMLRPC, setDisableXMLRPC] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [disableEmbed, setDisableEmbed] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [disableDbDebug, setDisableDbDebug] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [disableWLW, setDisableWLW] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [disableDirectory, setDisableDirectory] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const setSavingSettings = () => {
+    saveSettings();
+    setSettingsSaved(true);
+    setTimeout(function () {
+      setSettingsSaved(false);
+    }, 2000);
+  };
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useEffect)(() => {
+    if (settings.use_minify) {
+      setMinifyFiles(settings.use_minify);
+    }
+    if (settings.minify_html) {
+      setMinifyHtml(settings.minify_html);
+    }
+    if (settings.minify_css) {
+      setMinifyCss(settings.minify_css);
+    }
+    if (settings.minify_inline_css) {
+      setMinifyInlineCss(settings.minify_inline_css);
+    }
+    if (settings.minify_js) {
+      setMinifyJavascript(settings.minify_js);
+    }
+    if (settings.minify_inline_js) {
+      setMinifyInlineJavascript(settings.minify_inline_js);
+    }
+    if (settings.wp_content_directory) {
+      setWpContentDirectory(settings.wp_content_directory);
+    }
+    if (settings.wp_includes_directory) {
+      setWpIncludesDirectory(settings.wp_includes_directory);
+    }
+    if (settings.wp_uploads_directory) {
+      setWpUploadsDirectory(settings.wp_uploads_directory);
+    }
+    if (settings.wp_plugins_directory) {
+      setWpPluginsDirectory(settings.wp_plugins_directory);
+    }
+    if (settings.rename_plugin_directories) {
+      setRenamePluginDirectorys(settings.rename_plugin_directories);
+    }
+    if (settings.wp_themes_directory) {
+      setWpThemesDirectory(settings.wp_themes_directory);
+    }
+    if (settings.theme_style_name) {
+      setThemeStyleName(settings.theme_style_name);
+    }
+    if (settings.author_url) {
+      setAuthorUrl(settings.author_url);
+    }
+    if (settings.hide_rest_api) {
+      setHideRESTAPI(settings.hide_rest_api);
+    }
+    if (settings.hide_style_id) {
+      setHideStyleId(settings.hide_style_id);
+    }
+    if (settings.hide_comments) {
+      setHideComments(settings.hide_comments);
+    }
+    if (settings.hide_version) {
+      setHideVersion(settings.hide_version);
+    }
+    if (settings.hide_generator) {
+      setHideGenerator(settings.hide_generator);
+    }
+    if (settings.hide_prefetch) {
+      setHidePrefetch(settings.hide_prefetch);
+    }
+    if (settings.hide_rsd) {
+      setHideRSD(settings.hide_rsd);
+    }
+    if (settings.hide_emotes) {
+      setHideEmojis(settings.hide_emotes);
+    }
+    if (settings.disable_xmlrpc) {
+      setDisableXMLRPC(settings.disable_xmlrpc);
+    }
+    if (settings.disable_embed) {
+      setDisableEmbed(settings.disable_embed);
+    }
+    if (settings.disable_db_debug) {
+      setDisableDbDebug(settings.disable_db_debug);
+    }
+    if (settings.disable_wlw_manifest) {
+      setDisableWLW(settings.disable_wlw_manifest);
+    }
+    if (settings.disable_directory_browsing) {
+      setDisableDirectory(settings.disable_directory_browsing);
+    }
+  }, [settings]);
+  return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "inner-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Minify', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Minify Files?', 'simply-static'),
+    help: minifyFiles ? __('Enable minify files on your static website.', 'simply-static') : __('Don\'t enable minify files on your static website.', 'simply-static'),
+    checked: minifyFiles,
+    onChange: value => {
+      setMinifyFiles(value);
+      updateSetting('use_minify', value);
+    }
+  }), minifyFiles && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Minify HTML', 'simply-static'),
+    help: minifyHtml ? __('Minify HTML files.', 'simply-static') : __('Don\'t minify HTML files.', 'simply-static'),
+    checked: minifyHtml,
+    onChange: value => {
+      setMinifyHtml(value);
+      updateSetting('minify_html', value);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Minify CSS', 'simply-static'),
+    help: minifyCss ? __('Minify CSS files.', 'simply-static') : __('Don\'t minify CSS files.', 'simply-static'),
+    checked: minifyCss,
+    onChange: value => {
+      setMinifyCss(value);
+      updateSetting('minify_css', value);
+    }
+  }), minifyCss && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Minify Inline CSS', 'simply-static'),
+    help: minifyInlineCss ? __('Minify Inline CSS.', 'simply-static') : __('Don\'t minify Inline CSS.', 'simply-static'),
+    checked: minifyInlineCss,
+    onChange: value => {
+      setMinifyInlineCss(value);
+      updateSetting('minify_inline_css', value);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Minify JavaScript', 'simply-static'),
+    help: minifyJavascript ? __('Minify JavaScript files.', 'simply-static') : __('Don\'t minify JavaScript files.', 'simply-static'),
+    checked: minifyJavascript,
+    onChange: value => {
+      setMinifyJavascript(value);
+      updateSetting('minify_js', value);
+    }
+  }), minifyJavascript && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Minify Inline JavaScript', 'simply-static'),
+    help: minifyInlineJavascript ? __('Minify Inline JavaScript.', 'simply-static') : __('Don\'t minify Inline JavaScript.', 'simply-static'),
+    checked: minifyInlineJavascript,
+    onChange: value => {
+      setMinifyInlineJavascript(value);
+      updateSetting('minify_inline_js', value);
+    }
+  })))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Replace', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('wp-content directory', 'simply-static'),
+    help: __('Replace the "wp-content" directory.', 'simply-static'),
+    type: "text",
+    placeholder: "wp-content",
+    value: wpContentDirectory,
+    onChange: directory => {
+      updateSetting('wp_content_directory', directory);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('wp-includes directory', 'simply-static'),
+    help: __('Replace the "wp-includes" directory.', 'simply-static'),
+    type: "text",
+    placeholder: "wp-includes",
+    value: wpIncludesDirectory,
+    onChange: directory => {
+      updateSetting('wp_includes_directory', directory);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('uploads directory', 'simply-static'),
+    help: __('Replace the "wp-content/uploads" directory.', 'simply-static'),
+    type: "text",
+    placeholder: "uploads",
+    value: wpUploadsDirectory,
+    onChange: directory => {
+      setWpUploadsDirectory(directory);
+      updateSetting('wp_uploads_directory', directory);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('plugins directory', 'simply-static'),
+    help: __('Replace the "wp-content/plugins" directory.', 'simply-static'),
+    type: "text",
+    placeholder: "plugins",
+    value: wpPluginsDirectory,
+    onChange: directory => {
+      setWpPluginsDirectory(directory);
+      updateSetting('wp_plugins_directory', directory);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Replace Plugin Names?', 'simply-static'),
+    help: renamePlugin ? __('Replace plugin names with a random string combinations.', 'simply-static') : __('Keep plugin names.', 'simply-static'),
+    checked: renamePlugin,
+    onChange: value => {
+      setRenamePlugin(value);
+      updateSetting('rename_plugins', value);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('themes directory', 'simply-static'),
+    help: __('Replace the "wp-content/themes" directory.', 'simply-static'),
+    type: "text",
+    placeholder: "themes",
+    value: wpThemesDirectory,
+    onChange: directory => {
+      setWpThemesDirectory(directory);
+      updateSetting('wp_themes_directory', directory);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalInputControl, {
+    label: __('Theme style name', 'simply-static'),
+    help: __('Replace the style.css filename.', 'simply-static'),
+    type: "text",
+    className: "ss-theme-style-name",
+    suffix: '.css',
+    placeholder: "style",
+    value: themeStyleName,
+    onChange: style => {
+      setThemeStyleName(style);
+      updateSetting('theme_style_name', style);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Author URL', 'simply-static'),
+    help: __('Replace the author url.', 'simply-static'),
+    type: "text",
+    placeholder: "author",
+    value: authorUrl,
+    onChange: url => {
+      setAuthorUrl(url);
+      updateSetting('author_url', url);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Hide', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Hide REST API URLs', 'simply-static'),
+    checked: hideRESTAPI,
+    onChange: value => {
+      setHideRESTAPI(value);
+      updateSetting('hide_rest_api', value);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Hide Style/Script IDs', 'simply-static'),
+    checked: hideStyleId,
+    onChange: value => {
+      setHideStyleId(value);
+      updateSetting('hide_style_id', value);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Hide HTML Comments', 'simply-static'),
+    checked: hideComments,
+    onChange: value => {
+      setHideComments(value);
+      updateSetting('hide_comments', value);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Hide WordPress Version', 'simply-static'),
+    checked: hideVersion,
+    onChange: value => {
+      setHideVersion(value);
+      updateSetting('hide_version', value);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Hide WordPress Generator Meta', 'simply-static'),
+    checked: hideGenerator,
+    onChange: value => {
+      setHideGenerator(value);
+      updateSetting('hide_generator', value);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Hide DNS Prefetch WordPress link', 'simply-static'),
+    checked: hidePrefetch,
+    onChange: value => {
+      setHidePrefetch(value);
+      updateSetting('hide_prefetch', value);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Hide RSD Header', 'simply-static'),
+    checked: hideRSD,
+    onChange: value => {
+      setHideRSD(value);
+      updateSetting('hide_rsd', value);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Hide Emojis if you don\'t use them', 'simply-static'),
+    checked: hideEmojis,
+    onChange: value => {
+      setHideEmojis(value);
+      updateSetting('hide_emotes', value);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Disable', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Disable XML-RPC', 'simply-static'),
+    checked: disableXMLRPC,
+    onChange: value => {
+      setDisableXMLRPC(value);
+      updateSetting('disable_xmlrpc', value);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Disable Embed Scripts', 'simply-static'),
+    checked: disableEmbed,
+    onChange: value => {
+      setDisableEmbed(value);
+      updateSetting('disable_embed', value);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Disable DB Debug in Frontend', 'simply-static'),
+    checked: disableDbDebug,
+    onChange: value => {
+      setDisableDbDebug(value);
+      updateSetting('disable_db_debug', value);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Disable WLW Manifest Scripts', 'simply-static'),
+    checked: disableWLW,
+    onChange: value => {
+      setDisableWLW(value);
+      updateSetting('disable_wlw_manifest', value);
+    }
+  }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), settingsSaved && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings saved successfully.', 'simply-static')))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  })), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "save-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: setSavingSettings,
+    variant: "primary"
+  }, __('Save Settings', 'simply-static'))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (Optimize);
+
+/***/ }),
+
+/***/ "./src/settings/pages/SearchSettings.jsx":
+/*!***********************************************!*\
+  !*** ./src/settings/pages/SearchSettings.jsx ***!
+  \***********************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function SearchSettings() {
+  const {
+    settings,
+    updateSetting,
+    saveSettings,
+    settingsSaved,
+    setSettingsSaved
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__.SettingsContext);
+  const [useSearch, setUseSearch] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [searchType, setSearchType] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)('fuse');
+  const [isMetaModalOpen, setMetaModalOpen] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const openMetaModal = () => setMetaModalOpen(true);
+  const closeMetaModal = () => setMetaModalOpen(false);
+  const setSavingSettings = () => {
+    saveSettings();
+    setSettingsSaved(true);
+    setTimeout(function () {
+      setSettingsSaved(false);
+    }, 2000);
+  };
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useEffect)(() => {
+    if (settings.use_search) {
+      setUseSearch(settings.use_search);
+    }
+    if (settings.search_type) {
+      setSearchType(settings.search_type);
+    }
+  }, [settings]);
+  return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "inner-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Search', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Use search?', 'simply-static'),
+    help: useSearch ? __('Use search on your static website.', 'simply-static') : __('Don\'t use search on your static website.', 'simply-static'),
+    checked: useSearch,
+    onChange: value => {
+      setUseSearch(value);
+      updateSetting('use_search', value);
+    }
+  }), useSearch && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Search Type', 'simply-static'),
+    value: searchType,
+    help: __('Decide wich search type you want to use. Fuse runs locally based on file and Algolia is an external API service.', 'simply-static'),
+    options: [{
+      label: 'Fuse JS',
+      value: 'fuse'
+    }, {
+      label: 'Algolia API',
+      value: 'algolia'
+    }],
+    onChange: type => {
+      setSearchType(type);
+      updateSetting('search_type', type);
+    }
+  }))), useSearch && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, isMetaModalOpen && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Modal, {
+    title: __('How to select data with meta tags', 'simply-static'),
+    onRequestClose: closeMetaModal
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Targeting for excerpt in the meta description tag.', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("pre", null, "<meta name=\"description\" content=\"This content is what we want as excerpt\" />"), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Adding such meta in the excerpt field would be:', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("pre", null, "description|content"), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Targeting for title in the property meta tag.', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("pre", null, "<meta property=\"og:title\" content=\"This content is what we want as excerpt\" />"), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Adding such meta in the excerpt field would be:', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("pre", null, "property|og:title"), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('If the second item (after | ) is not <code>content</code>, we\'ll use it as value of that attribute (<code>property="og:title"</code> in this example) and use <code>content</code> for value.', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("strong", null, __('Caution: Use meta tags that exist everywhere for title.', 'simply-static')))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Indexing', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('CSS-Selector for Title', 'simply-static'),
+    type: "text",
+    placeholder: 'title',
+    help: [__('Add the CSS selector which contains the title of the page/post', 'simply-static'), ' ', (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+      variant: 'link',
+      onClick: openMetaModal
+    }, __('Or meta tags. Click for more information.', 'simply-static'))],
+    value: settings.search_index_title,
+    onChange: title => {
+      updateSetting('search_index_title', title);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('CSS-Selector for Content', 'simply-static'),
+    type: "text",
+    placeholder: 'body',
+    help: [__('Add the CSS selector which contains the content of the page/post.', 'simply-static'), ' ', (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+      variant: 'link',
+      onClick: openMetaModal
+    }, __('Or meta tags. Click for more information.', 'simply-static'))],
+    value: settings.search_index_content,
+    onChange: content => {
+      updateSetting('search_index_content', content);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('CSS-Selector for Excerpt', 'simply-static'),
+    type: "text",
+    placeholder: '.entry-content',
+    help: [__('Add the CSS selector which contains the excerpt of the page/post.', 'simply-static'), ' ', (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+      variant: 'link',
+      onClick: openMetaModal
+    }, __('Or meta tags. Click for more information.', 'simply-static'))],
+    value: settings.search_index_excerpt,
+    onChange: excerpt => {
+      updateSetting('search_index_excerpt', excerpt);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextareaControl, {
+    label: __('Exclude URLs', 'simply-static'),
+    placeholder: "author\narchive\ncategory",
+    help: __('Exclude URLs from indexing (one per line). You can use full URLs, parts of an URL or plain words (like stop words).', 'simply-static'),
+    value: settings.search_excludable,
+    onChange: excludes => {
+      updateSetting('search_excludable', excludes);
+    }
+  })))), useSearch && searchType === 'fuse' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Fuse.js', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('CSS-Selector', 'simply-static'),
+    type: "text",
+    help: __('Add the CSS selector of your search element here.', 'simply-static'),
+    value: settings.fuse_selector,
+    onChange: selector => {
+      updateSetting('fuse_selector', selector);
+    }
+  })))), useSearch && searchType === 'algolia' && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Algolia API', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Application ID', 'simply-static'),
+    type: "password",
+    help: __('Add your Algolia App ID.', 'simply-static'),
+    value: settings.algolia_app_id,
+    onChange: app_id => {
+      updateSetting('algolia_app_id', app_id);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Admin API Key', 'simply-static'),
+    type: "password",
+    help: __('Add your Algolia Admin API Key.', 'simply-static'),
+    value: settings.algolia_admin_api_key,
+    onChange: api_key => {
+      updateSetting('algolia_admin_api_key', api_key);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Search-Only API Key', 'simply-static'),
+    type: "password",
+    help: __('Add your Algolia Search-Only API Key here. This is the only key that will be visible on your static site.', 'simply-static'),
+    value: settings.algolia_search_api_key,
+    onChange: api_key => {
+      updateSetting('algolia_search_api_key', api_key);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Name for your index', 'simply-static'),
+    type: "text",
+    help: __('Add your Algolia index name here.', 'simply-static'),
+    value: settings.algolia_index,
+    onChange: index => {
+      updateSetting('algolia_index', index);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('CSS-Selector', 'simply-static'),
+    type: "text",
+    help: __('Add the CSS selector of your search element here.', 'simply-static'),
+    value: settings.algolia_selector,
+    onChange: selector => {
+      updateSetting('algolia_selector', selector);
+    }
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "warning",
+    isDismissible: false
+  }, __('If you have multiple search elements with different CSS selectors, separate them by a comma (,) such as: .search-field, .search-field2', 'simply-static')))))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), settingsSaved && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings saved successfully.', 'simply-static')))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  })), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "save-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: setSavingSettings,
+    variant: "primary"
+  }, __('Save Settings', 'simply-static'))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (SearchSettings);
+
+/***/ }),
+
+/***/ "./src/settings/pages/Utilities.jsx":
+/*!******************************************!*\
+  !*** ./src/settings/pages/Utilities.jsx ***!
+  \******************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function Utilities() {
+  const {
+    settings,
+    importSettings,
+    saveSettings,
+    resetSettings,
+    migrateSettings
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__.SettingsContext);
+  const [isExport, setIsExport] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [isImport, setIsImport] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [isReset, setIsReset] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [isMigrate, setIsMigrate] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [hasCopied, setHasCopied] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const [importData, setImportData] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.useState)(false);
+  const setImportDataValue = event => {
+    setImportData(JSON.parse(event.target.value));
+  };
+  const runImportSettings = () => {
+    importSettings(importData);
+    setIsImport(true);
+    setTimeout(function () {
+      setIsImport(false);
+    }, 2000);
+  };
+  const runResetSettings = () => {
+    resetSettings();
+    setIsReset(true);
+    setTimeout(function () {
+      setIsReset(false);
+    }, 2000);
+  };
+  const runMigrateSettings = () => {
+    migrateSettings();
+    saveSettings();
+    setIsMigrate(true);
+    setTimeout(function () {
+      setIsMigrate(false);
+      location.reload();
+    }, 2000);
+  };
+  return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "inner-settings"
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Migrate Settings', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Migrate all of your settings to Simply Static 3.0', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: runMigrateSettings,
+    variant: "primary"
+  }, __('Migrate settings', 'simply-static'))), isMigrate ? (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings migration successfully.', 'simply-static')))) : '')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Export', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, !isExport ? (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: setIsExport,
+    variant: "primary"
+  }, __('Export Settings', 'simply-static'))) : (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("code", null, JSON.stringify(settings))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ClipboardButton, {
+    variant: "secondary",
+    text: JSON.stringify(settings),
+    onCopy: () => setHasCopied(true),
+    onFinishCopy: () => setHasCopied(false)
+  }, hasCopied ? __('Copied!', 'simply-static') : __('Copy export data', 'simply-static')))))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Import', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Paste in the JSON string you got from your export to import all settings for the plugin.', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("textarea", {
+    rows: "8",
+    cols: "60",
+    name: "import-data",
+    onChange: setImportDataValue
+  })), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: runImportSettings,
+    variant: "primary"
+  }, __('Import Settings', 'simply-static'))), isImport ? (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings imported successfully.', 'simply-static')))) : '')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Reset Plugin Data', 'simply-static'))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('By clicking the following button, you will reset all plugin settings. This can be useful if you want to import a new set of settings or you want a fresh start.', 'simply-static')), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: runResetSettings,
+    variant: "secondary"
+  }, __('Reset Plugin Settings', 'simply-static'))), isReset ? (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings resetted successfully.', 'simply-static')))) : '')));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (Utilities);
+
+/***/ }),
+
+/***/ "./src/settings/settings.scss":
+/*!************************************!*\
+  !*** ./src/settings/settings.scss ***!
+  \************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+// extracted by mini-css-extract-plugin
+
+
+/***/ }),
+
+/***/ "./node_modules/react-data-table-component/dist/index.cjs.js":
+/*!*******************************************************************!*\
+  !*** ./node_modules/react-data-table-component/dist/index.cjs.js ***!
+  \*******************************************************************/
+/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+
+"use strict";
+Object.defineProperty(exports, "__esModule", ({value:!0}));var e=__webpack_require__(/*! react */ "react"),t=__webpack_require__(/*! styled-components */ "./node_modules/styled-components/dist/styled-components.browser.esm.js");function n(e){return e&&"object"==typeof e&&"default"in e?e:{default:e}}function o(e){if(e&&e.__esModule)return e;var t=Object.create(null);return e&&Object.keys(e).forEach((function(n){if("default"!==n){var o=Object.getOwnPropertyDescriptor(e,n);Object.defineProperty(t,n,o.get?o:{enumerable:!0,get:function(){return e[n]}})}})),t.default=e,Object.freeze(t)}var a,l=o(e),r=n(e),i=n(t);function s(e,t){return e[t]}function d(e,t){return t.split(".").reduce(((e,t)=>{const n=t.match(/[^\]\\[.]+/g);if(n&&n.length>1)for(let t=0;t<n.length;t++)return e[n[t]][n[t+1]];return e[t]}),e)}function c(e=[],t,n=0){return[...e.slice(0,n),t,...e.slice(n)]}function g(e=[],t,n="id"){const o=e.slice(),a=s(t,n);return a?o.splice(o.findIndex((e=>s(e,n)===a)),1):o.splice(o.findIndex((e=>e===t)),1),o}function u(e){return e.map(((e,t)=>{const n=Object.assign(Object.assign({},e),{sortable:e.sortable||!!e.sortFunction||void 0});return e.id||(n.id=t+1),n}))}function p(e,t){return Math.ceil(e/t)}function b(e,t){return Math.min(e,t)}!function(e){e.ASC="asc",e.DESC="desc"}(a||(a={}));const m=()=>null;function f(e,t=[],n=[]){let o={},a=[...n];return t.length&&t.forEach((t=>{if(!t.when||"function"!=typeof t.when)throw new Error('"when" must be defined in the conditional style object and must be function');t.when(e)&&(o=t.style||{},t.classNames&&(a=[...a,...t.classNames]),"function"==typeof t.style&&(o=t.style(e)||{}))})),{style:o,classNames:a.join(" ")}}function h(e,t=[],n="id"){const o=s(e,n);return o?t.some((e=>s(e,n)===o)):t.some((t=>t===e))}function w(e,t){return t?e.findIndex((e=>x(e.id,t))):-1}function x(e,t){return e==t}function C(e,t){const n=!e.toggleOnSelectedRowsChange;switch(t.type){case"SELECT_ALL_ROWS":{const{keyField:n,rows:o,rowCount:a,mergeSelections:l}=t,r=!e.allSelected,i=!e.toggleOnSelectedRowsChange;if(l){const t=r?[...e.selectedRows,...o.filter((t=>!h(t,e.selectedRows,n)))]:e.selectedRows.filter((e=>!h(e,o,n)));return Object.assign(Object.assign({},e),{allSelected:r,selectedCount:t.length,selectedRows:t,toggleOnSelectedRowsChange:i})}return Object.assign(Object.assign({},e),{allSelected:r,selectedCount:r?a:0,selectedRows:r?o:[],toggleOnSelectedRowsChange:i})}case"SELECT_SINGLE_ROW":{const{keyField:o,row:a,isSelected:l,rowCount:r,singleSelect:i}=t;return i?l?Object.assign(Object.assign({},e),{selectedCount:0,allSelected:!1,selectedRows:[],toggleOnSelectedRowsChange:n}):Object.assign(Object.assign({},e),{selectedCount:1,allSelected:!1,selectedRows:[a],toggleOnSelectedRowsChange:n}):l?Object.assign(Object.assign({},e),{selectedCount:e.selectedRows.length>0?e.selectedRows.length-1:0,allSelected:!1,selectedRows:g(e.selectedRows,a,o),toggleOnSelectedRowsChange:n}):Object.assign(Object.assign({},e),{selectedCount:e.selectedRows.length+1,allSelected:e.selectedRows.length+1===r,selectedRows:c(e.selectedRows,a),toggleOnSelectedRowsChange:n})}case"SELECT_MULTIPLE_ROWS":{const{keyField:o,selectedRows:a,totalRows:l,mergeSelections:r}=t;if(r){const t=[...e.selectedRows,...a.filter((t=>!h(t,e.selectedRows,o)))];return Object.assign(Object.assign({},e),{selectedCount:t.length,allSelected:!1,selectedRows:t,toggleOnSelectedRowsChange:n})}return Object.assign(Object.assign({},e),{selectedCount:a.length,allSelected:a.length===l,selectedRows:a,toggleOnSelectedRowsChange:n})}case"CLEAR_SELECTED_ROWS":{const{selectedRowsFlag:n}=t;return Object.assign(Object.assign({},e),{allSelected:!1,selectedCount:0,selectedRows:[],selectedRowsFlag:n})}case"SORT_CHANGE":{const{sortDirection:o,selectedColumn:a,clearSelectedOnSort:l}=t;return Object.assign(Object.assign(Object.assign({},e),{selectedColumn:a,sortDirection:o,currentPage:1}),l&&{allSelected:!1,selectedCount:0,selectedRows:[],toggleOnSelectedRowsChange:n})}case"CHANGE_PAGE":{const{page:o,paginationServer:a,visibleOnly:l,persistSelectedOnPageChange:r}=t,i=a&&r,s=a&&!r||l;return Object.assign(Object.assign(Object.assign(Object.assign({},e),{currentPage:o}),i&&{allSelected:!1}),s&&{allSelected:!1,selectedCount:0,selectedRows:[],toggleOnSelectedRowsChange:n})}case"CHANGE_ROWS_PER_PAGE":{const{rowsPerPage:n,page:o}=t;return Object.assign(Object.assign({},e),{currentPage:o,rowsPerPage:n})}}}const y=t.css`
 	pointer-events: none;
 	opacity: 0.4;
-`,C=c.default.div`
+`,v=i.default.div`
 	position: relative;
 	box-sizing: border-box;
 	display: flex;
@@ -9,51 +2986,55 @@
 	width: 100%;
 	height: 100%;
 	max-width: 100%;
-	${({disabled:e})=>e&&_};
+	${({disabled:e})=>e&&y};
 	${({theme:e})=>e.table.style};
-`,S=l.css`
+`,R=t.css`
 	position: sticky;
 	position: -webkit-sticky; /* Safari */
 	top: 0;
 	z-index: 1;
-`,x=c.default.div`
+`,S=i.default.div`
 	display: flex;
 	width: 100%;
-	${({$fixedHeader:e})=>e&&S};
+	${({fixedHeader:e})=>e&&R};
 	${({theme:e})=>e.head.style};
-`,k=c.default.div`
+`,E=i.default.div`
 	display: flex;
 	align-items: stretch;
 	width: 100%;
 	${({theme:e})=>e.headRow.style};
-	${({$dense:e,theme:t})=>e&&t.headRow.denseStyle};
-`,R=(e,...t)=>l.css`
+	${({dense:e,theme:t})=>e&&t.headRow.denseStyle};
+`,O=(e,...n)=>t.css`
 		@media screen and (max-width: ${599}px) {
-			${l.css(e,...t)}
+			${t.css(e,...n)}
 		}
-	`,P=(e,...t)=>l.css`
+	`,P=(e,...n)=>t.css`
 		@media screen and (max-width: ${959}px) {
-			${l.css(e,...t)}
+			${t.css(e,...n)}
 		}
-	`,O=(e,...t)=>l.css`
+	`,k=(e,...n)=>t.css`
 		@media screen and (max-width: ${1280}px) {
-			${l.css(e,...t)}
+			${t.css(e,...n)}
 		}
-	`,T=c.default.div`
+	`,D=e=>(n,...o)=>t.css`
+				@media screen and (max-width: ${e}px) {
+					${t.css(n,...o)}
+				}
+			`,H=i.default.div`
 	position: relative;
 	display: flex;
 	align-items: center;
 	box-sizing: border-box;
 	line-height: normal;
-	${({theme:e,$headCell:t})=>e[t?"headCells":"cells"].style};
-	${({$noPadding:e})=>e&&"padding: 0"};
-`,D=c.default(T)`
+	${({theme:e,headCell:t})=>e[t?"headCells":"cells"].style};
+	${({noPadding:e})=>e&&"padding: 0"};
+`,$=i.default(H)`
 	flex-grow: ${({button:e,grow:t})=>0===t||e?0:t||1};
 	flex-shrink: 0;
 	flex-basis: 0;
 	max-width: ${({maxWidth:e})=>e||"100%"};
 	min-width: ${({minWidth:e})=>e||"100px"};
-	${({width:e})=>e&&l.css`
+	${({width:e})=>e&&t.css`
 			min-width: ${e};
 			max-width: ${e};
 		`};
@@ -62,40 +3043,36 @@
 	${({compact:e,button:t})=>(e||t)&&"padding: 0"};
 
 	/* handle hiding cells */
-	${({hide:e})=>e&&"sm"===e&&R`
+	${({hide:e})=>e&&"sm"===e&&O`
     display: none;
   `};
 	${({hide:e})=>e&&"md"===e&&P`
     display: none;
   `};
-	${({hide:e})=>e&&"lg"===e&&O`
+	${({hide:e})=>e&&"lg"===e&&k`
     display: none;
   `};
-	${({hide:e})=>e&&Number.isInteger(e)&&(e=>(t,...n)=>l.css`
-			@media screen and (max-width: ${e}px) {
-				${l.css(t,...n)}
-			}
-		`)(e)`
+	${({hide:e})=>e&&Number.isInteger(e)&&D(e)`
     display: none;
   `};
-`,N=l.css`
+`,j=t.css`
 	div:first-child {
-		white-space: ${({$wrapCell:e})=>e?"normal":"nowrap"};
-		overflow: ${({$allowOverflow:e})=>e?"visible":"hidden"};
+		white-space: ${({wrapCell:e})=>e?"normal":"nowrap"};
+		overflow: ${({allowOverflow:e})=>e?"visible":"hidden"};
 		text-overflow: ellipsis;
 	}
-`,A=c.default(D).attrs((e=>({style:e.style})))`
-	${({$renderAsCell:e})=>!e&&N};
-	${({theme:e,$isDragging:t})=>t&&e.cells.draggingStyle};
-	${({$cellStyle:e})=>e};
-`;var I=o.memo((function({id:e,column:t,row:n,rowIndex:a,dataTag:l,isDragging:i,onDragStart:r,onDragOver:s,onDragEnd:c,onDragEnter:u,onDragLeave:d}){const{conditionalStyle:p,classNames:m}=f(n,t.conditionalCellStyles,["rdt_TableCell"]);return o.createElement(A,{id:e,"data-column-id":t.id,role:"cell",className:m,"data-tag":l,$cellStyle:t.style,$renderAsCell:!!t.cell,$allowOverflow:t.allowOverflow,button:t.button,center:t.center,compact:t.compact,grow:t.grow,hide:t.hide,maxWidth:t.maxWidth,minWidth:t.minWidth,right:t.right,width:t.width,$wrapCell:t.wrap,style:p,$isDragging:i,onDragStart:r,onDragOver:s,onDragEnd:c,onDragEnter:u,onDragLeave:d},!t.cell&&o.createElement("div",{"data-tag":l},function(e,t,n,a){return t?n&&"function"==typeof n?n(e,a):t(e,a):null}(n,t.selector,t.format,a)),t.cell&&t.cell(n,a,t,e))}));const $="input";var F=o.memo((function({name:e,component:t=$,componentOptions:n={style:{}},indeterminate:a=!1,checked:l=!1,disabled:i=!1,onClick:r=y}){const s=t,c=s!==$?n.style:(e=>Object.assign(Object.assign({fontSize:"18px"},!e&&{cursor:"pointer"}),{padding:0,marginTop:"1px",verticalAlign:"middle",position:"relative"}))(i),u=o.useMemo((()=>function(e,...t){let n;return Object.keys(e).map((t=>e[t])).forEach(((a,l)=>{const i=e;"function"==typeof a&&(n=Object.assign(Object.assign({},i),{[Object.keys(e)[l]]:a(...t)}))})),n||e}(n,a)),[n,a]);return o.createElement(s,Object.assign({type:"checkbox",ref:e=>{e&&(e.indeterminate=a)},style:c,onClick:i?y:r,name:e,"aria-label":e,checked:l,disabled:i},u,{onChange:y}))}));const H=c.default(T)`
+`,F=i.default($).attrs((e=>({style:e.style})))`
+	${({renderAsCell:e})=>!e&&j};
+	${({theme:e,isDragging:t})=>t&&e.cells.draggingStyle};
+	${({cellStyle:e})=>e};
+`;var T=l.memo((function({id:e,column:t,row:n,rowIndex:o,dataTag:a,isDragging:r,onDragStart:i,onDragOver:s,onDragEnd:c,onDragEnter:g,onDragLeave:u}){const{style:p,classNames:b}=f(n,t.conditionalCellStyles,["rdt_TableCell"]);return l.createElement(F,{id:e,"data-column-id":t.id,role:"cell",className:b,"data-tag":a,cellStyle:t.style,renderAsCell:!!t.cell,allowOverflow:t.allowOverflow,button:t.button,center:t.center,compact:t.compact,grow:t.grow,hide:t.hide,maxWidth:t.maxWidth,minWidth:t.minWidth,right:t.right,width:t.width,wrapCell:t.wrap,style:p,isDragging:r,onDragStart:i,onDragOver:s,onDragEnd:c,onDragEnter:g,onDragLeave:u},!t.cell&&l.createElement("div",{"data-tag":a},function(e,t,n,o){if(!t)return null;if("string"!=typeof t&&"function"!=typeof t)throw new Error("selector must be a . delimited string eg (my.property) or function (e.g. row => row.field");return n&&"function"==typeof n?n(e,o):t&&"function"==typeof t?t(e,o):d(e,t)}(n,t.selector,t.format,o)),t.cell&&t.cell(n,o,t,e))}));var I=l.memo((function({name:e,component:t="input",componentOptions:n={style:{}},indeterminate:o=!1,checked:a=!1,disabled:r=!1,onClick:i=m}){const s=t,d="input"!==s?n.style:(e=>Object.assign(Object.assign({fontSize:"18px"},!e&&{cursor:"pointer"}),{padding:0,marginTop:"1px",verticalAlign:"middle",position:"relative"}))(r),c=l.useMemo((()=>function(e,...t){let n;return Object.keys(e).map((t=>e[t])).forEach(((o,a)=>{const l=e;"function"==typeof o&&(n=Object.assign(Object.assign({},l),{[Object.keys(e)[a]]:o(...t)}))})),n||e}(n,o)),[n,o]);return l.createElement(s,Object.assign({type:"checkbox",ref:e=>{e&&(e.indeterminate=o)},style:d,onClick:r?m:i,name:e,"aria-label":e,checked:a,disabled:r},c,{onChange:m}))}));const M=i.default(H)`
 	flex: 0 0 48px;
 	min-width: 48px;
 	justify-content: center;
 	align-items: center;
 	user-select: none;
 	white-space: nowrap;
-`;function B({name:e,keyField:t,row:n,rowCount:a,selected:l,selectableRowsComponent:i,selectableRowsComponentProps:r,selectableRowsSingle:s,selectableRowDisabled:c,onSelectedRow:u}){const d=!(!c||!c(n));return o.createElement(H,{onClick:e=>e.stopPropagation(),className:"rdt_TableCell",$noPadding:!0},o.createElement(F,{name:e,component:i,componentOptions:r,checked:l,"aria-checked":l,onClick:()=>{u({type:"SELECT_SINGLE_ROW",row:n,isSelected:l,keyField:t,rowCount:a,singleSelect:s})},disabled:d}))}const L=c.default.button`
+`;function A({name:e,keyField:t,row:n,rowCount:o,selected:a,selectableRowsComponent:r,selectableRowsComponentProps:i,selectableRowsSingle:s,selectableRowDisabled:d,onSelectedRow:c}){const g=!(!d||!d(n));return l.createElement(M,{onClick:e=>e.stopPropagation(),className:"rdt_TableCell",noPadding:!0},l.createElement(I,{name:e,component:r,componentOptions:i,checked:a,"aria-checked":a,onClick:()=>{c({type:"SELECT_SINGLE_ROW",row:n,isSelected:a,keyField:t,rowCount:o,singleSelect:s})},disabled:g}))}const L=i.default.button`
 	display: inline-flex;
 	align-items: center;
 	user-select: none;
@@ -103,54 +3080,53 @@
 	border: none;
 	background-color: transparent;
 	${({theme:e})=>e.expanderButton.style};
-`;function j({disabled:e=!1,expanded:t=!1,expandableIcon:n,id:a,row:l,onToggled:i}){const r=t?n.expanded:n.collapsed;return o.createElement(L,{"aria-disabled":e,onClick:()=>i&&i(l),"data-testid":`expander-button-${a}`,disabled:e,"aria-label":t?"Collapse Row":"Expand Row",role:"button",type:"button"},r)}const M=c.default(T)`
+`;function _({disabled:e=!1,expanded:t=!1,expandableIcon:n,id:o,row:a,onToggled:r}){const i=t?n.expanded:n.collapsed;return l.createElement(L,{"aria-disabled":e,onClick:()=>r&&r(a),"data-testid":`expander-button-${o}`,disabled:e,"aria-label":t?"Collapse Row":"Expand Row",role:"button",type:"button"},i)}const z=i.default(H)`
 	white-space: nowrap;
 	font-weight: 400;
 	min-width: 48px;
 	${({theme:e})=>e.expanderCell.style};
-`;function z({row:e,expanded:t=!1,expandableIcon:n,id:a,onToggled:l,disabled:i=!1}){return o.createElement(M,{onClick:e=>e.stopPropagation(),$noPadding:!0},o.createElement(j,{id:a,row:e,expanded:t,expandableIcon:n,disabled:i,onToggled:l}))}const W=c.default.div`
+`;function N({row:e,expanded:t=!1,expandableIcon:n,id:o,onToggled:a,disabled:r=!1}){return l.createElement(z,{onClick:e=>e.stopPropagation(),noPadding:!0},l.createElement(_,{id:o,row:e,expanded:t,expandableIcon:n,disabled:r,onToggled:a}))}const W=i.default.div`
 	width: 100%;
 	box-sizing: border-box;
 	${({theme:e})=>e.expanderRow.style};
-	${({$extendedRowStyle:e})=>e};
-`;var U=o.memo((function({data:e,ExpanderComponent:t,expanderComponentProps:n,extendedRowStyle:a,extendedClassNames:l}){const i=["rdt_ExpanderRow",...l.split(" ").filter((e=>"rdt_TableRow"!==e))].join(" ");return o.createElement(W,{className:i,$extendedRowStyle:a},o.createElement(t,Object.assign({data:e},n)))}));const G="allowRowEvents";var Y,V,K;t.Nm=void 0,(Y=t.Nm||(t.Nm={})).LTR="ltr",Y.RTL="rtl",Y.AUTO="auto",t.v2=void 0,(V=t.v2||(t.v2={})).LEFT="left",V.RIGHT="right",V.CENTER="center",t.pU=void 0,(K=t.pU||(t.pU={})).SM="sm",K.MD="md",K.LG="lg";const J=l.css`
+	${({extendedRowStyle:e})=>e};
+`;var B=l.memo((function({data:e,ExpanderComponent:t,expanderComponentProps:n,extendedRowStyle:o,extendedClassNames:a}){const r=["rdt_ExpanderRow",...a.split(" ").filter((e=>"rdt_TableRow"!==e))].join(" ");return l.createElement(W,{className:r,extendedRowStyle:o},l.createElement(t,Object.assign({data:e},n)))}));var G,V,U;exports.Direction=void 0,(G=exports.Direction||(exports.Direction={})).LTR="ltr",G.RTL="rtl",G.AUTO="auto",exports.Alignment=void 0,(V=exports.Alignment||(exports.Alignment={})).LEFT="left",V.RIGHT="right",V.CENTER="center",exports.Media=void 0,(U=exports.Media||(exports.Media={})).SM="sm",U.MD="md",U.LG="lg";const q=t.css`
 	&:hover {
-		${({$highlightOnHover:e,theme:t})=>e&&t.rows.highlightOnHoverStyle};
+		${({highlightOnHover:e,theme:t})=>e&&t.rows.highlightOnHoverStyle};
 	}
-`,Z=l.css`
+`,Y=t.css`
 	&:hover {
 		cursor: pointer;
 	}
-`,q=c.default.div.attrs((e=>({style:e.style})))`
+`,K=i.default.div.attrs((e=>({style:e.style})))`
 	display: flex;
 	align-items: stretch;
 	align-content: stretch;
 	width: 100%;
 	box-sizing: border-box;
 	${({theme:e})=>e.rows.style};
-	${({$dense:e,theme:t})=>e&&t.rows.denseStyle};
-	${({$striped:e,theme:t})=>e&&t.rows.stripedStyle};
-	${({$highlightOnHover:e})=>e&&J};
-	${({$pointerOnHover:e})=>e&&Z};
-	${({$selected:e,theme:t})=>e&&t.rows.selectedHighlightStyle};
-	${({$conditionalStyle:e})=>e};
-`;function X({columns:e=[],conditionalRowStyles:t=[],defaultExpanded:n=!1,defaultExpanderDisabled:a=!1,dense:l=!1,expandableIcon:i,expandableRows:r=!1,expandableRowsComponent:s,expandableRowsComponentProps:c,expandableRowsHideExpander:d,expandOnRowClicked:p=!1,expandOnRowDoubleClicked:m=!1,highlightOnHover:g=!1,id:h,expandableInheritConditionalStyles:b,keyField:v,onRowClicked:w=y,onRowDoubleClicked:_=y,onRowMouseEnter:C=y,onRowMouseLeave:S=y,onRowExpandToggled:x=y,onSelectedRow:k=y,pointerOnHover:R=!1,row:P,rowCount:O,rowIndex:T,selectableRowDisabled:D=null,selectableRows:N=!1,selectableRowsComponent:A,selectableRowsComponentProps:$,selectableRowsHighlight:F=!1,selectableRowsSingle:H=!1,selected:L,striped:j=!1,draggingColumnId:M,onDragStart:W,onDragOver:Y,onDragEnd:V,onDragEnter:K,onDragLeave:J}){const[Z,X]=o.useState(n);o.useEffect((()=>{X(n)}),[n]);const Q=o.useCallback((()=>{X(!Z),x(!Z,P)}),[Z,x,P]),ee=R||r&&(p||m),te=o.useCallback((e=>{e.target.getAttribute("data-tag")===G&&(w(P,e),!a&&r&&p&&Q())}),[a,p,r,Q,w,P]),ne=o.useCallback((e=>{e.target.getAttribute("data-tag")===G&&(_(P,e),!a&&r&&m&&Q())}),[a,m,r,Q,_,P]),ae=o.useCallback((e=>{C(P,e)}),[C,P]),le=o.useCallback((e=>{S(P,e)}),[S,P]),ie=u(P,v),{conditionalStyle:re,classNames:oe}=f(P,t,["rdt_TableRow"]),se=F&&L,ce=b?re:{},ue=j&&T%2==0;return o.createElement(o.Fragment,null,o.createElement(q,{id:`row-${h}`,role:"row",$striped:ue,$highlightOnHover:g,$pointerOnHover:!a&&ee,$dense:l,onClick:te,onDoubleClick:ne,onMouseEnter:ae,onMouseLeave:le,className:oe,$selected:se,$conditionalStyle:re},N&&o.createElement(B,{name:`select-row-${ie}`,keyField:v,row:P,rowCount:O,selected:L,selectableRowsComponent:A,selectableRowsComponentProps:$,selectableRowDisabled:D,selectableRowsSingle:H,onSelectedRow:k}),r&&!d&&o.createElement(z,{id:ie,expandableIcon:i,expanded:Z,row:P,onToggled:Q,disabled:a}),e.map((e=>e.omit?null:o.createElement(I,{id:`cell-${e.id}-${ie}`,key:`cell-${e.id}-${ie}`,dataTag:e.ignoreRowClick||e.button?null:G,column:e,row:P,rowIndex:T,isDragging:E(M,e.id),onDragStart:W,onDragOver:Y,onDragEnd:V,onDragEnter:K,onDragLeave:J})))),r&&Z&&o.createElement(U,{key:`expander-${ie}`,data:P,extendedRowStyle:ce,extendedClassNames:oe,ExpanderComponent:s,expanderComponentProps:c}))}const Q=c.default.span`
+	${({dense:e,theme:t})=>e&&t.rows.denseStyle};
+	${({striped:e,theme:t})=>e&&t.rows.stripedStyle};
+	${({highlightOnHover:e})=>e&&q};
+	${({pointerOnHover:e})=>e&&Y};
+	${({selected:e,theme:t})=>e&&t.rows.selectedHighlightStyle};
+`;function J({columns:e=[],conditionalRowStyles:t=[],defaultExpanded:n=!1,defaultExpanderDisabled:o=!1,dense:a=!1,expandableIcon:r,expandableRows:i=!1,expandableRowsComponent:d,expandableRowsComponentProps:c,expandableRowsHideExpander:g,expandOnRowClicked:u=!1,expandOnRowDoubleClicked:p=!1,highlightOnHover:b=!1,id:h,expandableInheritConditionalStyles:w,keyField:C,onRowClicked:y=m,onRowDoubleClicked:v=m,onRowMouseEnter:R=m,onRowMouseLeave:S=m,onRowExpandToggled:E=m,onSelectedRow:O=m,pointerOnHover:P=!1,row:k,rowCount:D,rowIndex:H,selectableRowDisabled:$=null,selectableRows:j=!1,selectableRowsComponent:F,selectableRowsComponentProps:I,selectableRowsHighlight:M=!1,selectableRowsSingle:L=!1,selected:_,striped:z=!1,draggingColumnId:W,onDragStart:G,onDragOver:V,onDragEnd:U,onDragEnter:q,onDragLeave:Y}){const[J,Q]=l.useState(n);l.useEffect((()=>{Q(n)}),[n]);const X=l.useCallback((()=>{Q(!J),E(!J,k)}),[J,E,k]),Z=P||i&&(u||p),ee=l.useCallback((e=>{e.target&&"allowRowEvents"===e.target.getAttribute("data-tag")&&(y(k,e),!o&&i&&u&&X())}),[o,u,i,X,y,k]),te=l.useCallback((e=>{e.target&&"allowRowEvents"===e.target.getAttribute("data-tag")&&(v(k,e),!o&&i&&p&&X())}),[o,p,i,X,v,k]),ne=l.useCallback((e=>{R(k,e)}),[R,k]),oe=l.useCallback((e=>{S(k,e)}),[S,k]),ae=s(k,C),{style:le,classNames:re}=f(k,t,["rdt_TableRow"]),ie=M&&_,se=w?le:{},de=z&&H%2==0;return l.createElement(l.Fragment,null,l.createElement(K,{id:`row-${h}`,role:"row",striped:de,highlightOnHover:b,pointerOnHover:!o&&Z,dense:a,onClick:ee,onDoubleClick:te,onMouseEnter:ne,onMouseLeave:oe,className:re,selected:ie,style:le},j&&l.createElement(A,{name:`select-row-${ae}`,keyField:C,row:k,rowCount:D,selected:_,selectableRowsComponent:F,selectableRowsComponentProps:I,selectableRowDisabled:$,selectableRowsSingle:L,onSelectedRow:O}),i&&!g&&l.createElement(N,{id:ae,expandableIcon:r,expanded:J,row:k,onToggled:X,disabled:o}),e.map((e=>e.omit?null:l.createElement(T,{id:`cell-${e.id}-${ae}`,key:`cell-${e.id}-${ae}`,dataTag:e.ignoreRowClick||e.button?null:"allowRowEvents",column:e,row:k,rowIndex:H,isDragging:x(W,e.id),onDragStart:G,onDragOver:V,onDragEnd:U,onDragEnter:q,onDragLeave:Y})))),i&&J&&l.createElement(B,{key:`expander-${ae}`,data:k,extendedRowStyle:se,extendedClassNames:re,ExpanderComponent:d,expanderComponentProps:c}))}const Q=i.default.span`
 	padding: 2px;
 	color: inherit;
 	flex-grow: 0;
 	flex-shrink: 0;
-	${({$sortActive:e})=>e?"opacity: 1":"opacity: 0"};
-	${({$sortDirection:e})=>"desc"===e&&"transform: rotate(180deg)"};
-`,ee=({sortActive:e,sortDirection:t})=>s.default.createElement(Q,{$sortActive:e,$sortDirection:t},"▲"),te=c.default(D)`
+	${({sortActive:e})=>e?"opacity: 1":"opacity: 0"};
+	${({sortDirection:e})=>"desc"===e&&"transform: rotate(180deg)"};
+`,X=({sortActive:e,sortDirection:t})=>r.default.createElement(Q,{sortActive:e,sortDirection:t},"▲"),Z=i.default($)`
 	${({button:e})=>e&&"text-align: center"};
-	${({theme:e,$isDragging:t})=>t&&e.headCells.draggingStyle};
-`,ne=l.css`
+	${({theme:e,isDragging:t})=>t&&e.headCells.draggingStyle};
+`,ee=t.css`
 	cursor: pointer;
 	span.__rdt_custom_sort_icon__ {
 		i,
 		svg {
 			transform: 'translate3d(0, 0, 0)';
-			${({$sortActive:e})=>e?"opacity: 1":"opacity: 0"};
+			${({sortActive:e})=>e?"opacity: 1":"opacity: 0"};
 			color: inherit;
 			font-size: 18px;
 			height: 18px;
@@ -167,7 +3143,7 @@
 		}
 	}
 
-	${({$sortActive:e})=>!e&&l.css`
+	${({sortActive:e})=>!e&&t.css`
 			&:hover,
 			&:focus {
 				opacity: 0.7;
@@ -178,7 +3154,7 @@
 				}
 			}
 		`};
-`,ae=c.default.div`
+`,te=i.default.div`
 	display: inline-flex;
 	align-items: center;
 	justify-content: inherit;
@@ -187,19 +3163,19 @@
 	outline: none;
 	user-select: none;
 	overflow: hidden;
-	${({disabled:e})=>!e&&ne};
-`,le=c.default.div`
+	${({disabled:e})=>!e&&ee};
+`,ne=i.default.div`
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
-`;var ie=o.memo((function({column:e,disabled:t,draggingColumnId:n,selectedColumn:a={},sortDirection:l,sortIcon:i,sortServer:s,pagination:c,paginationServer:u,persistSelectedOnSort:d,selectableRowsVisibleOnly:p,onSort:m,onDragStart:g,onDragOver:h,onDragEnd:y,onDragEnter:f,onDragLeave:b}){o.useEffect((()=>{"string"==typeof e.selector&&console.error(`Warning: ${e.selector} is a string based column selector which has been deprecated as of v7 and will be removed in v8. Instead, use a selector function e.g. row => row[field]...`)}),[]);const[v,w]=o.useState(!1),_=o.useRef(null);if(o.useEffect((()=>{_.current&&w(_.current.scrollWidth>_.current.clientWidth)}),[v]),e.omit)return null;const C=()=>{if(!e.sortable&&!e.selector)return;let t=l;E(a.id,e.id)&&(t=l===r.ASC?r.DESC:r.ASC),m({type:"SORT_CHANGE",sortDirection:t,selectedColumn:e,clearSelectedOnSort:c&&u&&!d||s||p})},S=e=>o.createElement(ee,{sortActive:e,sortDirection:l}),x=()=>o.createElement("span",{className:[l,"__rdt_custom_sort_icon__"].join(" ")},i),k=!(!e.sortable||!E(a.id,e.id)),R=!e.sortable||t,P=e.sortable&&!i&&!e.right,O=e.sortable&&!i&&e.right,T=e.sortable&&i&&!e.right,D=e.sortable&&i&&e.right;return o.createElement(te,{"data-column-id":e.id,className:"rdt_TableCol",$headCell:!0,allowOverflow:e.allowOverflow,button:e.button,compact:e.compact,grow:e.grow,hide:e.hide,maxWidth:e.maxWidth,minWidth:e.minWidth,right:e.right,center:e.center,width:e.width,draggable:e.reorder,$isDragging:E(e.id,n),onDragStart:g,onDragOver:h,onDragEnd:y,onDragEnter:f,onDragLeave:b},e.name&&o.createElement(ae,{"data-column-id":e.id,"data-sort-id":e.id,role:"columnheader",tabIndex:0,className:"rdt_TableCol_Sortable",onClick:R?void 0:C,onKeyPress:R?void 0:e=>{"Enter"===e.key&&C()},$sortActive:!R&&k,disabled:R},!R&&D&&x(),!R&&O&&S(k),"string"==typeof e.name?o.createElement(le,{title:v?e.name:void 0,ref:_,"data-column-id":e.id},e.name):e.name,!R&&T&&x(),!R&&P&&S(k)))}));const re=c.default(T)`
+`;var oe=l.memo((function({column:e,disabled:t,draggingColumnId:n,selectedColumn:o={},sortDirection:r,sortIcon:i,sortServer:s,pagination:d,paginationServer:c,persistSelectedOnSort:g,selectableRowsVisibleOnly:u,onSort:p,onDragStart:b,onDragOver:m,onDragEnd:f,onDragEnter:h,onDragLeave:w}){l.useEffect((()=>{"string"==typeof e.selector&&console.error(`Warning: ${e.selector} is a string based column selector which has been deprecated as of v7 and will be removed in v8. Instead, use a selector function e.g. row => row[field]...`)}),[]);const[C,y]=l.useState(!1),v=l.useRef(null);if(l.useEffect((()=>{v.current&&y(v.current.scrollWidth>v.current.clientWidth)}),[C]),e.omit)return null;const R=()=>{if(!e.sortable&&!e.selector)return;let t=r;x(o.id,e.id)&&(t=r===a.ASC?a.DESC:a.ASC),p({type:"SORT_CHANGE",sortDirection:t,selectedColumn:e,clearSelectedOnSort:d&&c&&!g||s||u})},S=e=>l.createElement(X,{sortActive:e,sortDirection:r}),E=()=>l.createElement("span",{className:[r,"__rdt_custom_sort_icon__"].join(" ")},i),O=!(!e.sortable||!x(o.id,e.id)),P=!e.sortable||t,k=e.sortable&&!i&&!e.right,D=e.sortable&&!i&&e.right,H=e.sortable&&i&&!e.right,$=e.sortable&&i&&e.right;return l.createElement(Z,{"data-column-id":e.id,className:"rdt_TableCol",headCell:!0,allowOverflow:e.allowOverflow,button:e.button,compact:e.compact,grow:e.grow,hide:e.hide,maxWidth:e.maxWidth,minWidth:e.minWidth,right:e.right,center:e.center,width:e.width,draggable:e.reorder,isDragging:x(e.id,n),onDragStart:b,onDragOver:m,onDragEnd:f,onDragEnter:h,onDragLeave:w},e.name&&l.createElement(te,{"data-column-id":e.id,"data-sort-id":e.id,role:"columnheader",tabIndex:0,className:"rdt_TableCol_Sortable",onClick:P?void 0:R,onKeyPress:P?void 0:e=>{"Enter"===e.key&&R()},sortActive:!P&&O,disabled:P},!P&&$&&E(),!P&&D&&S(O),"string"==typeof e.name?l.createElement(ne,{title:C?e.name:void 0,ref:v,"data-column-id":e.id},e.name):e.name,!P&&H&&E(),!P&&k&&S(O)))}));const ae=i.default(H)`
 	flex: 0 0 48px;
 	justify-content: center;
 	align-items: center;
 	user-select: none;
 	white-space: nowrap;
 	font-size: unset;
-`;function oe({headCell:e=!0,rowData:t,keyField:n,allSelected:a,mergeSelections:l,selectedRows:i,selectableRowsComponent:r,selectableRowsComponentProps:s,selectableRowDisabled:c,onSelectAllRows:u}){const d=i.length>0&&!a,p=c?t.filter((e=>!c(e))):t,m=0===p.length,g=Math.min(t.length,p.length);return o.createElement(re,{className:"rdt_TableCol",$headCell:e,$noPadding:!0},o.createElement(F,{name:"select-all-rows",component:r,componentOptions:s,onClick:()=>{u({type:"SELECT_ALL_ROWS",rows:p,rowCount:g,mergeSelections:l,keyField:n})},checked:a,indeterminate:d,disabled:m}))}function se(e=t.Nm.AUTO){const n="object"==typeof window,[a,l]=o.useState(!1);return o.useEffect((()=>{if(n)if("auto"!==e)l("rtl"===e);else{const e=!(!window.document||!window.document.createElement),t=document.getElementsByTagName("BODY")[0],n=document.getElementsByTagName("HTML")[0],a="rtl"===t.dir||"rtl"===n.dir;l(e&&a)}}),[e,n]),a}const ce=c.default.div`
+`;function le({headCell:e=!0,rowData:t,keyField:n,allSelected:o,mergeSelections:a,selectedRows:r,selectableRowsComponent:i,selectableRowsComponentProps:s,selectableRowDisabled:d,onSelectAllRows:c}){const g=r.length>0&&!o,u=d?t.filter((e=>!d(e))):t,p=0===u.length,b=Math.min(t.length,u.length);return l.createElement(ae,{className:"rdt_TableCol",headCell:e,noPadding:!0},l.createElement(I,{name:"select-all-rows",component:i,componentOptions:s,onClick:()=>{c({type:"SELECT_ALL_ROWS",rows:u,rowCount:b,mergeSelections:a,keyField:n})},checked:o,indeterminate:g,disabled:p}))}function re(e=exports.Direction.AUTO){const t="object"==typeof window,[n,o]=l.useState(!1);return l.useEffect((()=>{if(t)if("auto"!==e)o("rtl"===e);else{const e=!(!window.document||!window.document.createElement),t=document.getElementsByTagName("BODY")[0],n=document.getElementsByTagName("HTML")[0],a="rtl"===t.dir||"rtl"===n.dir;o(e&&a)}}),[e,t]),n}const ie=i.default.div`
 	display: flex;
 	align-items: center;
 	flex: 1 0 auto;
@@ -207,12 +3183,12 @@
 	color: ${({theme:e})=>e.contextMenu.fontColor};
 	font-size: ${({theme:e})=>e.contextMenu.fontSize};
 	font-weight: 400;
-`,ue=c.default.div`
+`,se=i.default.div`
 	display: flex;
 	align-items: center;
 	justify-content: flex-end;
 	flex-wrap: wrap;
-`,de=c.default.div`
+`,de=i.default.div`
 	position: absolute;
 	top: 0;
 	left: 0;
@@ -223,10 +3199,10 @@
 	align-items: center;
 	justify-content: space-between;
 	display: flex;
-	${({$rtl:e})=>e&&"direction: rtl"};
+	${({rtl:e})=>e&&"direction: rtl"};
 	${({theme:e})=>e.contextMenu.style};
-	${({theme:e,$visible:t})=>t&&e.contextMenu.activeStyle};
-`;function pe({contextMessage:e,contextActions:t,contextComponent:n,selectedCount:a,direction:l}){const i=se(l),r=a>0;return n?o.createElement(de,{$visible:r},o.cloneElement(n,{selectedCount:a})):o.createElement(de,{$visible:r,$rtl:i},o.createElement(ce,null,((e,t,n)=>{if(0===t)return null;const a=1===t?e.singular:e.plural;return n?`${t} ${e.message||""} ${a}`:`${t} ${a} ${e.message||""}`})(e,a,i)),o.createElement(ue,null,t))}const me=c.default.div`
+	${({theme:e,visible:t})=>t&&e.contextMenu.activeStyle};
+`;function ce({contextMessage:e,contextActions:t,contextComponent:n,selectedCount:o,direction:a}){const r=re(a),i=o>0;return n?l.createElement(de,{visible:i},l.cloneElement(n,{selectedCount:o})):l.createElement(de,{visible:i,rtl:r},l.createElement(ie,null,((e,t,n)=>{if(0===t)return null;const o=1===t?e.singular:e.plural;return n?`${t} ${e.message||""} ${o}`:`${t} ${o} ${e.message||""}`})(e,o,r)),l.createElement(se,null,t))}const ge=i.default.div`
 	position: relative;
 	box-sizing: border-box;
 	overflow: hidden;
@@ -237,12 +3213,12 @@
 	width: 100%;
 	flex-wrap: wrap;
 	${({theme:e})=>e.header.style}
-`,ge=c.default.div`
+`,ue=i.default.div`
 	flex: 1 0 auto;
 	color: ${({theme:e})=>e.header.fontColor};
 	font-size: ${({theme:e})=>e.header.fontSize};
 	font-weight: 400;
-`,he=c.default.div`
+`,pe=i.default.div`
 	flex: 1 0 auto;
 	display: flex;
 	align-items: center;
@@ -251,7 +3227,21 @@
 	> * {
 		margin-left: 5px;
 	}
-`,ye=({title:e,actions:t=null,contextMessage:n,contextActions:a,contextComponent:l,selectedCount:i,direction:r,showMenu:s=!0})=>o.createElement(me,{className:"rdt_TableHeader",role:"heading","aria-level":1},o.createElement(ge,null,e),t&&o.createElement(he,null,t),s&&o.createElement(pe,{contextMessage:n,contextActions:a,contextComponent:l,direction:r,selectedCount:i}));function fe(e,t){var n={};for(var a in e)Object.prototype.hasOwnProperty.call(e,a)&&t.indexOf(a)<0&&(n[a]=e[a]);if(null!=e&&"function"==typeof Object.getOwnPropertySymbols){var l=0;for(a=Object.getOwnPropertySymbols(e);l<a.length;l++)t.indexOf(a[l])<0&&Object.prototype.propertyIsEnumerable.call(e,a[l])&&(n[a[l]]=e[a[l]])}return n}"function"==typeof SuppressedError&&SuppressedError;const be={left:"flex-start",right:"flex-end",center:"center"},ve=c.default.header`
+`,be=({title:e,actions:t=null,contextMessage:n,contextActions:o,contextComponent:a,selectedCount:r,direction:i,showMenu:s=!0})=>l.createElement(ge,{className:"rdt_TableHeader",role:"heading","aria-level":1},l.createElement(ue,null,e),t&&l.createElement(pe,null,t),s&&l.createElement(ce,{contextMessage:n,contextActions:o,contextComponent:a,direction:i,selectedCount:r}))
+/*! *****************************************************************************
+Copyright (c) Microsoft Corporation.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+***************************************************************************** */;function me(e,t){var n={};for(var o in e)Object.prototype.hasOwnProperty.call(e,o)&&t.indexOf(o)<0&&(n[o]=e[o]);if(null!=e&&"function"==typeof Object.getOwnPropertySymbols){var a=0;for(o=Object.getOwnPropertySymbols(e);a<o.length;a++)t.indexOf(o[a])<0&&Object.prototype.propertyIsEnumerable.call(e,o[a])&&(n[o[a]]=e[o[a]])}return n}const fe={left:"flex-start",right:"flex-end",center:"center"},he=i.default.header`
 	position: relative;
 	display: flex;
 	flex: 1 1 auto;
@@ -259,49 +3249,49 @@
 	align-items: center;
 	padding: 4px 16px 4px 24px;
 	width: 100%;
-	justify-content: ${({align:e})=>be[e]};
-	flex-wrap: ${({$wrapContent:e})=>e?"wrap":"nowrap"};
+	justify-content: ${({align:e})=>fe[e]};
+	flex-wrap: ${({wrapContent:e})=>e?"wrap":"nowrap"};
 	${({theme:e})=>e.subHeader.style}
-`,Ee=e=>{var{align:t="right",wrapContent:n=!0}=e,a=fe(e,["align","wrapContent"]);return o.createElement(ve,Object.assign({align:t,$wrapContent:n},a))},we=c.default.div`
+`,we=e=>{var{align:t="right",wrapContent:n=!0}=e,o=me(e,["align","wrapContent"]);return l.createElement(he,Object.assign({align:t,wrapContent:n},o))},xe=i.default.div`
 	display: flex;
 	flex-direction: column;
-`,_e=c.default.div`
+`,Ce=i.default.div`
 	position: relative;
 	width: 100%;
 	border-radius: inherit;
-	${({$responsive:e,$fixedHeader:t})=>e&&l.css`
+	${({responsive:e,fixedHeader:n})=>e&&t.css`
 			overflow-x: auto;
 
 			// hidden prevents vertical scrolling in firefox when fixedHeader is disabled
-			overflow-y: ${t?"auto":"hidden"};
+			overflow-y: ${n?"auto":"hidden"};
 			min-height: 0;
 		`};
 
-	${({$fixedHeader:e=!1,$fixedHeaderScrollHeight:t="100vh"})=>e&&l.css`
-			max-height: ${t};
+	${({fixedHeader:e=!1,fixedHeaderScrollHeight:n="100vh"})=>e&&t.css`
+			max-height: ${n};
 			-webkit-overflow-scrolling: touch;
 		`};
 
 	${({theme:e})=>e.responsiveWrapper.style};
-`,Ce=c.default.div`
+`,ye=i.default.div`
 	position: relative;
 	box-sizing: border-box;
 	width: 100%;
 	height: 100%;
 	${e=>e.theme.progress.style};
-`,Se=c.default.div`
+`,ve=i.default.div`
 	position: relative;
 	width: 100%;
 	${({theme:e})=>e.tableWrapper.style};
-`,xe=c.default(T)`
+`,Re=i.default(H)`
 	white-space: nowrap;
 	${({theme:e})=>e.expanderCell.style};
-`,ke=c.default.div`
+`,Se=i.default.div`
 	box-sizing: border-box;
 	width: 100%;
 	height: 100%;
 	${({theme:e})=>e.noData.style};
-`,Re=()=>s.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24"},s.default.createElement("path",{d:"M7 10l5 5 5-5z"}),s.default.createElement("path",{d:"M0 0h24v24H0z",fill:"none"})),Pe=c.default.select`
+`,Ee=()=>r.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24"},r.default.createElement("path",{d:"M7 10l5 5 5-5z"}),r.default.createElement("path",{d:"M0 0h24v24H0z",fill:"none"})),Oe=i.default.select`
 	cursor: pointer;
 	height: 24px;
 	max-width: 100%;
@@ -328,7 +3318,7 @@
 	option {
 		color: initial;
 	}
-`,Oe=c.default.div`
+`,Pe=i.default.div`
 	position: relative;
 	flex-shrink: 0;
 	font-size: inherit;
@@ -347,7 +3337,7 @@
 		user-select: none;
 		pointer-events: none;
 	}
-`,Te=e=>{var{defaultValue:t,onChange:n}=e,a=fe(e,["defaultValue","onChange"]);return o.createElement(Oe,null,o.createElement(Pe,Object.assign({onChange:n,defaultValue:t},a)),o.createElement(Re,null))},De={columns:[],data:[],title:"",keyField:"id",selectableRows:!1,selectableRowsHighlight:!1,selectableRowsNoSelectAll:!1,selectableRowSelected:null,selectableRowDisabled:null,selectableRowsComponent:"input",selectableRowsComponentProps:{},selectableRowsVisibleOnly:!1,selectableRowsSingle:!1,clearSelectedRows:!1,expandableRows:!1,expandableRowDisabled:null,expandableRowExpanded:null,expandOnRowClicked:!1,expandableRowsHideExpander:!1,expandOnRowDoubleClicked:!1,expandableInheritConditionalStyles:!1,expandableRowsComponent:function(){return s.default.createElement("div",null,"To add an expander pass in a component instance via ",s.default.createElement("strong",null,"expandableRowsComponent"),". You can then access props.data from this component.")},expandableIcon:{collapsed:s.default.createElement((()=>s.default.createElement("svg",{fill:"currentColor",height:"24",viewBox:"0 0 24 24",width:"24",xmlns:"http://www.w3.org/2000/svg"},s.default.createElement("path",{d:"M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"}),s.default.createElement("path",{d:"M0-.25h24v24H0z",fill:"none"}))),null),expanded:s.default.createElement((()=>s.default.createElement("svg",{fill:"currentColor",height:"24",viewBox:"0 0 24 24",width:"24",xmlns:"http://www.w3.org/2000/svg"},s.default.createElement("path",{d:"M7.41 7.84L12 12.42l4.59-4.58L18 9.25l-6 6-6-6z"}),s.default.createElement("path",{d:"M0-.75h24v24H0z",fill:"none"}))),null)},expandableRowsComponentProps:{},progressPending:!1,progressComponent:s.default.createElement("div",{style:{fontSize:"24px",fontWeight:700,padding:"24px"}},"Loading..."),persistTableHead:!1,sortIcon:null,sortFunction:null,sortServer:!1,striped:!1,highlightOnHover:!1,pointerOnHover:!1,noContextMenu:!1,contextMessage:{singular:"item",plural:"items",message:"selected"},actions:null,contextActions:null,contextComponent:null,defaultSortFieldId:null,defaultSortAsc:!0,responsive:!0,noDataComponent:s.default.createElement("div",{style:{padding:"24px"}},"There are no records to display"),disabled:!1,noTableHead:!1,noHeader:!1,subHeader:!1,subHeaderAlign:t.v2.RIGHT,subHeaderWrap:!0,subHeaderComponent:null,fixedHeader:!1,fixedHeaderScrollHeight:"100vh",pagination:!1,paginationServer:!1,paginationServerOptions:{persistSelectedOnSort:!1,persistSelectedOnPageChange:!1},paginationDefaultPage:1,paginationResetDefaultPage:!1,paginationTotalRows:0,paginationPerPage:10,paginationRowsPerPageOptions:[10,15,20,25,30],paginationComponent:null,paginationComponentOptions:{},paginationIconFirstPage:s.default.createElement((()=>s.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24","aria-hidden":"true",role:"presentation"},s.default.createElement("path",{d:"M18.41 16.59L13.82 12l4.59-4.59L17 6l-6 6 6 6zM6 6h2v12H6z"}),s.default.createElement("path",{fill:"none",d:"M24 24H0V0h24v24z"}))),null),paginationIconLastPage:s.default.createElement((()=>s.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24","aria-hidden":"true",role:"presentation"},s.default.createElement("path",{d:"M5.59 7.41L10.18 12l-4.59 4.59L7 18l6-6-6-6zM16 6h2v12h-2z"}),s.default.createElement("path",{fill:"none",d:"M0 0h24v24H0V0z"}))),null),paginationIconNext:s.default.createElement((()=>s.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24","aria-hidden":"true",role:"presentation"},s.default.createElement("path",{d:"M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"}),s.default.createElement("path",{d:"M0 0h24v24H0z",fill:"none"}))),null),paginationIconPrevious:s.default.createElement((()=>s.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24","aria-hidden":"true",role:"presentation"},s.default.createElement("path",{d:"M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"}),s.default.createElement("path",{d:"M0 0h24v24H0z",fill:"none"}))),null),dense:!1,conditionalRowStyles:[],theme:"default",customStyles:{},direction:t.Nm.AUTO,onChangePage:y,onChangeRowsPerPage:y,onRowClicked:y,onRowDoubleClicked:y,onRowMouseEnter:y,onRowMouseLeave:y,onRowExpandToggled:y,onSelectedRowsChange:y,onSort:y,onColumnOrderChange:y},Ne={rowsPerPageText:"Rows per page:",rangeSeparatorText:"of",noRowsPerPage:!1,selectAllRowsItem:!1,selectAllRowsItemText:"All"},Ae=c.default.nav`
+`,ke=e=>{var{defaultValue:t,onChange:n}=e,o=me(e,["defaultValue","onChange"]);return l.createElement(Pe,null,l.createElement(Oe,Object.assign({onChange:n,defaultValue:t},o)),l.createElement(Ee,null))},De={columns:[],data:[],title:"",keyField:"id",selectableRows:!1,selectableRowsHighlight:!1,selectableRowsNoSelectAll:!1,selectableRowSelected:null,selectableRowDisabled:null,selectableRowsComponent:"input",selectableRowsComponentProps:{},selectableRowsVisibleOnly:!1,selectableRowsSingle:!1,clearSelectedRows:!1,expandableRows:!1,expandableRowDisabled:null,expandableRowExpanded:null,expandOnRowClicked:!1,expandableRowsHideExpander:!1,expandOnRowDoubleClicked:!1,expandableInheritConditionalStyles:!1,expandableRowsComponent:function(){return r.default.createElement("div",null,"To add an expander pass in a component instance via ",r.default.createElement("strong",null,"expandableRowsComponent"),". You can then access props.data from this component.")},expandableIcon:{collapsed:r.default.createElement((()=>r.default.createElement("svg",{fill:"currentColor",height:"24",viewBox:"0 0 24 24",width:"24",xmlns:"http://www.w3.org/2000/svg"},r.default.createElement("path",{d:"M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"}),r.default.createElement("path",{d:"M0-.25h24v24H0z",fill:"none"}))),null),expanded:r.default.createElement((()=>r.default.createElement("svg",{fill:"currentColor",height:"24",viewBox:"0 0 24 24",width:"24",xmlns:"http://www.w3.org/2000/svg"},r.default.createElement("path",{d:"M7.41 7.84L12 12.42l4.59-4.58L18 9.25l-6 6-6-6z"}),r.default.createElement("path",{d:"M0-.75h24v24H0z",fill:"none"}))),null)},expandableRowsComponentProps:{},progressPending:!1,progressComponent:r.default.createElement("div",{style:{fontSize:"24px",fontWeight:700,padding:"24px"}},"Loading..."),persistTableHead:!1,sortIcon:null,sortFunction:null,sortServer:!1,striped:!1,highlightOnHover:!1,pointerOnHover:!1,noContextMenu:!1,contextMessage:{singular:"item",plural:"items",message:"selected"},actions:null,contextActions:null,contextComponent:null,defaultSortFieldId:null,defaultSortAsc:!0,responsive:!0,noDataComponent:r.default.createElement("div",{style:{padding:"24px"}},"There are no records to display"),disabled:!1,noTableHead:!1,noHeader:!1,subHeader:!1,subHeaderAlign:exports.Alignment.RIGHT,subHeaderWrap:!0,subHeaderComponent:null,fixedHeader:!1,fixedHeaderScrollHeight:"100vh",pagination:!1,paginationServer:!1,paginationServerOptions:{persistSelectedOnSort:!1,persistSelectedOnPageChange:!1},paginationDefaultPage:1,paginationResetDefaultPage:!1,paginationTotalRows:0,paginationPerPage:10,paginationRowsPerPageOptions:[10,15,20,25,30],paginationComponent:null,paginationComponentOptions:{},paginationIconFirstPage:r.default.createElement((()=>r.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24","aria-hidden":"true",role:"presentation"},r.default.createElement("path",{d:"M18.41 16.59L13.82 12l4.59-4.59L17 6l-6 6 6 6zM6 6h2v12H6z"}),r.default.createElement("path",{fill:"none",d:"M24 24H0V0h24v24z"}))),null),paginationIconLastPage:r.default.createElement((()=>r.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24","aria-hidden":"true",role:"presentation"},r.default.createElement("path",{d:"M5.59 7.41L10.18 12l-4.59 4.59L7 18l6-6-6-6zM16 6h2v12h-2z"}),r.default.createElement("path",{fill:"none",d:"M0 0h24v24H0V0z"}))),null),paginationIconNext:r.default.createElement((()=>r.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24","aria-hidden":"true",role:"presentation"},r.default.createElement("path",{d:"M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"}),r.default.createElement("path",{d:"M0 0h24v24H0z",fill:"none"}))),null),paginationIconPrevious:r.default.createElement((()=>r.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24","aria-hidden":"true",role:"presentation"},r.default.createElement("path",{d:"M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"}),r.default.createElement("path",{d:"M0 0h24v24H0z",fill:"none"}))),null),dense:!1,conditionalRowStyles:[],theme:"default",customStyles:{},direction:exports.Direction.AUTO,onChangePage:m,onChangeRowsPerPage:m,onRowClicked:m,onRowDoubleClicked:m,onRowMouseEnter:m,onRowMouseLeave:m,onRowExpandToggled:m,onSelectedRowsChange:m,onSort:m,onColumnOrderChange:m},He={rowsPerPageText:"Rows per page:",rangeSeparatorText:"of",noRowsPerPage:!1,selectAllRowsItem:!1,selectAllRowsItemText:"All"},$e=i.default.nav`
 	display: flex;
 	flex: 1 1 auto;
 	justify-content: flex-end;
@@ -357,27 +3347,1782 @@
 	padding-left: 8px;
 	width: 100%;
 	${({theme:e})=>e.pagination.style};
-`,Ie=c.default.button`
+`,je=i.default.button`
 	position: relative;
 	display: block;
 	user-select: none;
 	border: none;
 	${({theme:e})=>e.pagination.pageButtonsStyle};
-	${({$isRTL:e})=>e&&"transform: scale(-1, -1)"};
-`,$e=c.default.div`
+	${({isRTL:e})=>e&&"transform: scale(-1, -1)"};
+`,Fe=i.default.div`
 	display: flex;
 	align-items: center;
 	border-radius: 4px;
 	white-space: nowrap;
-	${R`
+	${O`
     width: 100%;
     justify-content: space-around;
   `};
-`,Fe=c.default.span`
+`,Te=i.default.span`
 	flex-shrink: 1;
 	user-select: none;
-`,He=c.default(Fe)`
+`,Ie=i.default(Te)`
 	margin: 0 24px;
-`,Be=c.default(Fe)`
+`,Me=i.default(Te)`
 	margin: 0 4px;
-`;var Le=o.memo((function({rowsPerPage:e,rowCount:t,currentPage:n,direction:a=De.direction,paginationRowsPerPageOptions:l=De.paginationRowsPerPageOptions,paginationIconLastPage:i=De.paginationIconLastPage,paginationIconFirstPage:r=De.paginationIconFirstPage,paginationIconNext:s=De.paginationIconNext,paginationIconPrevious:c=De.paginationIconPrevious,paginationComponentOptions:u=De.paginationComponentOptions,onChangeRowsPerPage:d=De.onChangeRowsPerPage,onChangePage:p=De.onChangePage}){const m=(()=>{const e="object"==typeof window;function t(){return{width:e?window.innerWidth:void 0,height:e?window.innerHeight:void 0}}const[n,a]=o.useState(t);return o.useEffect((()=>{if(!e)return()=>null;function n(){a(t())}return window.addEventListener("resize",n),()=>window.removeEventListener("resize",n)}),[]),n})(),h=se(a),y=m.width&&m.width>599,f=g(t,e),b=n*e,v=b-e+1,E=1===n,w=n===f,_=Object.assign(Object.assign({},Ne),u),C=n===f?`${v}-${t} ${_.rangeSeparatorText} ${t}`:`${v}-${b} ${_.rangeSeparatorText} ${t}`,S=o.useCallback((()=>p(n-1)),[n,p]),x=o.useCallback((()=>p(n+1)),[n,p]),k=o.useCallback((()=>p(1)),[p]),R=o.useCallback((()=>p(g(t,e))),[p,t,e]),P=o.useCallback((e=>d(Number(e.target.value),n)),[n,d]),O=l.map((e=>o.createElement("option",{key:e,value:e},e)));_.selectAllRowsItem&&O.push(o.createElement("option",{key:-1,value:t},_.selectAllRowsItemText));const T=o.createElement(Te,{onChange:P,defaultValue:e,"aria-label":_.rowsPerPageText},O);return o.createElement(Ae,{className:"rdt_Pagination"},!_.noRowsPerPage&&y&&o.createElement(o.Fragment,null,o.createElement(Be,null,_.rowsPerPageText),T),y&&o.createElement(He,null,C),o.createElement($e,null,o.createElement(Ie,{id:"pagination-first-page",type:"button","aria-label":"First Page","aria-disabled":E,onClick:k,disabled:E,$isRTL:h},r),o.createElement(Ie,{id:"pagination-previous-page",type:"button","aria-label":"Previous Page","aria-disabled":E,onClick:S,disabled:E,$isRTL:h},c),!_.noRowsPerPage&&!y&&T,o.createElement(Ie,{id:"pagination-next-page",type:"button","aria-label":"Next Page","aria-disabled":w,onClick:x,disabled:w,$isRTL:h},s),o.createElement(Ie,{id:"pagination-last-page",type:"button","aria-label":"Last Page","aria-disabled":w,onClick:R,disabled:w,$isRTL:h},i)))}));const je=(e,t)=>{const n=o.useRef(!0);o.useEffect((()=>{n.current?n.current=!1:e()}),t)};var Me=function(e){return function(e){return!!e&&"object"==typeof e}(e)&&!function(e){var t=Object.prototype.toString.call(e);return"[object RegExp]"===t||"[object Date]"===t||function(e){return e.$$typeof===ze}(e)}(e)},ze="function"==typeof Symbol&&Symbol.for?Symbol.for("react.element"):60103;function We(e,t){return!1!==t.clone&&t.isMergeableObject(e)?Ve((n=e,Array.isArray(n)?[]:{}),e,t):e;var n}function Ue(e,t,n){return e.concat(t).map((function(e){return We(e,n)}))}function Ge(e){return Object.keys(e).concat(function(e){return Object.getOwnPropertySymbols?Object.getOwnPropertySymbols(e).filter((function(t){return Object.propertyIsEnumerable.call(e,t)})):[]}(e))}function Ye(e,t){try{return t in e}catch(e){return!1}}function Ve(e,t,n){(n=n||{}).arrayMerge=n.arrayMerge||Ue,n.isMergeableObject=n.isMergeableObject||Me,n.cloneUnlessOtherwiseSpecified=We;var a=Array.isArray(t);return a===Array.isArray(e)?a?n.arrayMerge(e,t,n):function(e,t,n){var a={};return n.isMergeableObject(e)&&Ge(e).forEach((function(t){a[t]=We(e[t],n)})),Ge(t).forEach((function(l){(function(e,t){return Ye(e,t)&&!(Object.hasOwnProperty.call(e,t)&&Object.propertyIsEnumerable.call(e,t))})(e,l)||(Ye(e,l)&&n.isMergeableObject(t[l])?a[l]=function(e,t){if(!t.customMerge)return Ve;var n=t.customMerge(e);return"function"==typeof n?n:Ve}(l,n)(e[l],t[l],n):a[l]=We(t[l],n))})),a}(e,t,n):We(t,n)}Ve.all=function(e,t){if(!Array.isArray(e))throw new Error("first argument should be an array");return e.reduce((function(e,n){return Ve(e,n,t)}),{})};var Ke=function(e){return e&&e.__esModule&&Object.prototype.hasOwnProperty.call(e,"default")?e.default:e}(Ve);const Je={text:{primary:"rgba(0, 0, 0, 0.87)",secondary:"rgba(0, 0, 0, 0.54)",disabled:"rgba(0, 0, 0, 0.38)"},background:{default:"#FFFFFF"},context:{background:"#e3f2fd",text:"rgba(0, 0, 0, 0.87)"},divider:{default:"rgba(0,0,0,.12)"},button:{default:"rgba(0,0,0,.54)",focus:"rgba(0,0,0,.12)",hover:"rgba(0,0,0,.12)",disabled:"rgba(0, 0, 0, .18)"},selected:{default:"#e3f2fd",text:"rgba(0, 0, 0, 0.87)"},highlightOnHover:{default:"#EEEEEE",text:"rgba(0, 0, 0, 0.87)"},striped:{default:"#FAFAFA",text:"rgba(0, 0, 0, 0.87)"}},Ze={default:Je,light:Je,dark:{text:{primary:"#FFFFFF",secondary:"rgba(255, 255, 255, 0.7)",disabled:"rgba(0,0,0,.12)"},background:{default:"#424242"},context:{background:"#E91E63",text:"#FFFFFF"},divider:{default:"rgba(81, 81, 81, 1)"},button:{default:"#FFFFFF",focus:"rgba(255, 255, 255, .54)",hover:"rgba(255, 255, 255, .12)",disabled:"rgba(255, 255, 255, .18)"},selected:{default:"rgba(0, 0, 0, .7)",text:"#FFFFFF"},highlightOnHover:{default:"rgba(0, 0, 0, .7)",text:"#FFFFFF"},striped:{default:"rgba(0, 0, 0, .87)",text:"#FFFFFF"}}};function qe(e,t,n,a){const[l,i]=o.useState((()=>m(e))),[s,c]=o.useState(""),u=o.useRef("");je((()=>{i(m(e))}),[e]);const d=o.useCallback((e=>{var t,n,a;const{attributes:i}=e.target,r=null===(t=i.getNamedItem("data-column-id"))||void 0===t?void 0:t.value;r&&(u.current=(null===(a=null===(n=l[v(l,r)])||void 0===n?void 0:n.id)||void 0===a?void 0:a.toString())||"",c(u.current))}),[l]),p=o.useCallback((e=>{var n;const{attributes:a}=e.target,r=null===(n=a.getNamedItem("data-column-id"))||void 0===n?void 0:n.value;if(r&&u.current&&r!==u.current){const e=v(l,u.current),n=v(l,r),a=[...l];a[e]=l[n],a[n]=l[e],i(a),t(a)}}),[t,l]),g=o.useCallback((e=>{e.preventDefault()}),[]),h=o.useCallback((e=>{e.preventDefault()}),[]),y=o.useCallback((e=>{e.preventDefault(),u.current="",c("")}),[]),f=function(e=!1){return e?r.ASC:r.DESC}(a),b=o.useMemo((()=>l[v(l,null==n?void 0:n.toString())]||{}),[n,l]);return{tableColumns:l,draggingColumnId:s,handleDragStart:d,handleDragEnter:p,handleDragOver:g,handleDragLeave:h,handleDragEnd:y,defaultSortDirection:f,defaultSortColumn:b}}var Xe=o.memo((function(e){const{data:t=De.data,columns:n=De.columns,title:a=De.title,actions:i=De.actions,keyField:s=De.keyField,striped:c=De.striped,highlightOnHover:d=De.highlightOnHover,pointerOnHover:p=De.pointerOnHover,dense:m=De.dense,selectableRows:y=De.selectableRows,selectableRowsSingle:f=De.selectableRowsSingle,selectableRowsHighlight:v=De.selectableRowsHighlight,selectableRowsNoSelectAll:E=De.selectableRowsNoSelectAll,selectableRowsVisibleOnly:_=De.selectableRowsVisibleOnly,selectableRowSelected:S=De.selectableRowSelected,selectableRowDisabled:R=De.selectableRowDisabled,selectableRowsComponent:P=De.selectableRowsComponent,selectableRowsComponentProps:O=De.selectableRowsComponentProps,onRowExpandToggled:D=De.onRowExpandToggled,onSelectedRowsChange:N=De.onSelectedRowsChange,expandableIcon:A=De.expandableIcon,onChangeRowsPerPage:I=De.onChangeRowsPerPage,onChangePage:$=De.onChangePage,paginationServer:F=De.paginationServer,paginationServerOptions:H=De.paginationServerOptions,paginationTotalRows:B=De.paginationTotalRows,paginationDefaultPage:L=De.paginationDefaultPage,paginationResetDefaultPage:j=De.paginationResetDefaultPage,paginationPerPage:M=De.paginationPerPage,paginationRowsPerPageOptions:z=De.paginationRowsPerPageOptions,paginationIconLastPage:W=De.paginationIconLastPage,paginationIconFirstPage:U=De.paginationIconFirstPage,paginationIconNext:G=De.paginationIconNext,paginationIconPrevious:Y=De.paginationIconPrevious,paginationComponent:V=De.paginationComponent,paginationComponentOptions:K=De.paginationComponentOptions,responsive:J=De.responsive,progressPending:Z=De.progressPending,progressComponent:q=De.progressComponent,persistTableHead:Q=De.persistTableHead,noDataComponent:ee=De.noDataComponent,disabled:te=De.disabled,noTableHead:ne=De.noTableHead,noHeader:ae=De.noHeader,fixedHeader:le=De.fixedHeader,fixedHeaderScrollHeight:re=De.fixedHeaderScrollHeight,pagination:se=De.pagination,subHeader:ce=De.subHeader,subHeaderAlign:ue=De.subHeaderAlign,subHeaderWrap:de=De.subHeaderWrap,subHeaderComponent:pe=De.subHeaderComponent,noContextMenu:me=De.noContextMenu,contextMessage:ge=De.contextMessage,contextActions:he=De.contextActions,contextComponent:fe=De.contextComponent,expandableRows:be=De.expandableRows,onRowClicked:ve=De.onRowClicked,onRowDoubleClicked:Re=De.onRowDoubleClicked,onRowMouseEnter:Pe=De.onRowMouseEnter,onRowMouseLeave:Oe=De.onRowMouseLeave,sortIcon:Te=De.sortIcon,onSort:Ne=De.onSort,sortFunction:Ae=De.sortFunction,sortServer:Ie=De.sortServer,expandableRowsComponent:$e=De.expandableRowsComponent,expandableRowsComponentProps:Fe=De.expandableRowsComponentProps,expandableRowDisabled:He=De.expandableRowDisabled,expandableRowsHideExpander:Be=De.expandableRowsHideExpander,expandOnRowClicked:Me=De.expandOnRowClicked,expandOnRowDoubleClicked:ze=De.expandOnRowDoubleClicked,expandableRowExpanded:We=De.expandableRowExpanded,expandableInheritConditionalStyles:Ue=De.expandableInheritConditionalStyles,defaultSortFieldId:Ge=De.defaultSortFieldId,defaultSortAsc:Ye=De.defaultSortAsc,clearSelectedRows:Ve=De.clearSelectedRows,conditionalRowStyles:Je=De.conditionalRowStyles,theme:Xe=De.theme,customStyles:Qe=De.customStyles,direction:et=De.direction,onColumnOrderChange:tt=De.onColumnOrderChange,className:nt}=e,{tableColumns:at,draggingColumnId:lt,handleDragStart:it,handleDragEnter:rt,handleDragOver:ot,handleDragLeave:st,handleDragEnd:ct,defaultSortDirection:ut,defaultSortColumn:dt}=qe(n,tt,Ge,Ye),[{rowsPerPage:pt,currentPage:mt,selectedRows:gt,allSelected:ht,selectedCount:yt,selectedColumn:ft,sortDirection:bt,toggleOnSelectedRowsChange:vt},Et]=o.useReducer(w,{allSelected:!1,selectedCount:0,selectedRows:[],selectedColumn:dt,toggleOnSelectedRowsChange:!1,sortDirection:ut,currentPage:L,rowsPerPage:M,selectedRowsFlag:!1,contextMessage:De.contextMessage}),{persistSelectedOnSort:wt=!1,persistSelectedOnPageChange:_t=!1}=H,Ct=!(!F||!_t&&!wt),St=se&&!Z&&t.length>0,xt=V||Le,kt=o.useMemo((()=>((e={},t="default",n="default")=>{return Ke({table:{style:{color:(a=Ze[Ze[t]?t:n]).text.primary,backgroundColor:a.background.default}},tableWrapper:{style:{display:"table"}},responsiveWrapper:{style:{}},header:{style:{fontSize:"22px",color:a.text.primary,backgroundColor:a.background.default,minHeight:"56px",paddingLeft:"16px",paddingRight:"8px"}},subHeader:{style:{backgroundColor:a.background.default,minHeight:"52px"}},head:{style:{color:a.text.primary,fontSize:"12px",fontWeight:500}},headRow:{style:{backgroundColor:a.background.default,minHeight:"52px",borderBottomWidth:"1px",borderBottomColor:a.divider.default,borderBottomStyle:"solid"},denseStyle:{minHeight:"32px"}},headCells:{style:{paddingLeft:"16px",paddingRight:"16px"},draggingStyle:{cursor:"move"}},contextMenu:{style:{backgroundColor:a.context.background,fontSize:"18px",fontWeight:400,color:a.context.text,paddingLeft:"16px",paddingRight:"8px",transform:"translate3d(0, -100%, 0)",transitionDuration:"125ms",transitionTimingFunction:"cubic-bezier(0, 0, 0.2, 1)",willChange:"transform"},activeStyle:{transform:"translate3d(0, 0, 0)"}},cells:{style:{paddingLeft:"16px",paddingRight:"16px",wordBreak:"break-word"},draggingStyle:{}},rows:{style:{fontSize:"13px",fontWeight:400,color:a.text.primary,backgroundColor:a.background.default,minHeight:"48px","&:not(:last-of-type)":{borderBottomStyle:"solid",borderBottomWidth:"1px",borderBottomColor:a.divider.default}},denseStyle:{minHeight:"32px"},selectedHighlightStyle:{"&:nth-of-type(n)":{color:a.selected.text,backgroundColor:a.selected.default,borderBottomColor:a.background.default}},highlightOnHoverStyle:{color:a.highlightOnHover.text,backgroundColor:a.highlightOnHover.default,transitionDuration:"0.15s",transitionProperty:"background-color",borderBottomColor:a.background.default,outlineStyle:"solid",outlineWidth:"1px",outlineColor:a.background.default},stripedStyle:{color:a.striped.text,backgroundColor:a.striped.default}},expanderRow:{style:{color:a.text.primary,backgroundColor:a.background.default}},expanderCell:{style:{flex:"0 0 48px"}},expanderButton:{style:{color:a.button.default,fill:a.button.default,backgroundColor:"transparent",borderRadius:"2px",transition:"0.25s",height:"100%",width:"100%","&:hover:enabled":{cursor:"pointer"},"&:disabled":{color:a.button.disabled},"&:hover:not(:disabled)":{cursor:"pointer",backgroundColor:a.button.hover},"&:focus":{outline:"none",backgroundColor:a.button.focus},svg:{margin:"auto"}}},pagination:{style:{color:a.text.secondary,fontSize:"13px",minHeight:"56px",backgroundColor:a.background.default,borderTopStyle:"solid",borderTopWidth:"1px",borderTopColor:a.divider.default},pageButtonsStyle:{borderRadius:"50%",height:"40px",width:"40px",padding:"8px",margin:"px",cursor:"pointer",transition:"0.4s",color:a.button.default,fill:a.button.default,backgroundColor:"transparent","&:disabled":{cursor:"unset",color:a.button.disabled,fill:a.button.disabled},"&:hover:not(:disabled)":{backgroundColor:a.button.hover},"&:focus":{outline:"none",backgroundColor:a.button.focus}}},noData:{style:{display:"flex",alignItems:"center",justifyContent:"center",color:a.text.primary,backgroundColor:a.background.default}},progress:{style:{display:"flex",alignItems:"center",justifyContent:"center",color:a.text.primary,backgroundColor:a.background.default}}},e);var a})(Qe,Xe)),[Qe,Xe]),Rt=o.useMemo((()=>Object.assign({},"auto"!==et&&{dir:et})),[et]),Pt=o.useMemo((()=>{if(Ie)return t;if((null==ft?void 0:ft.sortFunction)&&"function"==typeof ft.sortFunction){const e=ft.sortFunction,n=bt===r.ASC?e:(t,n)=>-1*e(t,n);return[...t].sort(n)}return function(e,t,n,a){return t?a&&"function"==typeof a?a(e.slice(0),t,n):e.slice(0).sort(((e,a)=>{const l=t(e),i=t(a);if("asc"===n){if(l<i)return-1;if(l>i)return 1}if("desc"===n){if(l>i)return-1;if(l<i)return 1}return 0})):e}(t,null==ft?void 0:ft.selector,bt,Ae)}),[Ie,ft,bt,t,Ae]),Ot=o.useMemo((()=>{if(se&&!F){const e=mt*pt,t=e-pt;return Pt.slice(t,e)}return Pt}),[mt,se,F,pt,Pt]),Tt=o.useCallback((e=>{Et(e)}),[]),Dt=o.useCallback((e=>{Et(e)}),[]),Nt=o.useCallback((e=>{Et(e)}),[]),At=o.useCallback(((e,t)=>ve(e,t)),[ve]),It=o.useCallback(((e,t)=>Re(e,t)),[Re]),$t=o.useCallback(((e,t)=>Pe(e,t)),[Pe]),Ft=o.useCallback(((e,t)=>Oe(e,t)),[Oe]),Ht=o.useCallback((e=>Et({type:"CHANGE_PAGE",page:e,paginationServer:F,visibleOnly:_,persistSelectedOnPageChange:_t})),[F,_t,_]),Bt=o.useCallback((e=>{const t=g(B||Ot.length,e),n=h(mt,t);F||Ht(n),Et({type:"CHANGE_ROWS_PER_PAGE",page:n,rowsPerPage:e})}),[mt,Ht,F,B,Ot.length]);if(se&&!F&&Pt.length>0&&0===Ot.length){const e=g(Pt.length,pt),t=h(mt,e);Ht(t)}je((()=>{N({allSelected:ht,selectedCount:yt,selectedRows:gt.slice(0)})}),[vt]),je((()=>{Ne(ft,bt,Pt.slice(0))}),[ft,bt]),je((()=>{$(mt,B||Pt.length)}),[mt]),je((()=>{I(pt,mt)}),[pt]),je((()=>{Ht(L)}),[L,j]),je((()=>{if(se&&F&&B>0){const e=g(B,pt),t=h(mt,e);mt!==t&&Ht(t)}}),[B]),o.useEffect((()=>{Et({type:"CLEAR_SELECTED_ROWS",selectedRowsFlag:Ve})}),[f,Ve]),o.useEffect((()=>{if(!S)return;const e=Pt.filter((e=>S(e))),t=f?e.slice(0,1):e;Et({type:"SELECT_MULTIPLE_ROWS",keyField:s,selectedRows:t,totalRows:Pt.length,mergeSelections:Ct})}),[t,S]);const Lt=_?Ot:Pt,jt=_t||f||E;return o.createElement(l.ThemeProvider,{theme:kt},!ae&&(!!a||!!i)&&o.createElement(ye,{title:a,actions:i,showMenu:!me,selectedCount:yt,direction:et,contextActions:he,contextComponent:fe,contextMessage:ge}),ce&&o.createElement(Ee,{align:ue,wrapContent:de},pe),o.createElement(_e,Object.assign({$responsive:J,$fixedHeader:le,$fixedHeaderScrollHeight:re,className:nt},Rt),o.createElement(Se,null,Z&&!Q&&o.createElement(Ce,null,q),o.createElement(C,{disabled:te,className:"rdt_Table",role:"table"},!ne&&(!!Q||Pt.length>0&&!Z)&&o.createElement(x,{className:"rdt_TableHead",role:"rowgroup",$fixedHeader:le},o.createElement(k,{className:"rdt_TableHeadRow",role:"row",$dense:m},y&&(jt?o.createElement(T,{style:{flex:"0 0 48px"}}):o.createElement(oe,{allSelected:ht,selectedRows:gt,selectableRowsComponent:P,selectableRowsComponentProps:O,selectableRowDisabled:R,rowData:Lt,keyField:s,mergeSelections:Ct,onSelectAllRows:Dt})),be&&!Be&&o.createElement(xe,null),at.map((e=>o.createElement(ie,{key:e.id,column:e,selectedColumn:ft,disabled:Z||0===Pt.length,pagination:se,paginationServer:F,persistSelectedOnSort:wt,selectableRowsVisibleOnly:_,sortDirection:bt,sortIcon:Te,sortServer:Ie,onSort:Tt,onDragStart:it,onDragOver:ot,onDragEnd:ct,onDragEnter:rt,onDragLeave:st,draggingColumnId:lt}))))),!Pt.length&&!Z&&o.createElement(ke,null,ee),Z&&Q&&o.createElement(Ce,null,q),!Z&&Pt.length>0&&o.createElement(we,{className:"rdt_TableBody",role:"rowgroup"},Ot.map(((e,t)=>{const n=u(e,s),a=function(e=""){return"number"!=typeof e&&(!e||0===e.length)}(n)?t:n,l=b(e,gt,s),i=!!(be&&We&&We(e)),r=!!(be&&He&&He(e));return o.createElement(X,{id:a,key:a,keyField:s,"data-row-id":a,columns:at,row:e,rowCount:Pt.length,rowIndex:t,selectableRows:y,expandableRows:be,expandableIcon:A,highlightOnHover:d,pointerOnHover:p,dense:m,expandOnRowClicked:Me,expandOnRowDoubleClicked:ze,expandableRowsComponent:$e,expandableRowsComponentProps:Fe,expandableRowsHideExpander:Be,defaultExpanderDisabled:r,defaultExpanded:i,expandableInheritConditionalStyles:Ue,conditionalRowStyles:Je,selected:l,selectableRowsHighlight:v,selectableRowsComponent:P,selectableRowsComponentProps:O,selectableRowDisabled:R,selectableRowsSingle:f,striped:c,onRowExpandToggled:D,onRowClicked:At,onRowDoubleClicked:It,onRowMouseEnter:$t,onRowMouseLeave:Ft,onSelectedRow:Nt,draggingColumnId:lt,onDragStart:it,onDragOver:ot,onDragEnd:ct,onDragEnter:rt,onDragLeave:st})})))))),St&&o.createElement("div",null,o.createElement(xt,{onChangePage:Ht,onChangeRowsPerPage:Bt,rowCount:B||Pt.length,currentPage:mt,rowsPerPage:pt,direction:et,paginationRowsPerPageOptions:z,paginationIconLastPage:W,paginationIconFirstPage:U,paginationIconNext:G,paginationIconPrevious:Y,paginationComponentOptions:K})))}));t.ZP=Xe},774:e=>{e.exports=function(e,t,n,a){var l=n?n.call(a,e,t):void 0;if(void 0!==l)return!!l;if(e===t)return!0;if("object"!=typeof e||!e||"object"!=typeof t||!t)return!1;var i=Object.keys(e),r=Object.keys(t);if(i.length!==r.length)return!1;for(var o=Object.prototype.hasOwnProperty.bind(t),s=0;s<i.length;s++){var c=i[s];if(!o(c))return!1;var u=e[c],d=t[c];if(!1===(l=n?n.call(a,u,d,c):void 0)||void 0===l&&u!==d)return!1}return!0}},331:(e,t,n)=>{"use strict";n.r(t),n.d(t,{ServerStyleSheet:()=>an,StyleSheetConsumer:()=>Pt,StyleSheetContext:()=>Rt,StyleSheetManager:()=>Dt,ThemeConsumer:()=>zt,ThemeContext:()=>Mt,ThemeProvider:()=>Ut,__PRIVATE__:()=>ln,createGlobalStyle:()=>en,css:()=>Jt,default:()=>Xt,isStyledComponent:()=>Ze,keyframes:()=>tn,styled:()=>Xt,useTheme:()=>Wt,version:()=>de,withTheme:()=>nn});var a=function(){return a=Object.assign||function(e){for(var t,n=1,a=arguments.length;n<a;n++)for(var l in t=arguments[n])Object.prototype.hasOwnProperty.call(t,l)&&(e[l]=t[l]);return e},a.apply(this,arguments)};function l(e,t,n){if(n||2===arguments.length)for(var a,l=0,i=t.length;l<i;l++)!a&&l in t||(a||(a=Array.prototype.slice.call(t,0,l)),a[l]=t[l]);return e.concat(a||Array.prototype.slice.call(t))}Object.create,Object.create;var i=n(196),r=n.n(i),o=n(774),s=n.n(o),c="-ms-",u="-moz-",d="-webkit-",p="comm",m="rule",g="decl",h="@import",y="@keyframes",f="@layer",b=Math.abs,v=String.fromCharCode,E=Object.assign;function w(e){return e.trim()}function _(e,t){return(e=t.exec(e))?e[0]:e}function C(e,t,n){return e.replace(t,n)}function S(e,t,n){return e.indexOf(t,n)}function x(e,t){return 0|e.charCodeAt(t)}function k(e,t,n){return e.slice(t,n)}function R(e){return e.length}function P(e){return e.length}function O(e,t){return t.push(e),e}function T(e,t){return e.filter((function(e){return!_(e,t)}))}var D=1,N=1,A=0,I=0,$=0,F="";function H(e,t,n,a,l,i,r,o){return{value:e,root:t,parent:n,type:a,props:l,children:i,line:D,column:N,length:r,return:"",siblings:o}}function B(e,t){return E(H("",null,null,"",null,null,0,e.siblings),e,{length:-e.length},t)}function L(e){for(;e.root;)e=B(e.root,{children:[e]});O(e,e.siblings)}function j(){return $=I>0?x(F,--I):0,N--,10===$&&(N=1,D--),$}function M(){return $=I<A?x(F,I++):0,N++,10===$&&(N=1,D++),$}function z(){return x(F,I)}function W(){return I}function U(e,t){return k(F,e,t)}function G(e){switch(e){case 0:case 9:case 10:case 13:case 32:return 5;case 33:case 43:case 44:case 47:case 62:case 64:case 126:case 59:case 123:case 125:return 4;case 58:return 3;case 34:case 39:case 40:case 91:return 2;case 41:case 93:return 1}return 0}function Y(e){return w(U(I-1,J(91===e?e+2:40===e?e+1:e)))}function V(e){for(;($=z())&&$<33;)M();return G(e)>2||G($)>3?"":" "}function K(e,t){for(;--t&&M()&&!($<48||$>102||$>57&&$<65||$>70&&$<97););return U(e,W()+(t<6&&32==z()&&32==M()))}function J(e){for(;M();)switch($){case e:return I;case 34:case 39:34!==e&&39!==e&&J($);break;case 40:41===e&&J(e);break;case 92:M()}return I}function Z(e,t){for(;M()&&e+$!==57&&(e+$!==84||47!==z()););return"/*"+U(t,I-1)+"*"+v(47===e?e:M())}function q(e){for(;!G(z());)M();return U(e,I)}function X(e,t){for(var n="",a=0;a<e.length;a++)n+=t(e[a],a,e,t)||"";return n}function Q(e,t,n,a){switch(e.type){case f:if(e.children.length)break;case h:case g:return e.return=e.return||e.value;case p:return"";case y:return e.return=e.value+"{"+X(e.children,a)+"}";case m:if(!R(e.value=e.props.join(",")))return""}return R(n=X(e.children,a))?e.return=e.value+"{"+n+"}":""}function ee(e,t,n){switch(function(e,t){return 45^x(e,0)?(((t<<2^x(e,0))<<2^x(e,1))<<2^x(e,2))<<2^x(e,3):0}(e,t)){case 5103:return d+"print-"+e+e;case 5737:case 4201:case 3177:case 3433:case 1641:case 4457:case 2921:case 5572:case 6356:case 5844:case 3191:case 6645:case 3005:case 6391:case 5879:case 5623:case 6135:case 4599:case 4855:case 4215:case 6389:case 5109:case 5365:case 5621:case 3829:return d+e+e;case 4789:return u+e+e;case 5349:case 4246:case 4810:case 6968:case 2756:return d+e+u+e+c+e+e;case 5936:switch(x(e,t+11)){case 114:return d+e+c+C(e,/[svh]\w+-[tblr]{2}/,"tb")+e;case 108:return d+e+c+C(e,/[svh]\w+-[tblr]{2}/,"tb-rl")+e;case 45:return d+e+c+C(e,/[svh]\w+-[tblr]{2}/,"lr")+e}case 6828:case 4268:case 2903:return d+e+c+e+e;case 6165:return d+e+c+"flex-"+e+e;case 5187:return d+e+C(e,/(\w+).+(:[^]+)/,d+"box-$1$2"+c+"flex-$1$2")+e;case 5443:return d+e+c+"flex-item-"+C(e,/flex-|-self/g,"")+(_(e,/flex-|baseline/)?"":c+"grid-row-"+C(e,/flex-|-self/g,""))+e;case 4675:return d+e+c+"flex-line-pack"+C(e,/align-content|flex-|-self/g,"")+e;case 5548:return d+e+c+C(e,"shrink","negative")+e;case 5292:return d+e+c+C(e,"basis","preferred-size")+e;case 6060:return d+"box-"+C(e,"-grow","")+d+e+c+C(e,"grow","positive")+e;case 4554:return d+C(e,/([^-])(transform)/g,"$1"+d+"$2")+e;case 6187:return C(C(C(e,/(zoom-|grab)/,d+"$1"),/(image-set)/,d+"$1"),e,"")+e;case 5495:case 3959:return C(e,/(image-set\([^]*)/,d+"$1$`$1");case 4968:return C(C(e,/(.+:)(flex-)?(.*)/,d+"box-pack:$3"+c+"flex-pack:$3"),/s.+-b[^;]+/,"justify")+d+e+e;case 4200:if(!_(e,/flex-|baseline/))return c+"grid-column-align"+k(e,t)+e;break;case 2592:case 3360:return c+C(e,"template-","")+e;case 4384:case 3616:return n&&n.some((function(e,n){return t=n,_(e.props,/grid-\w+-end/)}))?~S(e+(n=n[t].value),"span",0)?e:c+C(e,"-start","")+e+c+"grid-row-span:"+(~S(n,"span",0)?_(n,/\d+/):+_(n,/\d+/)-+_(e,/\d+/))+";":c+C(e,"-start","")+e;case 4896:case 4128:return n&&n.some((function(e){return _(e.props,/grid-\w+-start/)}))?e:c+C(C(e,"-end","-span"),"span ","")+e;case 4095:case 3583:case 4068:case 2532:return C(e,/(.+)-inline(.+)/,d+"$1$2")+e;case 8116:case 7059:case 5753:case 5535:case 5445:case 5701:case 4933:case 4677:case 5533:case 5789:case 5021:case 4765:if(R(e)-1-t>6)switch(x(e,t+1)){case 109:if(45!==x(e,t+4))break;case 102:return C(e,/(.+:)(.+)-([^]+)/,"$1"+d+"$2-$3$1"+u+(108==x(e,t+3)?"$3":"$2-$3"))+e;case 115:return~S(e,"stretch",0)?ee(C(e,"stretch","fill-available"),t,n)+e:e}break;case 5152:case 5920:return C(e,/(.+?):(\d+)(\s*\/\s*(span)?\s*(\d+))?(.*)/,(function(t,n,a,l,i,r,o){return c+n+":"+a+o+(l?c+n+"-span:"+(i?r:+r-+a)+o:"")+e}));case 4949:if(121===x(e,t+6))return C(e,":",":"+d)+e;break;case 6444:switch(x(e,45===x(e,14)?18:11)){case 120:return C(e,/(.+:)([^;\s!]+)(;|(\s+)?!.+)?/,"$1"+d+(45===x(e,14)?"inline-":"")+"box$3$1"+d+"$2$3$1"+c+"$2box$3")+e;case 100:return C(e,":",":"+c)+e}break;case 5719:case 2647:case 2135:case 3927:case 2391:return C(e,"scroll-","scroll-snap-")+e}return e}function te(e,t,n,a){if(e.length>-1&&!e.return)switch(e.type){case g:return void(e.return=ee(e.value,e.length,n));case y:return X([B(e,{value:C(e.value,"@","@"+d)})],a);case m:if(e.length)return function(e,t){return e.map(t).join("")}(n=e.props,(function(t){switch(_(t,a=/(::plac\w+|:read-\w+)/)){case":read-only":case":read-write":L(B(e,{props:[C(t,/:(read-\w+)/,":"+u+"$1")]})),L(B(e,{props:[t]})),E(e,{props:T(n,a)});break;case"::placeholder":L(B(e,{props:[C(t,/:(plac\w+)/,":"+d+"input-$1")]})),L(B(e,{props:[C(t,/:(plac\w+)/,":"+u+"$1")]})),L(B(e,{props:[C(t,/:(plac\w+)/,c+"input-$1")]})),L(B(e,{props:[t]})),E(e,{props:T(n,a)})}return""}))}}function ne(e){return function(e){return F="",e}(ae("",null,null,null,[""],e=function(e){return D=N=1,A=R(F=e),I=0,[]}(e),0,[0],e))}function ae(e,t,n,a,l,i,r,o,s){for(var c=0,u=0,d=r,p=0,m=0,g=0,h=1,y=1,f=1,E=0,w="",_=l,k=i,P=a,T=w;y;)switch(g=E,E=M()){case 40:if(108!=g&&58==x(T,d-1)){-1!=S(T+=C(Y(E),"&","&\f"),"&\f",b(c?o[c-1]:0))&&(f=-1);break}case 34:case 39:case 91:T+=Y(E);break;case 9:case 10:case 13:case 32:T+=V(g);break;case 92:T+=K(W()-1,7);continue;case 47:switch(z()){case 42:case 47:O(ie(Z(M(),W()),t,n,s),s);break;default:T+="/"}break;case 123*h:o[c++]=R(T)*f;case 125*h:case 59:case 0:switch(E){case 0:case 125:y=0;case 59+u:-1==f&&(T=C(T,/\f/g,"")),m>0&&R(T)-d&&O(m>32?re(T+";",a,n,d-1,s):re(C(T," ","")+";",a,n,d-2,s),s);break;case 59:T+=";";default:if(O(P=le(T,t,n,c,u,l,o,w,_=[],k=[],d,i),i),123===E)if(0===u)ae(T,t,P,P,_,i,d,o,k);else switch(99===p&&110===x(T,3)?100:p){case 100:case 108:case 109:case 115:ae(e,P,P,a&&O(le(e,P,P,0,0,l,o,w,l,_=[],d,k),k),l,k,d,o,a?_:k);break;default:ae(T,P,P,P,[""],k,0,o,k)}}c=u=m=0,h=f=1,w=T="",d=r;break;case 58:d=1+R(T),m=g;default:if(h<1)if(123==E)--h;else if(125==E&&0==h++&&125==j())continue;switch(T+=v(E),E*h){case 38:f=u>0?1:(T+="\f",-1);break;case 44:o[c++]=(R(T)-1)*f,f=1;break;case 64:45===z()&&(T+=Y(M())),p=z(),u=d=R(w=T+=q(W())),E++;break;case 45:45===g&&2==R(T)&&(h=0)}}return i}function le(e,t,n,a,l,i,r,o,s,c,u,d){for(var p=l-1,g=0===l?i:[""],h=P(g),y=0,f=0,v=0;y<a;++y)for(var E=0,_=k(e,p+1,p=b(f=r[y])),S=e;E<h;++E)(S=w(f>0?g[E]+" "+_:C(_,/&\f/g,g[E])))&&(s[v++]=S);return H(e,t,n,0===l?m:o,s,c,u,d)}function ie(e,t,n,a){return H(e,t,n,p,v($),k(e,2,-2),0,a)}function re(e,t,n,a,l){return H(e,t,n,g,k(e,0,a),k(e,a+1,-1),a,l)}const oe={animationIterationCount:1,borderImageOutset:1,borderImageSlice:1,borderImageWidth:1,boxFlex:1,boxFlexGroup:1,boxOrdinalGroup:1,columnCount:1,columns:1,flex:1,flexGrow:1,flexPositive:1,flexShrink:1,flexNegative:1,flexOrder:1,gridRow:1,gridRowEnd:1,gridRowSpan:1,gridRowStart:1,gridColumn:1,gridColumnEnd:1,gridColumnSpan:1,gridColumnStart:1,msGridRow:1,msGridRowSpan:1,msGridColumn:1,msGridColumnSpan:1,fontWeight:1,lineHeight:1,opacity:1,order:1,orphans:1,tabSize:1,widows:1,zIndex:1,zoom:1,WebkitLineClamp:1,fillOpacity:1,floodOpacity:1,stopOpacity:1,strokeDasharray:1,strokeDashoffset:1,strokeMiterlimit:1,strokeOpacity:1,strokeWidth:1};var se="undefined"!=typeof process&&void 0!==process.env&&(process.env.REACT_APP_SC_ATTR||process.env.SC_ATTR)||"data-styled",ce="active",ue="data-styled-version",de="6.1.8",pe="/*!sc*/\n",me="undefined"!=typeof window&&"HTMLElement"in window,ge=Boolean("boolean"==typeof SC_DISABLE_SPEEDY?SC_DISABLE_SPEEDY:"undefined"!=typeof process&&void 0!==process.env&&void 0!==process.env.REACT_APP_SC_DISABLE_SPEEDY&&""!==process.env.REACT_APP_SC_DISABLE_SPEEDY?"false"!==process.env.REACT_APP_SC_DISABLE_SPEEDY&&process.env.REACT_APP_SC_DISABLE_SPEEDY:"undefined"!=typeof process&&void 0!==process.env&&void 0!==process.env.SC_DISABLE_SPEEDY&&""!==process.env.SC_DISABLE_SPEEDY&&"false"!==process.env.SC_DISABLE_SPEEDY&&process.env.SC_DISABLE_SPEEDY),he={},ye=(new Set,Object.freeze([])),fe=Object.freeze({});function be(e,t,n){return void 0===n&&(n=fe),e.theme!==n.theme&&e.theme||t||n.theme}var ve=new Set(["a","abbr","address","area","article","aside","audio","b","base","bdi","bdo","big","blockquote","body","br","button","canvas","caption","cite","code","col","colgroup","data","datalist","dd","del","details","dfn","dialog","div","dl","dt","em","embed","fieldset","figcaption","figure","footer","form","h1","h2","h3","h4","h5","h6","header","hgroup","hr","html","i","iframe","img","input","ins","kbd","keygen","label","legend","li","link","main","map","mark","menu","menuitem","meta","meter","nav","noscript","object","ol","optgroup","option","output","p","param","picture","pre","progress","q","rp","rt","ruby","s","samp","script","section","select","small","source","span","strong","style","sub","summary","sup","table","tbody","td","textarea","tfoot","th","thead","time","tr","track","u","ul","use","var","video","wbr","circle","clipPath","defs","ellipse","foreignObject","g","image","line","linearGradient","marker","mask","path","pattern","polygon","polyline","radialGradient","rect","stop","svg","text","tspan"]),Ee=/[!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~-]+/g,we=/(^-|-$)/g;function _e(e){return e.replace(Ee,"-").replace(we,"")}var Ce=/(a)(d)/gi,Se=52,xe=function(e){return String.fromCharCode(e+(e>25?39:97))};function ke(e){var t,n="";for(t=Math.abs(e);t>Se;t=t/Se|0)n=xe(t%Se)+n;return(xe(t%Se)+n).replace(Ce,"$1-$2")}var Re,Pe=5381,Oe=function(e,t){for(var n=t.length;n;)e=33*e^t.charCodeAt(--n);return e},Te=function(e){return Oe(Pe,e)};function De(e){return ke(Te(e)>>>0)}function Ne(e){return e.displayName||e.name||"Component"}function Ae(e){return"string"==typeof e&&!0}var Ie="function"==typeof Symbol&&Symbol.for,$e=Ie?Symbol.for("react.memo"):60115,Fe=Ie?Symbol.for("react.forward_ref"):60112,He={childContextTypes:!0,contextType:!0,contextTypes:!0,defaultProps:!0,displayName:!0,getDefaultProps:!0,getDerivedStateFromError:!0,getDerivedStateFromProps:!0,mixins:!0,propTypes:!0,type:!0},Be={name:!0,length:!0,prototype:!0,caller:!0,callee:!0,arguments:!0,arity:!0},Le={$$typeof:!0,compare:!0,defaultProps:!0,displayName:!0,propTypes:!0,type:!0},je=((Re={})[Fe]={$$typeof:!0,render:!0,defaultProps:!0,displayName:!0,propTypes:!0},Re[$e]=Le,Re);function Me(e){return("type"in(t=e)&&t.type.$$typeof)===$e?Le:"$$typeof"in e?je[e.$$typeof]:He;var t}var ze=Object.defineProperty,We=Object.getOwnPropertyNames,Ue=Object.getOwnPropertySymbols,Ge=Object.getOwnPropertyDescriptor,Ye=Object.getPrototypeOf,Ve=Object.prototype;function Ke(e,t,n){if("string"!=typeof t){if(Ve){var a=Ye(t);a&&a!==Ve&&Ke(e,a,n)}var l=We(t);Ue&&(l=l.concat(Ue(t)));for(var i=Me(e),r=Me(t),o=0;o<l.length;++o){var s=l[o];if(!(s in Be||n&&n[s]||r&&s in r||i&&s in i)){var c=Ge(t,s);try{ze(e,s,c)}catch(e){}}}}return e}function Je(e){return"function"==typeof e}function Ze(e){return"object"==typeof e&&"styledComponentId"in e}function qe(e,t){return e&&t?"".concat(e," ").concat(t):e||t||""}function Xe(e,t){if(0===e.length)return"";for(var n=e[0],a=1;a<e.length;a++)n+=t?t+e[a]:e[a];return n}function Qe(e){return null!==e&&"object"==typeof e&&e.constructor.name===Object.name&&!("props"in e&&e.$$typeof)}function et(e,t,n){if(void 0===n&&(n=!1),!n&&!Qe(e)&&!Array.isArray(e))return t;if(Array.isArray(t))for(var a=0;a<t.length;a++)e[a]=et(e[a],t[a]);else if(Qe(t))for(var a in t)e[a]=et(e[a],t[a]);return e}function tt(e,t){Object.defineProperty(e,"toString",{value:t})}function nt(e){for(var t=[],n=1;n<arguments.length;n++)t[n-1]=arguments[n];return new Error("An error occurred. See https://github.com/styled-components/styled-components/blob/main/packages/styled-components/src/utils/errors.md#".concat(e," for more information.").concat(t.length>0?" Args: ".concat(t.join(", ")):""))}var at=function(){function e(e){this.groupSizes=new Uint32Array(512),this.length=512,this.tag=e}return e.prototype.indexOfGroup=function(e){for(var t=0,n=0;n<e;n++)t+=this.groupSizes[n];return t},e.prototype.insertRules=function(e,t){if(e>=this.groupSizes.length){for(var n=this.groupSizes,a=n.length,l=a;e>=l;)if((l<<=1)<0)throw nt(16,"".concat(e));this.groupSizes=new Uint32Array(l),this.groupSizes.set(n),this.length=l;for(var i=a;i<l;i++)this.groupSizes[i]=0}for(var r=this.indexOfGroup(e+1),o=(i=0,t.length);i<o;i++)this.tag.insertRule(r,t[i])&&(this.groupSizes[e]++,r++)},e.prototype.clearGroup=function(e){if(e<this.length){var t=this.groupSizes[e],n=this.indexOfGroup(e),a=n+t;this.groupSizes[e]=0;for(var l=n;l<a;l++)this.tag.deleteRule(n)}},e.prototype.getGroup=function(e){var t="";if(e>=this.length||0===this.groupSizes[e])return t;for(var n=this.groupSizes[e],a=this.indexOfGroup(e),l=a+n,i=a;i<l;i++)t+="".concat(this.tag.getRule(i)).concat(pe);return t},e}(),lt=new Map,it=new Map,rt=1,ot=function(e){if(lt.has(e))return lt.get(e);for(;it.has(rt);)rt++;var t=rt++;return lt.set(e,t),it.set(t,e),t},st=function(e,t){rt=t+1,lt.set(e,t),it.set(t,e)},ct="style[".concat(se,"][").concat(ue,'="').concat(de,'"]'),ut=new RegExp("^".concat(se,'\\.g(\\d+)\\[id="([\\w\\d-]+)"\\].*?"([^"]*)')),dt=function(e,t,n){for(var a,l=n.split(","),i=0,r=l.length;i<r;i++)(a=l[i])&&e.registerName(t,a)},pt=function(e,t){for(var n,a=(null!==(n=t.textContent)&&void 0!==n?n:"").split(pe),l=[],i=0,r=a.length;i<r;i++){var o=a[i].trim();if(o){var s=o.match(ut);if(s){var c=0|parseInt(s[1],10),u=s[2];0!==c&&(st(u,c),dt(e,u,s[3]),e.getTag().insertRules(c,l)),l.length=0}else l.push(o)}}};function mt(){return n.nc}var gt=function(e){var t=document.head,n=e||t,a=document.createElement("style"),l=function(e){var t=Array.from(e.querySelectorAll("style[".concat(se,"]")));return t[t.length-1]}(n),i=void 0!==l?l.nextSibling:null;a.setAttribute(se,ce),a.setAttribute(ue,de);var r=mt();return r&&a.setAttribute("nonce",r),n.insertBefore(a,i),a},ht=function(){function e(e){this.element=gt(e),this.element.appendChild(document.createTextNode("")),this.sheet=function(e){if(e.sheet)return e.sheet;for(var t=document.styleSheets,n=0,a=t.length;n<a;n++){var l=t[n];if(l.ownerNode===e)return l}throw nt(17)}(this.element),this.length=0}return e.prototype.insertRule=function(e,t){try{return this.sheet.insertRule(t,e),this.length++,!0}catch(e){return!1}},e.prototype.deleteRule=function(e){this.sheet.deleteRule(e),this.length--},e.prototype.getRule=function(e){var t=this.sheet.cssRules[e];return t&&t.cssText?t.cssText:""},e}(),yt=function(){function e(e){this.element=gt(e),this.nodes=this.element.childNodes,this.length=0}return e.prototype.insertRule=function(e,t){if(e<=this.length&&e>=0){var n=document.createTextNode(t);return this.element.insertBefore(n,this.nodes[e]||null),this.length++,!0}return!1},e.prototype.deleteRule=function(e){this.element.removeChild(this.nodes[e]),this.length--},e.prototype.getRule=function(e){return e<this.length?this.nodes[e].textContent:""},e}(),ft=function(){function e(e){this.rules=[],this.length=0}return e.prototype.insertRule=function(e,t){return e<=this.length&&(this.rules.splice(e,0,t),this.length++,!0)},e.prototype.deleteRule=function(e){this.rules.splice(e,1),this.length--},e.prototype.getRule=function(e){return e<this.length?this.rules[e]:""},e}(),bt=me,vt={isServer:!me,useCSSOMInjection:!ge},Et=function(){function e(e,t,n){void 0===e&&(e=fe),void 0===t&&(t={});var l=this;this.options=a(a({},vt),e),this.gs=t,this.names=new Map(n),this.server=!!e.isServer,!this.server&&me&&bt&&(bt=!1,function(e){for(var t=document.querySelectorAll(ct),n=0,a=t.length;n<a;n++){var l=t[n];l&&l.getAttribute(se)!==ce&&(pt(e,l),l.parentNode&&l.parentNode.removeChild(l))}}(this)),tt(this,(function(){return function(e){for(var t=e.getTag(),n=t.length,a="",l=function(n){var l=function(e){return it.get(e)}(n);if(void 0===l)return"continue";var i=e.names.get(l),r=t.getGroup(n);if(void 0===i||0===r.length)return"continue";var o="".concat(se,".g").concat(n,'[id="').concat(l,'"]'),s="";void 0!==i&&i.forEach((function(e){e.length>0&&(s+="".concat(e,","))})),a+="".concat(r).concat(o,'{content:"').concat(s,'"}').concat(pe)},i=0;i<n;i++)l(i);return a}(l)}))}return e.registerId=function(e){return ot(e)},e.prototype.reconstructWithOptions=function(t,n){return void 0===n&&(n=!0),new e(a(a({},this.options),t),this.gs,n&&this.names||void 0)},e.prototype.allocateGSInstance=function(e){return this.gs[e]=(this.gs[e]||0)+1},e.prototype.getTag=function(){return this.tag||(this.tag=(e=function(e){var t=e.useCSSOMInjection,n=e.target;return e.isServer?new ft(n):t?new ht(n):new yt(n)}(this.options),new at(e)));var e},e.prototype.hasNameForId=function(e,t){return this.names.has(e)&&this.names.get(e).has(t)},e.prototype.registerName=function(e,t){if(ot(e),this.names.has(e))this.names.get(e).add(t);else{var n=new Set;n.add(t),this.names.set(e,n)}},e.prototype.insertRules=function(e,t,n){this.registerName(e,t),this.getTag().insertRules(ot(e),n)},e.prototype.clearNames=function(e){this.names.has(e)&&this.names.get(e).clear()},e.prototype.clearRules=function(e){this.getTag().clearGroup(ot(e)),this.clearNames(e)},e.prototype.clearTag=function(){this.tag=void 0},e}(),wt=/&/g,_t=/^\s*\/\/.*$/gm;function Ct(e,t){return e.map((function(e){return"rule"===e.type&&(e.value="".concat(t," ").concat(e.value),e.value=e.value.replaceAll(",",",".concat(t," ")),e.props=e.props.map((function(e){return"".concat(t," ").concat(e)}))),Array.isArray(e.children)&&"@keyframes"!==e.type&&(e.children=Ct(e.children,t)),e}))}function St(e){var t,n,a,l=void 0===e?fe:e,i=l.options,r=void 0===i?fe:i,o=l.plugins,s=void 0===o?ye:o,c=function(e,a,l){return l.startsWith(n)&&l.endsWith(n)&&l.replaceAll(n,"").length>0?".".concat(t):e},u=s.slice();u.push((function(e){e.type===m&&e.value.includes("&")&&(e.props[0]=e.props[0].replace(wt,n).replace(a,c))})),r.prefix&&u.push(te),u.push(Q);var d=function(e,l,i,o){void 0===l&&(l=""),void 0===i&&(i=""),void 0===o&&(o="&"),t=o,n=l,a=new RegExp("\\".concat(n,"\\b"),"g");var s=e.replace(_t,""),c=ne(i||l?"".concat(i," ").concat(l," { ").concat(s," }"):s);r.namespace&&(c=Ct(c,r.namespace));var d,p,m,g=[];return X(c,(d=u.concat((m=function(e){return g.push(e)},function(e){e.root||(e=e.return)&&m(e)})),p=P(d),function(e,t,n,a){for(var l="",i=0;i<p;i++)l+=d[i](e,t,n,a)||"";return l})),g};return d.hash=s.length?s.reduce((function(e,t){return t.name||nt(15),Oe(e,t.name)}),Pe).toString():"",d}var xt=new Et,kt=St(),Rt=r().createContext({shouldForwardProp:void 0,styleSheet:xt,stylis:kt}),Pt=Rt.Consumer,Ot=r().createContext(void 0);function Tt(){return(0,i.useContext)(Rt)}function Dt(e){var t=(0,i.useState)(e.stylisPlugins),n=t[0],a=t[1],l=Tt().styleSheet,o=(0,i.useMemo)((function(){var t=l;return e.sheet?t=e.sheet:e.target&&(t=t.reconstructWithOptions({target:e.target},!1)),e.disableCSSOMInjection&&(t=t.reconstructWithOptions({useCSSOMInjection:!1})),t}),[e.disableCSSOMInjection,e.sheet,e.target,l]),c=(0,i.useMemo)((function(){return St({options:{namespace:e.namespace,prefix:e.enableVendorPrefixes},plugins:n})}),[e.enableVendorPrefixes,e.namespace,n]);(0,i.useEffect)((function(){s()(n,e.stylisPlugins)||a(e.stylisPlugins)}),[e.stylisPlugins]);var u=(0,i.useMemo)((function(){return{shouldForwardProp:e.shouldForwardProp,styleSheet:o,stylis:c}}),[e.shouldForwardProp,o,c]);return r().createElement(Rt.Provider,{value:u},r().createElement(Ot.Provider,{value:c},e.children))}var Nt=function(){function e(e,t){var n=this;this.inject=function(e,t){void 0===t&&(t=kt);var a=n.name+t.hash;e.hasNameForId(n.id,a)||e.insertRules(n.id,a,t(n.rules,a,"@keyframes"))},this.name=e,this.id="sc-keyframes-".concat(e),this.rules=t,tt(this,(function(){throw nt(12,String(n.name))}))}return e.prototype.getName=function(e){return void 0===e&&(e=kt),this.name+e.hash},e}(),At=function(e){return e>="A"&&e<="Z"};function It(e){for(var t="",n=0;n<e.length;n++){var a=e[n];if(1===n&&"-"===a&&"-"===e[0])return e;At(a)?t+="-"+a.toLowerCase():t+=a}return t.startsWith("ms-")?"-"+t:t}var $t=function(e){return null==e||!1===e||""===e},Ft=function(e){var t,n,a=[];for(var i in e){var r=e[i];e.hasOwnProperty(i)&&!$t(r)&&(Array.isArray(r)&&r.isCss||Je(r)?a.push("".concat(It(i),":"),r,";"):Qe(r)?a.push.apply(a,l(l(["".concat(i," {")],Ft(r),!1),["}"],!1)):a.push("".concat(It(i),": ").concat((t=i,null==(n=r)||"boolean"==typeof n||""===n?"":"number"!=typeof n||0===n||t in oe||t.startsWith("--")?String(n).trim():"".concat(n,"px")),";")))}return a};function Ht(e,t,n,a){return $t(e)?[]:Ze(e)?[".".concat(e.styledComponentId)]:Je(e)?!Je(l=e)||l.prototype&&l.prototype.isReactComponent||!t?[e]:Ht(e(t),t,n,a):e instanceof Nt?n?(e.inject(n,a),[e.getName(a)]):[e]:Qe(e)?Ft(e):Array.isArray(e)?Array.prototype.concat.apply(ye,e.map((function(e){return Ht(e,t,n,a)}))):[e.toString()];var l}function Bt(e){for(var t=0;t<e.length;t+=1){var n=e[t];if(Je(n)&&!Ze(n))return!1}return!0}var Lt=Te(de),jt=function(){function e(e,t,n){this.rules=e,this.staticRulesId="",this.isStatic=(void 0===n||n.isStatic)&&Bt(e),this.componentId=t,this.baseHash=Oe(Lt,t),this.baseStyle=n,Et.registerId(t)}return e.prototype.generateAndInjectStyles=function(e,t,n){var a=this.baseStyle?this.baseStyle.generateAndInjectStyles(e,t,n):"";if(this.isStatic&&!n.hash)if(this.staticRulesId&&t.hasNameForId(this.componentId,this.staticRulesId))a=qe(a,this.staticRulesId);else{var l=Xe(Ht(this.rules,e,t,n)),i=ke(Oe(this.baseHash,l)>>>0);if(!t.hasNameForId(this.componentId,i)){var r=n(l,".".concat(i),void 0,this.componentId);t.insertRules(this.componentId,i,r)}a=qe(a,i),this.staticRulesId=i}else{for(var o=Oe(this.baseHash,n.hash),s="",c=0;c<this.rules.length;c++){var u=this.rules[c];if("string"==typeof u)s+=u;else if(u){var d=Xe(Ht(u,e,t,n));o=Oe(o,d+c),s+=d}}if(s){var p=ke(o>>>0);t.hasNameForId(this.componentId,p)||t.insertRules(this.componentId,p,n(s,".".concat(p),void 0,this.componentId)),a=qe(a,p)}}return a},e}(),Mt=r().createContext(void 0),zt=Mt.Consumer;function Wt(){var e=(0,i.useContext)(Mt);if(!e)throw nt(18);return e}function Ut(e){var t=r().useContext(Mt),n=(0,i.useMemo)((function(){return function(e,t){if(!e)throw nt(14);if(Je(e))return e(t);if(Array.isArray(e)||"object"!=typeof e)throw nt(8);return t?a(a({},t),e):e}(e.theme,t)}),[e.theme,t]);return e.children?r().createElement(Mt.Provider,{value:n},e.children):null}var Gt={};function Yt(e,t,n){var l=Ze(e),o=e,s=!Ae(e),c=t.attrs,u=void 0===c?ye:c,d=t.componentId,p=void 0===d?function(e,t){var n="string"!=typeof e?"sc":_e(e);Gt[n]=(Gt[n]||0)+1;var a="".concat(n,"-").concat(De(de+n+Gt[n]));return t?"".concat(t,"-").concat(a):a}(t.displayName,t.parentComponentId):d,m=t.displayName,g=void 0===m?function(e){return Ae(e)?"styled.".concat(e):"Styled(".concat(Ne(e),")")}(e):m,h=t.displayName&&t.componentId?"".concat(_e(t.displayName),"-").concat(t.componentId):t.componentId||p,y=l&&o.attrs?o.attrs.concat(u).filter(Boolean):u,f=t.shouldForwardProp;if(l&&o.shouldForwardProp){var b=o.shouldForwardProp;if(t.shouldForwardProp){var v=t.shouldForwardProp;f=function(e,t){return b(e,t)&&v(e,t)}}else f=b}var E=new jt(n,h,l?o.componentStyle:void 0);function w(e,t){return function(e,t,n){var l=e.attrs,o=e.componentStyle,s=e.defaultProps,c=e.foldedComponentIds,u=e.styledComponentId,d=e.target,p=r().useContext(Mt),m=Tt(),g=e.shouldForwardProp||m.shouldForwardProp,h=be(t,p,s)||fe,y=function(e,t,n){for(var l,i=a(a({},t),{className:void 0,theme:n}),r=0;r<e.length;r+=1){var o=Je(l=e[r])?l(i):l;for(var s in o)i[s]="className"===s?qe(i[s],o[s]):"style"===s?a(a({},i[s]),o[s]):o[s]}return t.className&&(i.className=qe(i.className,t.className)),i}(l,t,h),f=y.as||d,b={};for(var v in y)void 0===y[v]||"$"===v[0]||"as"===v||"theme"===v&&y.theme===h||("forwardedAs"===v?b.as=y.forwardedAs:g&&!g(v,f)||(b[v]=y[v]));var E=function(e,t){var n=Tt();return e.generateAndInjectStyles(t,n.styleSheet,n.stylis)}(o,y),w=qe(c,u);return E&&(w+=" "+E),y.className&&(w+=" "+y.className),b[Ae(f)&&!ve.has(f)?"class":"className"]=w,b.ref=n,(0,i.createElement)(f,b)}(_,e,t)}w.displayName=g;var _=r().forwardRef(w);return _.attrs=y,_.componentStyle=E,_.displayName=g,_.shouldForwardProp=f,_.foldedComponentIds=l?qe(o.foldedComponentIds,o.styledComponentId):"",_.styledComponentId=h,_.target=l?o.target:e,Object.defineProperty(_,"defaultProps",{get:function(){return this._foldedDefaultProps},set:function(e){this._foldedDefaultProps=l?function(e){for(var t=[],n=1;n<arguments.length;n++)t[n-1]=arguments[n];for(var a=0,l=t;a<l.length;a++)et(e,l[a],!0);return e}({},o.defaultProps,e):e}}),tt(_,(function(){return".".concat(_.styledComponentId)})),s&&Ke(_,e,{attrs:!0,componentStyle:!0,displayName:!0,foldedComponentIds:!0,shouldForwardProp:!0,styledComponentId:!0,target:!0}),_}function Vt(e,t){for(var n=[e[0]],a=0,l=t.length;a<l;a+=1)n.push(t[a],e[a+1]);return n}new Set;var Kt=function(e){return Object.assign(e,{isCss:!0})};function Jt(e){for(var t=[],n=1;n<arguments.length;n++)t[n-1]=arguments[n];if(Je(e)||Qe(e))return Kt(Ht(Vt(ye,l([e],t,!0))));var a=e;return 0===t.length&&1===a.length&&"string"==typeof a[0]?Ht(a):Kt(Ht(Vt(a,t)))}function Zt(e,t,n){if(void 0===n&&(n=fe),!t)throw nt(1,t);var i=function(a){for(var i=[],r=1;r<arguments.length;r++)i[r-1]=arguments[r];return e(t,n,Jt.apply(void 0,l([a],i,!1)))};return i.attrs=function(l){return Zt(e,t,a(a({},n),{attrs:Array.prototype.concat(n.attrs,l).filter(Boolean)}))},i.withConfig=function(l){return Zt(e,t,a(a({},n),l))},i}var qt=function(e){return Zt(Yt,e)},Xt=qt;ve.forEach((function(e){Xt[e]=qt(e)}));var Qt=function(){function e(e,t){this.rules=e,this.componentId=t,this.isStatic=Bt(e),Et.registerId(this.componentId+1)}return e.prototype.createStyles=function(e,t,n,a){var l=a(Xe(Ht(this.rules,t,n,a)),""),i=this.componentId+e;n.insertRules(i,i,l)},e.prototype.removeStyles=function(e,t){t.clearRules(this.componentId+e)},e.prototype.renderStyles=function(e,t,n,a){e>2&&Et.registerId(this.componentId+e),this.removeStyles(e,n),this.createStyles(e,t,n,a)},e}();function en(e){for(var t=[],n=1;n<arguments.length;n++)t[n-1]=arguments[n];var i=Jt.apply(void 0,l([e],t,!1)),o="sc-global-".concat(De(JSON.stringify(i))),s=new Qt(i,o),c=function(e){var t=Tt(),n=r().useContext(Mt),a=r().useRef(t.styleSheet.allocateGSInstance(o)).current;return t.styleSheet.server&&u(a,e,t.styleSheet,n,t.stylis),r().useLayoutEffect((function(){if(!t.styleSheet.server)return u(a,e,t.styleSheet,n,t.stylis),function(){return s.removeStyles(a,t.styleSheet)}}),[a,e,t.styleSheet,n,t.stylis]),null};function u(e,t,n,l,i){if(s.isStatic)s.renderStyles(e,he,n,i);else{var r=a(a({},t),{theme:be(t,l,c.defaultProps)});s.renderStyles(e,r,n,i)}}return r().memo(c)}function tn(e){for(var t=[],n=1;n<arguments.length;n++)t[n-1]=arguments[n];var a=Xe(Jt.apply(void 0,l([e],t,!1))),i=De(a);return new Nt(i,a)}function nn(e){var t=r().forwardRef((function(t,n){var l=be(t,r().useContext(Mt),e.defaultProps);return r().createElement(e,a({},t,{theme:l,ref:n}))}));return t.displayName="WithTheme(".concat(Ne(e),")"),Ke(t,e)}var an=function(){function e(){var e=this;this._emitSheetCSS=function(){var t=e.instance.toString(),n=mt(),a=Xe([n&&'nonce="'.concat(n,'"'),"".concat(se,'="true"'),"".concat(ue,'="').concat(de,'"')].filter(Boolean)," ");return"<style ".concat(a,">").concat(t,"</style>")},this.getStyleTags=function(){if(e.sealed)throw nt(2);return e._emitSheetCSS()},this.getStyleElement=function(){var t;if(e.sealed)throw nt(2);var n=((t={})[se]="",t[ue]=de,t.dangerouslySetInnerHTML={__html:e.instance.toString()},t),l=mt();return l&&(n.nonce=l),[r().createElement("style",a({},n,{key:"sc-0-0"}))]},this.seal=function(){e.sealed=!0},this.instance=new Et({isServer:!0}),this.sealed=!1}return e.prototype.collectStyles=function(e){if(this.sealed)throw nt(2);return r().createElement(Dt,{sheet:this.instance},e)},e.prototype.interleaveWithNodeStream=function(e){throw nt(3)},e}(),ln={StyleSheet:Et,mainSheet:xt};"__sc-".concat(se,"__")},196:e=>{"use strict";e.exports=window.React}},t={};function n(a){var l=t[a];if(void 0!==l)return l.exports;var i=t[a]={exports:{}};return e[a](i,i.exports,n),i.exports}n.n=e=>{var t=e&&e.__esModule?()=>e.default:()=>e;return n.d(t,{a:t}),t},n.d=(e,t)=>{for(var a in t)n.o(t,a)&&!n.o(e,a)&&Object.defineProperty(e,a,{enumerable:!0,get:t[a]})},n.o=(e,t)=>Object.prototype.hasOwnProperty.call(e,t),n.r=e=>{"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})},n.nc=void 0,(()=>{"use strict";var e=n(196),t=n.n(e);const a=window.wp.element,l=window.wp.apiFetch;var i=n.n(l);function r(t,n){const a=(0,e.useRef)();(0,e.useEffect)((()=>{a.current=t}),[t]),(0,e.useEffect)((()=>{if(null!==n){let e=setInterval((function(){a.current()}),n);return()=>clearInterval(e)}}),[n])}const{__}=wp.i18n,o=(0,a.createContext)(),s=function(t){const n={destination_scheme:"https://",destination_host:"",temp_files_dir:options.temp_files_dir,additional_urls:"",additional_files:"",urls_to_exclude:"wp-json\nwp-login.php",delivery_method:"zip",local_dir:"",relative_path:"",destination_url_type:"relative",debugging_mode:!0,http_basic_auth_username:"",http_basic_auth_password:"",origin_url:"",version:options.version,force_replace_url:!1,clear_directory_before_export:!1,ssh_security_token:"",ssh_use_forms:!0,ssh_404_page_id:"",ssh_thank_you_page_id:"",tiiny_email:options.admin_email,tiiny_subdomain:"",tiiny_domain_suffix:"tiiny.site",tiiny_password:"",cdn_api_key:"",cdn_storage_host:"storage.bunnycdn.com",cdn_access_key:"",cdn_pull_zone:"",cdn_storage_zone:"",cdn_directory:"",cdn_404:"",github_account_type:"personal",github_user:"",github_email:"",github_personal_access_token:"",github_repository:"",github_repository_visibility:"public",github_branch:"main",github_webhook_url:"",github_folder_path:"",aws_region:"us-east-2",aws_access_key:"",aws_access_secret:"",aws_bucket:"",aws_subdirectory:"",aws_distribution_id:"",aws_empty:!1,digitalocean_key:"",digitalocean_secret:"",digitalocean_bucket:"",digitalocean_region:"",fix_cors:"allowed_http_origins",static_url:"",use_forms:!1,use_comments:!1,comment_redirect:"",use_search:!1,search_type:"fuse",search_index_title:"title",search_index_content:"body",search_index_excerpt:".entry-content",search_excludable:"",search_metadata:"",fuse_selector:".search-field",algolia_app_id:"",algolia_admin_api_key:"",algolia_search_api_key:"",algolia_index:"simply_static",algolia_selector:".search-field",use_minify:!1,minify_html:!1,minify_css:!1,minify_inline_css:!1,minify_js:!1,minify_inline_js:!1,generate_404:!1,wp_content_folder:"",wp_includes_folder:"",wp_uploads_folder:"",wp_plugins_folder:"",wp_themes_folder:"",theme_style_name:"style",rename_plugin_folders:!1,author_url:"",hide_rest_api:!1,hide_style_id:!1,hide_comments:!1,hide_version:!1,hide_generator:!1,hide_prefetch:!1,hide_rsd:!1,hide_emotes:!1,disable_xmlrpc:!1,disable_embed:!1,disable_db_debug:!1,disable_wlw_manifest:!1},[l,s]=(0,a.useState)(!1),[c,u]=(0,a.useState)(!1),[d,p]=(0,a.useState)(n),[m,g]=(0,a.useState)({}),[h,y]=(0,a.useState)(1),f=()=>{i()({path:"/simplystatic/v1/is-running",method:"GET"}).then((e=>{var t=JSON.parse(e);s(t.running)}))};return r((()=>{f()}),l?5e3:null),(0,a.useEffect)((()=>{i()({path:"/simplystatic/v1/settings"}).then((e=>{p(e)})),i()({path:"/simplystatic/v1/system-status"}).then((e=>{g(e)})),f(),y(options.blog_id)}),[]),(0,e.createElement)(o.Provider,{value:{settings:d,configs:m,settingsSaved:c,setSettingsSaved:u,updateSetting:(e,t)=>{p({...d,[e]:t})},setSettings:p,saveSettings:()=>{i()({path:"/simplystatic/v1/settings",method:"POST",data:d})},resetSettings:()=>{p(n),i()({path:"/simplystatic/v1/settings/reset",method:"POST",data:n})},updateFromNetwork:e=>{i()({path:"/simplystatic/v1/update-from-network",method:"POST",data:{blog_id:e}})},importSettings:e=>{p(e),i()({path:"/simplystatic/v1/settings",method:"POST",data:e})},migrateSettings:()=>{i()({path:"/simplystatic/v1/migrate",method:"POST",migrate:!0})},isRunning:l,setIsRunning:s,blogId:h,setBlogId:y}},t.children)},c=window.wp.components,{__:u}=wp.i18n,d=function(){const{settings:t,updateSetting:n,saveSettings:l,settingsSaved:i,setSettingsSaved:r}=(0,a.useContext)(o),[s,d]=(0,a.useState)("relative"),[p,m]=(0,a.useState)("https://"),[g,h]=(0,a.useState)(""),[y,f]=(0,a.useState)("/"),[b,v]=(0,a.useState)(!1),[E,w]=(0,a.useState)(!1),[_,C]=(0,a.useState)(!1);return(0,a.useEffect)((()=>{t.destination_url_type&&d(t.destination_url_type),t.destination_scheme&&m(t.destination_scheme),t.destination_host&&h(t.destination_host),t.relative_path&&f(t.relative_path),t.force_replace_url&&v(t.force_replace_url),t.generate_404&&C(t.generate_404)}),[t]),(0,e.createElement)("div",{className:"inner-settings"},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,u("Replacing URLs","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,u("When exporting your static site, any links to your WordPress site will be replaced by one of the following: absolute URLs, relative URLs, or URLs contructed for offline use.","simply-static")),(0,e.createElement)(c.SelectControl,{label:u("Replacing URLs","simply-static"),value:s,options:[{label:u("Absolute URLs","simply-static"),value:"absolute"},{label:u("Relative Path","simply-static"),value:"relative"},{label:u("Offline Usage","simply-static"),value:"offline"}],onChange:e=>{d(e),n("destination_url_type",e)}}),"absolute"===s&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,{style:{minWidth:"15%"}},(0,e.createElement)(c.SelectControl,{label:u("Scheme","simply-static"),value:p,options:[{label:"https://",value:"https://"},{label:"http://",value:"http://"},{label:"//",value:"//"}],onChange:e=>{m(e),n("destination_scheme",e)}})),(0,e.createElement)(c.FlexItem,{style:{minWidth:"85%"}},(0,e.createElement)(c.TextControl,{label:u("Host","simply-static"),type:"text",placeholder:"example.com",value:g,onChange:e=>{h(e),n("destination_host",e)}}))),(0,e.createElement)("p",null,u("Convert all URLs for your WordPress site to absolute URLs at the domain specified above.","simply-static"))),"relative"===s&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.TextControl,{label:u("Path","simply-static"),type:"text",placeholder:"/",value:y,onChange:e=>{f(e),n("relative_path",e)}}),(0,e.createElement)("p",null,u("Convert all URLs for your WordPress site to relative URLs that will work at any domain.","simply-static"),(0,e.createElement)("br",null),u("Optionally specify a path above if you intend to place the files in a subdirectory.","simply-static")),(0,e.createElement)("p",null,(0,e.createElement)(c.Notice,{status:"warning",isDismissible:!1},(0,e.createElement)("b",null,u("Example","simply-static"),": "),u("enter /path above if you wanted to serve your files at www.example.com/path/","simply-static")))),"offline"===s&&(0,e.createElement)("p",null,u("Convert all URLs for your WordPress site so that you can browse the site locally on your own computer without hosting it on a web server.","simply-static")),(0,e.createElement)(c.ToggleControl,{label:u("Force URL replacements","simply-static"),help:u(b?"Replace all occurrences of the WordPress URL with the static URL (includes inline CSS and JS).":"Replace only occurrences of the WordPress URL that match our tag list.","simply-static"),checked:b,onChange:e=>{v(e),n("force_replace_url",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,u("Include","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextareaControl,{label:u("Additional URLs","simply-static"),placeholder:options.home+"/hidden-page/",help:u("If you want to create static copies of pages or files that aren't linked to, add the URLs here (one per line).","simply-static"),value:t.additional_urls,onChange:e=>{n("additional_urls",e)}}),(0,e.createElement)(c.TextareaControl,{label:u("Additional Files and Directories","simply-static"),placeholder:options.home_path+"additional-directory/\n"+options.home_path+"additional-file.html",help:u("Sometimes you may want to include additional files (such as files referenced via AJAX) or directories. Add the paths to those files or directories here (one per line).","simply-static"),value:t.additional_files,onChange:e=>{n("additional_files",e)}}),(0,e.createElement)(c.ClipboardButton,{variant:"secondary",text:options.home_path,onCopy:()=>w(!0),onFinishCopy:()=>w(!1)},u(E?"Copied home path":"Copy home path","simply-static")),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.ToggleControl,{label:u("Generate 404 Page?","simply-static"),help:u(_?"Generate a 404 page.":"Don't generate a 404 page.","simply-static"),checked:_,onChange:e=>{C(e),n("generate_404",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,u("Exclude","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextareaControl,{label:u("Urls to exclude","simply-static"),placeholder:"wp-json.php\nwp-login.php\n.jpg",help:u("Specify URLs (or parts of URLs) you want to exclude from the processing (one per line).","simply-static"),value:t.urls_to_exclude,onChange:e=>{n("urls_to_exclude",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),i&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,u("Settings saved successfully.","simply-static"))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5})),(0,e.createElement)("div",{className:"save-settings"},(0,e.createElement)(c.Button,{onClick:()=>{l(),r(!0),setTimeout((function(){r(!1)}),2e3)},variant:"primary"},u("Save Settings","simply-static"))))},p=function(){const{configs:t}=(0,a.useContext)(o);return(0,e.createElement)("div",{className:"inner-settings"},(0,e.createElement)("div",null,Object.keys(t).map((n=>{const a=t[n];return(0,e.createElement)("div",{key:n},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,n)),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("div",null,(0,e.createElement)("table",{style:{width:"100%",tableLayout:"fixed"}},(0,e.createElement)("tbody",{className:"table-data"},Object.entries(a).map((t=>(0,e.createElement)("tr",{className:"table-row",key:t[0]},(0,e.createElement)("td",{className:"diagnostics-icon"}," ",t[1].test?(0,e.createElement)(c.Dashicon,{className:"icon-yes",icon:"yes"}):(0,e.createElement)(c.Dashicon,{className:"icon-no",icon:"no"})),(0,e.createElement)("td",{className:"diagnostics-test"},(0,e.createElement)("b",null,t[0])),(0,e.createElement)("td",null,t[1].test),(0,e.createElement)("td",{className:"diagnostics-result"}," ",t[1].test?(0,e.createElement)("p",null,t[1].description):(0,e.createElement)("p",null,t[1].error)))))))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}))}))))},{__:m}=wp.i18n,g=function(){const{settings:t,importSettings:n,saveSettings:l,resetSettings:i,migrateSettings:r}=(0,a.useContext)(o),[s,u]=(0,a.useState)(!1),[d,p]=(0,a.useState)(!1),[g,h]=(0,a.useState)(!1),[y,f]=(0,a.useState)(!1),[b,v]=(0,a.useState)(!1),[E,w]=(0,a.useState)(!1);return(0,e.createElement)("div",{className:"inner-settings"},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,m("Migrate Settings","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,m("Migrate all of your settings to Simply Static 3.0","simply-static")),(0,e.createElement)("p",null,(0,e.createElement)(c.Button,{onClick:()=>{r(),l(),f(!0),setTimeout((function(){f(!1),location.reload()}),2e3)},variant:"primary"},m("Migrate settings","simply-static"))),y?(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,m("Settings migration successfully.","simply-static"))))):"")),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,m("Export","simply-static"))),(0,e.createElement)(c.CardBody,null,s?(0,e.createElement)(e.Fragment,null,(0,e.createElement)("p",null,(0,e.createElement)("code",null,JSON.stringify(t))),(0,e.createElement)("p",null,(0,e.createElement)(c.ClipboardButton,{variant:"secondary",text:JSON.stringify(t),onCopy:()=>v(!0),onFinishCopy:()=>v(!1)},m(b?"Copied!":"Copy export data","simply-static")))):(0,e.createElement)("p",null,(0,e.createElement)(c.Button,{onClick:u,variant:"primary"},m("Export Settings","simply-static"))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,m("Import","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,m("Paste in the JSON string you got from your export to import all settings for the plugin.","simply-static")),(0,e.createElement)("p",null,(0,e.createElement)("textarea",{rows:"8",cols:"60",name:"import-data",onChange:e=>{w(JSON.parse(e.target.value))}})),(0,e.createElement)("p",null,(0,e.createElement)(c.Button,{onClick:()=>{n(E),p(!0),setTimeout((function(){p(!1)}),2e3)},variant:"primary"},m("Import Settings","simply-static"))),d?(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,m("Settings imported successfully.","simply-static"))))):"")),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,m("Reset Plugin Data","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,m("By clicking the following button, you will reset all plugin settings. This can be useful if you want to import a new set of settings or you want a fresh start.","simply-static")),(0,e.createElement)("p",null,(0,e.createElement)(c.Button,{onClick:()=>{i(),h(!0),setTimeout((function(){h(!1)}),2e3)},variant:"secondary"},m("Reset Plugin Settings","simply-static"))),g?(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,m("Settings resetted successfully.","simply-static"))))):"")))},{__:h}=wp.i18n,y=function(){const{settings:t,updateSetting:n,saveSettings:l,settingsSaved:r,setSettingsSaved:s}=(0,a.useContext)(o),[u,d]=(0,a.useState)("zip"),[p,m]=(0,a.useState)(!1),[g,y]=(0,a.useState)("personal"),[f,b]=(0,a.useState)("private"),[v,E]=(0,a.useState)(!1),[w,_]=(0,a.useState)(!0),[C,S]=(0,a.useState)("us-east-2"),[x,k]=(0,a.useState)(!1),[R,P]=(0,a.useState)(!1);return(0,a.useEffect)((()=>{t.delivery_method&&d(t.delivery_method),t.clear_directory_before_export&&m(t.clear_directory_before_export),t.ssh_use_forms&&_(t.ssh_use_forms),t.github_account_type&&y(t.github_account_type),t.github_repository_visibility&&b(t.github_repository_visibility),t.github_repository_visibility&&b(t.github_repository_visibility),t.aws_empty&&E(t.aws_empty),t.aws_region&&S(t.aws_region),i()({path:"/simplystatic/v1/pages"}).then((e=>{let t=e;t.unshift({label:h("No page selected","simply-static"),value:0}),P(t)}))}),[t]),(0,e.createElement)("div",{className:"inner-settings"},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,h("Deployment Settings","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,h("Choose from a variety of deployment methods. Depending on your selection we either provide a ZIP file, export to a local directory or send your files to a remote destination.","simply-static")),"pro"===options.plan?(0,e.createElement)(c.SelectControl,{label:h("Deployment method","simply-static"),value:u,options:[{label:h("ZIP Archive","simply-static"),value:"zip"},{label:h("GitHub","simply-static"),value:"github"},{label:h("AWS S3","simply-static"),value:"aws-s3"},{label:h("Tiiny.host","simply-static"),value:"tiiny"},{label:h("Bunny CDN","simply-static"),value:"cdn"},{label:h("Simply CDN","simply-static"),value:"simply-cdn"},{label:h("Local Directory","simply-static"),value:"local"},{label:h("Digital Ocean Spaces","simply-static"),value:"digitalocean"}],onChange:e=>{d(e),n("delivery_method",e)}}):(0,e.createElement)(c.SelectControl,{label:h("Deployment method","simply-static"),value:u,options:[{label:h("ZIP Archive","simply-static"),value:"zip"},{label:h("Local Directory","simply-static"),value:"local"},{label:h("Simply CDN","simply-static"),value:"simply-cdn"}],onChange:e=>{d(e),n("delivery_method",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),"local"===u&&(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,h("Local Directory","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextControl,{label:h("Path","simply-static"),type:"text",help:h("This is the directory where your static files will be saved. The directory must exist and be writeable by the webserver","simply-static"),placeholder:options.home_path+"public_static/",value:t.local_dir,onChange:e=>{n("local_dir",e)}}),(0,e.createElement)("p",null,(0,e.createElement)(c.ClipboardButton,{variant:"secondary",text:options.home_path,onCopy:()=>k(!0),onFinishCopy:()=>k(!1)},h(x?"Copied home path":"Copy home path","simply-static"))),(0,e.createElement)("p",null,(0,e.createElement)(c.ToggleControl,{label:h("Clear Local Directory","simply-static"),help:h(p?"Clear local directory before running an export.":"Don't clear local directory before running an export.","simply-static"),checked:p,onChange:e=>{m(e),n("clear_directory_before_export",e)}})))),"simply-cdn"===u&&(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,h("Simply CDN","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,h("The fast and easy way to bring your static website online. Simply CDN handles hosting, performance, security and form submissions for your static site.","simply-static")),(0,e.createElement)(c.TextControl,{label:h("Security Token","simply-static"),type:"text",help:h("Copy and paste the Security Token from your project.","simply-static"),value:t.ssh_security_token,onChange:e=>{n("ssh_security_token",e)}}),t.ssh_security_token&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.SelectControl,{label:h("Select a 404 page","content-protector"),options:R,help:h("We will use that page as a 404 error page on your static website.","simply-static"),value:t.ssh_404_page_id,onChange:e=>{n("ssh_404_page_id",e)}}),(0,e.createElement)(c.ToggleControl,{label:h("Use Forms?","simply-static"),help:h(w?"Proxy form submissions through Simply CDN.":"Don't proxy form submissions through Simply CDN.","simply-static"),checked:w,onChange:e=>{_(e),n("ssh_use_forms",e)}}),w&&(0,e.createElement)(c.SelectControl,{label:h('Select a "Thank You" page',"simply-static"),options:R,help:h("We will use that page to redirect your visitors after submitting a form on your static website.","simply-static"),value:t.ssh_thank_you_page_id,onChange:e=>{n("ssh_thank_you_page_id",e)}})))),"pro"===options.plan&&(0,e.createElement)(e.Fragment,null,"github"===u&&(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,h("GitHub","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,h("GitHub enables you to export your static website to one of the common static hosting providers like Netlify, Cloudflare Pages or GitHub Pages.","simply-static")),(0,e.createElement)(c.SelectControl,{label:h("Account Type","simply-static"),value:g,help:h("Depending on the account type the settings fields will change.","simply-static"),options:[{label:h("Personal","simply-static"),value:"personal"},{label:h("Organization","simply-static"),value:"organization"}],onChange:e=>{y(e),n("github_account_type",e)}}),"organization"===g?(0,e.createElement)(c.TextControl,{label:h("Organization","simply-static"),type:"text",help:h("Enter the name of your organization.","simply-static"),value:t.github_user,onChange:e=>{n("github_user",e)}}):(0,e.createElement)(c.TextControl,{label:h("Username","simply-static"),type:"text",help:h("Enter your GitHub username.","simply-static"),value:t.github_user,onChange:e=>{n("github_user",e)}}),(0,e.createElement)(c.TextControl,{label:h("E-Mail","simply-static"),type:"email",help:h("Enter your GitHub email address. This will be used to commit files to your repository.","simply-static"),value:t.github_email,onChange:e=>{n("github_email",e)}}),(0,e.createElement)(c.TextControl,{label:h("Personal Access Token","simply-static"),type:"password",help:h("You need a personal access token from GitHub.","simply-static"),value:t.github_personal_access_token,onChange:e=>{n("github_personal_access_token",e)}}),(0,e.createElement)(c.TextControl,{label:h("Repository","simply-static"),type:"text",help:h("Enter a name for your repository. This should be lowercase and without any spaces or special characters.","simply-static"),value:t.github_repository,onChange:e=>{n("github_repository",e)}}),(0,e.createElement)(c.TextControl,{label:h("Folder","simply-static"),type:"text",help:h("Enter a relative path to a folder if you want to push files under it. Example: for github.com/USER/REPOSITORY/folder1, enter folder1","simply-static"),value:t.github_folder_path,onChange:e=>{n("github_folder_path",e)}}),"organization"===g&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Notice,{status:"warning",isDismissible:!1},(0,e.createElement)("p",null,h("You need to create the repository manually within your organization before connecting it.","simply-static"))),(0,e.createElement)(c.__experimentalSpacer,{margin:5})),(0,e.createElement)(c.SelectControl,{label:h("Visiblity","simply-static"),value:f,help:h("Decide if you want to make your repository public or private.","simply-static"),options:[{label:h("Public","simply-static"),value:"public"},{label:h("Private","simply-static"),value:"private"}],onChange:e=>{b(e),n("github_repository_visibility",e)}}),(0,e.createElement)(c.TextControl,{label:h("Branch","simply-static"),type:t.github_branch,placeholder:"main",help:h('Simply Static automatically uses "main" as branch. You may want to modify that for example to gh-pages. for GitHub Pages.',"simply-static"),value:t.github_branch,onChange:e=>{n("github_branch",e)}}),(0,e.createElement)(c.TextControl,{label:h("Webhook URL","simply-static"),type:"url",help:h("Enter your Webhook URL here and Simply Static will send a POST request after all files are commited to GitHub.","simply-static"),value:t.github_webhook_url,onChange:e=>{n("github_webhook_url",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),"tiiny"===u&&(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,h("Tiiny.host","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,h("Deploying to Tiiny.host is the easiest and fastest deployment option available in Simply Static Pro.","simply-static")),(0,e.createElement)(c.TextControl,{disabled:!0,label:h("E-Mail","simply-static"),type:"text",help:h("This field is auto-filled with the e-mail address used for activating Simply Static Pro. An account will be created automatically on your first deployment.","simply-static"),value:options.admin_email}),(0,e.createElement)(c.TextControl,{label:h("Subdomain","simply-static"),type:"text",help:h("That's the part before your TLD. Your full URL is the combination of the subdomain plus the domain suffix.","simply-static"),value:t.tiiny_subdomain,onChange:e=>{n("tiiny_subdomain",e)}}),(0,e.createElement)(c.TextControl,{label:h("Domain Suffix","simply-static"),type:"text",help:h("This defaults to tiiny.site. If you have a custom domain configured in Tiiny.host, you can also use  that one.","simply-static"),value:t.tiiny_domain_suffix,onChange:e=>{n("tiiny_domain_suffix",e)}}),(0,e.createElement)(c.TextControl,{label:h("Password Protection","simply-static"),type:"password",help:h("Adding a password will activate password protection on your static site. The website is only visible with the password.","simply-static"),value:t.tiiny_password,onChange:e=>{n("tiiny_password",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),"cdn"===u&&(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,h("Bunny CDN","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,h("Bunny CDN is a fast and reliable CDN provider that you can run your static website on.","simply-static")),(0,e.createElement)(c.TextControl,{label:h("Bunny CDN API Key","simply-static"),type:"password",help:h("Enter your API Key from Bunny CDN. You can find your API-Key as described here.","simply-static"),value:t.cdn_api_key,onChange:e=>{n("cdn_api_key",e)}}),(0,e.createElement)(c.TextControl,{label:h("Storage Host","simply-static"),type:"text",help:h("Depending on your location, you have a different storage host. You find out which URL to use here.","simply-static"),value:t.cdn_storage_host,onChange:e=>{n("cdn_storage_host",e)}}),(0,e.createElement)(c.TextControl,{label:h("Bunny CDN Access Key","simply-static"),type:"password",help:h("Enter your Acess Key from Bunny CDN. You will find it within your storage zone setttings within FTP & API Access -> Password.","simply-static"),value:t.cdn_access_key,onChange:e=>{n("cdn_access_key",e)}}),(0,e.createElement)(c.TextControl,{label:h("Pull Zone","simply-static"),type:"text",help:h("A pull zone is the connection of your CDN to the internet. Simply Static will try to find an existing pull zone with the provided name, if there is none it creates a new pull zone.","simply-static"),value:t.cdn_pull_zone,onChange:e=>{n("cdn_pull_zone",e)}}),(0,e.createElement)(c.TextControl,{label:h("Storage Zone","simply-static"),type:"text",help:h("A storage zone contains your static files. Simply Static will try to find an existing storage zone with the provided name, if there is none it creates a new storage zone.","simply-static"),value:t.cdn_storage_zone,onChange:e=>{n("cdn_storage_zone",e)}}),(0,e.createElement)(c.TextControl,{label:h("Subdirectory","simply-static"),type:"text",placeholder:"/subdirectory/",help:h("If you want to transfer the files to a specific subdirectory on your storage zone add the name of that directory here.","simply-static"),value:t.cdn_directory,onChange:e=>{n("cdn_directory",e)}}),(0,e.createElement)(c.TextControl,{label:h("404 Page","simply-static"),type:"text",placeholder:"/custom-404/",help:h("Relative path to your custom 404 page.","simply-static"),value:t.cdn_404,onChange:e=>{n("cdn_404",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),"aws-s3"===u&&(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,h("Amazon AWS S3","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextControl,{label:h("Access Key ID","simply-static"),type:"text",help:h("Enter your Access Key from AWS.","simply-static"),value:t.aws_access_key,onChange:e=>{n("aws_access_key",e)}}),(0,e.createElement)(c.TextControl,{label:h("Secret Access Key","simply-static"),type:"password",help:h("Enter your Secret Key from AWS.","simply-static"),value:t.aws_access_secret,onChange:e=>{n("aws_access_secret",e)}}),(0,e.createElement)(c.SelectControl,{label:h("Region","simply-static"),value:C,options:[{label:h("US East (Ohio)","simply-static"),value:"us-east-2"},{label:h("US East (N. Virginia)","simply-static"),value:"us-east-1"},{label:h("US West (N. California)","simply-static"),value:"us-west-1"},{label:h("US West (Oregon)","simply-static"),value:"us-west-2"},{label:h("Africa (Cape Town)","simply-static"),value:"af-south-1"},{label:h("Asia Pacific (Hong Kong)","simply-static"),value:"ap-east-1"},{label:h("Asia Pacific (Hyderabad)","simply-static"),value:"ap-south-2"},{label:h("Asia Pacific (Jakarta)","simply-static"),value:"ap-southeast-3"},{label:h("Asia Pacific (Melbourne)","simply-static"),value:"ap-southeast-4"},{label:h("Asia Pacific (Mumbai)","simply-static"),value:"ap-south-1"},{label:h("Asia Pacific (Osaka)","simply-static"),value:"ap-northeast-3"},{label:h("Asia Pacific (Seoul)","simply-static"),value:"ap-northeast-2"},{label:h("Asia Pacific (Singapore)","simply-static"),value:"ap-southeast-1"},{label:h("Asia Pacific (Sydney)","simply-static"),value:"ap-southeast-2"},{label:h("Asia Pacific (Tokyo)","simply-static"),value:"ap-northeast-1"},{label:h("Canada (Central)","simply-static"),value:"ca-central-1"},{label:h("Europe (Frankfurt)","simply-static"),value:"eu-central-1"},{label:h("Europe (Ireland)","simply-static"),value:"eu-west-1"},{label:h("Europe (London)","simply-static"),value:"eu-west-2"},{label:h("Europe (Milan)","simply-static"),value:"eu-south-1"},{label:h("Europe (Paris)","simply-static"),value:"eu-west-3"},{label:h("Europe (Spain)","simply-static"),value:"eu-south-2"},{label:h("Europe (Stockholm)","simply-static"),value:"eu-north-1"},{label:h("Europe (Zurich)","simply-static"),value:"eu-central-2"},{label:h("Middle East (Bahrain)","simply-static"),value:"me-south-1"},{label:h("Middle East (UAE)","simply-static"),value:"me-central-1"},{label:h("South America (São Paulo)","simply-static"),value:"sa-east-1"},{label:h("AWS GovCloud (US-East)","simply-static"),value:"us-gov-east-1"},{label:h("AWS GovCloud (US-West)","simply-static"),value:"us-gov-west-1"}],onChange:e=>{S(e),n("aws_region",e)}}),(0,e.createElement)(c.TextControl,{label:h("Bucket","simply-static"),type:"text",help:h("Add the name of your bucket here.","simply-static"),value:t.aws_bucket,onChange:e=>{n("aws_bucket",e)}}),(0,e.createElement)(c.TextControl,{label:h("Subdirectory","simply-static"),type:"text",help:h("Add an optional subdirectory for your bucket","simply-static"),value:t.aws_subdirectory,onChange:e=>{n("aws_subdirectory",e)}}),(0,e.createElement)(c.TextControl,{label:h("Cloudfront Distribution ID","simply-static"),type:"text",help:h("We automatically invalidate the cache after each export.","simply-static"),value:t.aws_distribution_id,onChange:e=>{n("aws_distribution_id",e)}}),(0,e.createElement)(c.ToggleControl,{label:h("Empty bucket before new export?","simply-static"),help:h(v?"Clear bucket before new export.":"Don't clear bucket before new export.","simply-static"),checked:v,onChange:e=>{E(e),n("aws_empty",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),"digitalocean"===u&&(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,h("Digital Ocean Spaces","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextControl,{label:h("Spaces Key","simply-static"),type:"text",help:h("Enter your Spaces Key from Digital Ocean.","simply-static"),value:t.digitalocean_key,onChange:e=>{n("digitalocean_key",e)}}),(0,e.createElement)(c.TextControl,{label:h("Secret","simply-static"),type:"password",help:h("Enter your Spaces Secret from Digital Ocean.","simply-static"),value:t.digitalocean_secret,onChange:e=>{n("digitalocean_secret",e)}}),(0,e.createElement)(c.TextControl,{label:h("Bucket Name","simply-static"),help:h("The bucket name for your space.","simply-static"),type:"text",placeholder:"my-bucket",value:t.digitalocean_bucket,onChange:e=>{n("digitalocean_bucket",e)}}),(0,e.createElement)(c.TextControl,{label:h("Region","simply-static"),type:"text",help:h("The region for your space.","simply-static"),placeholder:"ams3",value:t.digitalocean_region,onChange:e=>{n("digitalocean_region",e)}}),(0,e.createElement)("p",null,t.digitalocean_bucket&&t.digitalocean_region&&(0,e.createElement)(c.Notice,{status:"warning",isDismissible:!1},h("Your endpoint will be","simply-static")," :","https://"+t.digitalocean_bucket+"."+t.digitalocean_region+".digitaloceanspaces.com"))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),r&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,h("Settings saved successfully.","simply-static"))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5})),(0,e.createElement)("div",{className:"save-settings"},(0,e.createElement)(c.Button,{onClick:()=>{l(),s(!0),setTimeout((function(){s(!1)}),2e3)},variant:"primary"},h("Save Settings","simply-static"))))},{__:f}=wp.i18n,b=function(){const{settings:t,updateSetting:n,saveSettings:l,settingsSaved:i,setSettingsSaved:r}=(0,a.useContext)(o),[s,u]=(0,a.useState)("allowed_http_origins"),[d,p]=(0,a.useState)(!1),[m,g]=(0,a.useState)(!1);return(0,a.useEffect)((()=>{t.fix_cors&&u(t.fix_cors),t.use_forms&&p(t.use_forms),t.use_comments&&g(t.use_comments)}),[t]),(0,e.createElement)("div",{className:"inner-settings"},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,f("Forms","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.ToggleControl,{label:f("Use forms?","simply-static"),help:f(d?"Use Forms on your static website.":"Don't use forms on your static website.","simply-static"),checked:d,onChange:e=>{p(e),n("use_forms",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,f("Comments","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.ToggleControl,{label:f("Use comments?","simply-static"),help:f(m?"Use comments on your static website.":"Don't use comments on your static website.","simply-static"),checked:m,onChange:e=>{g(e),n("use_comments",e)}}),m&&(0,e.createElement)(c.TextControl,{label:f("Redirect URL","simply-static"),type:"url",placeholder:"https://static-example.com/thank-you",help:f("The page will be generated and committed automatically after a comment was added, but it might take a while so its good practice to redirect the visitor.","simply-static"),value:t.comment_redirect,onChange:e=>{n("comment_redirect",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,f("CORS","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,f("When using Forms and Comments in Simply Static Pro you may encouter CORS issues as you make requests from your static website to your original one.","simply-static")),(0,e.createElement)(c.Notice,{status:"warning",isDismissible:!1},(0,e.createElement)("p",null,f("Due to the variety of server setups out there, you may need to make changes on your server.","simply-static"))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.TextControl,{label:f("Static URL","simply-static"),type:"url",placeholder:"https://static-site.com",help:f("Add the URL of your static website to allow CORS from it.","simply-static"),value:t.static_url,onChange:e=>{n("static_url",e)}}),(0,e.createElement)(c.SelectControl,{label:f("Select CORS method","simply-static"),value:s,help:f("Choose one of the methods to allow CORS for your website.","simply-static"),options:[{label:"allowed_http_origins",value:"allowed_http_origins"},{label:"wp_headers",value:"wp_headers"}],onChange:e=>{u(e),n("fix_cors",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),i&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,f("Settings saved successfully.","simply-static"))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5})),(0,e.createElement)("div",{className:"save-settings"},(0,e.createElement)(c.Button,{onClick:()=>{l(),r(!0),setTimeout((function(){r(!1)}),2e3)},variant:"primary"},f("Save Settings","simply-static"))))},{__:v}=wp.i18n,E=function(){const{settings:t,updateSetting:n,saveSettings:l,settingsSaved:i,setSettingsSaved:r}=(0,a.useContext)(o),[s,u]=(0,a.useState)(!1),[d,p]=(0,a.useState)("fuse"),[m,g]=(0,a.useState)(!1),h=()=>g(!0);return(0,a.useEffect)((()=>{t.use_search&&u(t.use_search),t.search_type&&p(t.search_type)}),[t]),(0,e.createElement)("div",{className:"inner-settings"},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,v("Search","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.ToggleControl,{label:v("Use search?","simply-static"),help:v(s?"Use search on your static website.":"Don't use search on your static website.","simply-static"),checked:s,onChange:e=>{u(e),n("use_search",e)}}),s&&(0,e.createElement)(c.SelectControl,{label:v("Search Type","simply-static"),value:d,help:v("Decide wich search type you want to use. Fuse runs locally based on file and Algolia is an external API service.","simply-static"),options:[{label:"Fuse JS",value:"fuse"},{label:"Algolia API",value:"algolia"}],onChange:e=>{p(e),n("search_type",e)}}))),s&&(0,e.createElement)(e.Fragment,null,m&&(0,e.createElement)(c.Modal,{title:v("How to select data with meta tags","simply-static"),onRequestClose:()=>g(!1)},(0,e.createElement)("p",null,v("Targeting for excerpt in the meta description tag.","simply-static")),(0,e.createElement)("pre",null,'<meta name="description" content="This content is what we want as excerpt" />'),(0,e.createElement)("p",null,v("Adding such meta in the excerpt field would be:","simply-static")),(0,e.createElement)("pre",null,"description|content"),(0,e.createElement)("p",null,v("Targeting for title in the property meta tag.","simply-static")),(0,e.createElement)("pre",null,'<meta property="og:title" content="This content is what we want as excerpt" />'),(0,e.createElement)("p",null,v("Adding such meta in the excerpt field would be:","simply-static")),(0,e.createElement)("pre",null,"property|og:title"),(0,e.createElement)("p",null,v('If the second item (after | ) is not <code>content</code>, we\'ll use it as value of that attribute (<code>property="og:title"</code> in this example) and use <code>content</code> for value.',"simply-static")),(0,e.createElement)("p",null,(0,e.createElement)("strong",null,v("Caution: Use meta tags that exist everywhere for title.","simply-static")))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,v("Indexing","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextControl,{label:v("CSS-Selector for Title","simply-static"),type:"text",placeholder:"title",help:[v("Add the CSS selector which contains the title of the page/post","simply-static")," ",(0,e.createElement)(c.Button,{variant:"link",onClick:h},v("Or meta tags. Click for more information.","simply-static"))],value:t.search_index_title,onChange:e=>{n("search_index_title",e)}}),(0,e.createElement)(c.TextControl,{label:v("CSS-Selector for Content","simply-static"),type:"text",placeholder:"body",help:[v("Add the CSS selector which contains the content of the page/post.","simply-static")," ",(0,e.createElement)(c.Button,{variant:"link",onClick:h},v("Or meta tags. Click for more information.","simply-static"))],value:t.search_index_content,onChange:e=>{n("search_index_content",e)}}),(0,e.createElement)(c.TextControl,{label:v("CSS-Selector for Excerpt","simply-static"),type:"text",placeholder:".entry-content",help:[v("Add the CSS selector which contains the excerpt of the page/post.","simply-static")," ",(0,e.createElement)(c.Button,{variant:"link",onClick:h},v("Or meta tags. Click for more information.","simply-static"))],value:t.search_index_excerpt,onChange:e=>{n("search_index_excerpt",e)}}),(0,e.createElement)(c.TextareaControl,{label:v("Exclude URLs","simply-static"),placeholder:"author\narchive\ncategory",help:v("Exclude URLs from indexing (one per line). You can use full URLs, parts of an URL or plain words (like stop words).","simply-static"),value:t.search_excludable,onChange:e=>{n("search_excludable",e)}})))),s&&"fuse"===d&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,v("Fuse.js","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextControl,{label:v("CSS-Selector","simply-static"),type:"text",help:v("Add the CSS selector of your search element here.","simply-static"),value:t.fuse_selector,onChange:e=>{n("fuse_selector",e)}})))),s&&"algolia"===d&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,v("Algolia API","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextControl,{label:v("Application ID","simply-static"),type:"password",help:v("Add your Algolia App ID.","simply-static"),value:t.algolia_app_id,onChange:e=>{n("algolia_app_id",e)}}),(0,e.createElement)(c.TextControl,{label:v("Admin API Key","simply-static"),type:"password",help:v("Add your Algolia Admin API Key.","simply-static"),value:t.algolia_admin_api_key,onChange:e=>{n("algolia_admin_api_key",e)}}),(0,e.createElement)(c.TextControl,{label:v("Search-Only API Key","simply-static"),type:"password",help:v("Add your Algolia Search-Only API Key here. This is the only key that will be visible on your static site.","simply-static"),value:t.algolia_search_api_key,onChange:e=>{n("algolia_search_api_key",e)}}),(0,e.createElement)(c.TextControl,{label:v("Name for your index","simply-static"),type:"text",help:v("Add your Algolia index name here.","simply-static"),value:t.algolia_index,onChange:e=>{n("algolia_index",e)}}),(0,e.createElement)(c.TextControl,{label:v("CSS-Selector","simply-static"),type:"text",help:v("Add the CSS selector of your search element here.","simply-static"),value:t.algolia_selector,onChange:e=>{n("algolia_selector",e)}}),(0,e.createElement)("p",null,(0,e.createElement)(c.Notice,{status:"warning",isDismissible:!1},v("If you have multiple search elements with different CSS selectors, separate them by a comma (,) such as: .search-field, .search-field2","simply-static")))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),i&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,v("Settings saved successfully.","simply-static"))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5})),(0,e.createElement)("div",{className:"save-settings"},(0,e.createElement)(c.Button,{onClick:()=>{l(),r(!0),setTimeout((function(){r(!1)}),2e3)},variant:"primary"},v("Save Settings","simply-static"))))},{__:w}=wp.i18n,_=function(){const{settings:t,updateSetting:n,saveSettings:l,settingsSaved:i,setSettingsSaved:r}=(0,a.useContext)(o),[s,u]=(0,a.useState)(!1);return(0,a.useEffect)((()=>{t.debugging_mode&&u(t.debugging_mode)}),[t]),(0,e.createElement)("div",{className:"inner-settings"},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,w("Temporary Files","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,w("Your static files are temporarily saved to a directory before being copied to their destination or creating a ZIP.","simply-static")),(0,e.createElement)(c.TextControl,{label:w("Temporary Files Directory","simply-static"),type:"text",placeholder:options.temp_files_dir,help:w("Specify the directory to save your temporary files. This directory must exist and be writeable.","simply-static"),value:t.temp_files_dir,onChange:e=>{n("temp_files_dir",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,w("Basic Auth","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,w("If you've secured WordPress with HTTP Basic Auth you can specify the username and password to use below.","simply-static")),(0,e.createElement)(c.TextControl,{label:w("Basic Auth Username","simply-static"),autoComplete:"off",type:"text",value:t.http_basic_auth_username,onChange:e=>{n("http_basic_auth_username",e)}}),(0,e.createElement)(c.TextControl,{label:w("Basic Auth Password","simply-static"),type:"password",autoComplete:"off",value:t.http_basic_auth_password,onChange:e=>{n("http_basic_auth_password",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,w("Debugging","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.ToggleControl,{label:w("Debugging Mode","simply-static"),help:w(s?"Enable debugging mode.":"Disable debugging mode.","simply-static"),checked:s,onChange:e=>{u(e),n("debugging_mode",e)}}),(0,e.createElement)(c.TextControl,{label:w("Origin URL","simply-static"),type:"url",help:w("If the URL of your WordPress installation differs from the public-facing URL (Proxy Setup), add the public URL here.","simply-static"),placeholder:options.home,autoComplete:"off",value:t.origin_url,onChange:e=>{n("origin_url",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),i&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,w("Settings saved successfully.","simply-static"))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5})),(0,e.createElement)("div",{className:"save-settings"},(0,e.createElement)(c.Button,{onClick:()=>{l(),r(!0),setTimeout((function(){r(!1)}),2e3)},variant:"primary"},w("Save Settings","simply-static"))))};function C(e,t){var n="function"==typeof Symbol&&e[Symbol.iterator];if(!n)return e;var a,l,i=n.call(e),r=[];try{for(;(void 0===t||t-- >0)&&!(a=i.next()).done;)r.push(a.value)}catch(e){l={error:e}}finally{try{a&&!a.done&&(n=i.return)&&n.call(i)}finally{if(l)throw l.error}}return r}"function"==typeof SuppressedError&&SuppressedError;var S,x,k=function(e){var n=e.children;return t().createElement("div",{className:"react-terminal-line"},n)};!function(e,t){void 0===t&&(t={});var n=t.insertAt;if(e&&"undefined"!=typeof document){var a=document.head||document.getElementsByTagName("head")[0],l=document.createElement("style");l.type="text/css","top"===n&&a.firstChild?a.insertBefore(l,a.firstChild):a.appendChild(l),l.styleSheet?l.styleSheet.cssText=e:l.appendChild(document.createTextNode(e))}}("/**\n * Modfied version of [termynal.js](https://github.com/ines/termynal/blob/master/termynal.css).\n *\n * @author Ines Montani <ines@ines.io>\n * @version 0.0.1\n * @license MIT\n */\n .react-terminal-wrapper {\n  width: 100%;\n  background: #252a33;\n  color: #eee;\n  font-size: 18px;\n  font-family: 'Fira Mono', Consolas, Menlo, Monaco, 'Courier New', Courier, monospace;\n  border-radius: 4px;\n  padding: 75px 45px 35px;\n  position: relative;\n  -webkit-box-sizing: border-box;\n          box-sizing: border-box;\n }\n\n.react-terminal {\n  overflow: auto;\n  display: flex;\n  flex-direction: column;\n}\n\n.react-terminal-wrapper.react-terminal-light {\n  background: #ddd;\n  color: #1a1e24;\n}\n\n.react-terminal-window-buttons {\n  position: absolute;\n  top: 15px;\n  left: 15px;\n  display: flex;\n  flex-direction: row;\n  gap: 10px;\n}\n\n.react-terminal-window-buttons button {\n  width: 15px;\n  height: 15px;\n  border-radius: 50%;\n  border: 0;\n}\n\n.react-terminal-window-buttons button.clickable {\n  cursor: pointer;\n}\n\n.react-terminal-window-buttons button.red-btn {\n  background: #d9515d;\n}\n\n.react-terminal-window-buttons button.yellow-btn {\n  background: #f4c025;\n}\n\n.react-terminal-window-buttons button.green-btn {\n  background: #3ec930;\n}\n\n.react-terminal-wrapper:after {\n  content: attr(data-terminal-name);\n  position: absolute;\n  color: #a2a2a2;\n  top: 5px;\n  left: 0;\n  width: 100%;\n  text-align: center;\n  pointer-events: none;\n}\n\n.react-terminal-wrapper.react-terminal-light:after {\n  color: #D76D77;\n}\n\n.react-terminal-line {\n  white-space: pre;\n}\n\n.react-terminal-line:before {\n  /* Set up defaults and ensure empty lines are displayed. */\n  content: '';\n  display: inline-block;\n  vertical-align: middle;\n  color: #a2a2a2;\n}\n\n.react-terminal-light .react-terminal-line:before {\n  color: #D76D77;\n}\n\n.react-terminal-input:before {\n  margin-right: 0.75em;\n  content: '$';\n}\n\n.react-terminal-input[data-terminal-prompt]:before {\n  content: attr(data-terminal-prompt);\n}\n\n.react-terminal-wrapper:focus-within .react-terminal-active-input .cursor {\n  position: relative;\n  display: inline-block;\n  width: 0.55em;\n  height: 1em;\n  top: 0.225em;\n  background: #fff;\n  -webkit-animation: blink 1s infinite;\n          animation: blink 1s infinite;\n}\n\n/* Cursor animation */\n\n@-webkit-keyframes blink {\n  50% {\n      opacity: 0;\n  }\n}\n\n@keyframes blink {\n  50% {\n      opacity: 0;\n  }\n}\n\n.terminal-hidden-input {\n    position: fixed;\n    left: -1000px;\n}\n\n/* .react-terminal-progress {\n  display: flex;\n  margin: .5rem 0;\n}\n\n.react-terminal-progress-bar {\n  background-color: #fff;\n  border-radius: .25rem;\n  width: 25%;\n}\n\n.react-terminal-wrapper.react-terminal-light .react-terminal-progress-bar {\n  background-color: #000;\n} */\n"),(x=S||(S={}))[x.Light=0]="Light",x[x.Dark=1]="Dark";var R=function(n){var a=n.name,l=n.prompt,i=n.height,r=void 0===i?"600px":i,o=n.colorMode,s=n.onInput,c=n.children,u=n.startingInputValue,d=void 0===u?"":u,p=n.redBtnCallback,m=n.yellowBtnCallback,g=n.greenBtnCallback,h=C((0,e.useState)(""),2),y=h[0],f=h[1],b=C((0,e.useState)(0),2),v=b[0],E=b[1],w=(0,e.useRef)(null);(0,e.useEffect)((function(){f(d.trim())}),[d]),(0,e.useEffect)((function(){var e,t;if(null!=s){var n=[],a=function(e){var t=function(){var t;return null===(t=null==e?void 0:e.querySelector(".terminal-hidden-input"))||void 0===t?void 0:t.focus()};null==e||e.addEventListener("click",t),n.push({terminalEl:e,listener:t})};try{for(var l=function(e){var t="function"==typeof Symbol&&Symbol.iterator,n=t&&e[t],a=0;if(n)return n.call(e);if(e&&"number"==typeof e.length)return{next:function(){return e&&a>=e.length&&(e=void 0),{value:e&&e[a++],done:!e}}};throw new TypeError(t?"Object is not iterable.":"Symbol.iterator is not defined.")}(document.getElementsByClassName("react-terminal-wrapper")),i=l.next();!i.done;i=l.next())a(i.value)}catch(t){e={error:t}}finally{try{i&&!i.done&&(t=l.return)&&t.call(l)}finally{if(e)throw e.error}}return function(){n.forEach((function(e){e.terminalEl.removeEventListener("click",e.listener)}))}}}),[s]);var _=["react-terminal-wrapper"];return o===S.Light&&_.push("react-terminal-light"),t().createElement("div",{className:_.join(" "),"data-terminal-name":a},t().createElement("div",{className:"react-terminal-window-buttons"},t().createElement("button",{className:(m?"clickable":"")+" red-btn",disabled:!p,onClick:p}),t().createElement("button",{className:(m?"clickable":"")+" yellow-btn",disabled:!m,onClick:m}),t().createElement("button",{className:(g?"clickable":"")+" green-btn",disabled:!g,onClick:g})),t().createElement("div",{className:"react-terminal",style:{height:r}},c,"function"==typeof s&&t().createElement("div",{className:"react-terminal-line react-terminal-input react-terminal-active-input","data-terminal-prompt":l||"$",key:"terminal-line-prompt"},y,t().createElement("span",{className:"cursor",style:{left:v+1+"px"}})),t().createElement("div",{ref:w})),t().createElement("input",{className:"terminal-hidden-input",placeholder:"Terminal Hidden Input",value:y,autoFocus:null!=s,onChange:function(e){f(e.target.value)},onKeyDown:function(e){var t,n;if(s)if("Enter"===e.key)s(y),E(0),f(""),setTimeout((function(){var e;return null===(e=null==w?void 0:w.current)||void 0===e?void 0:e.scrollIntoView({behavior:"auto",block:"nearest"})}),500);else if(["ArrowLeft","ArrowRight","ArrowDown","ArrowUp","Delete"].includes(e.key)){var a=e.currentTarget,l="",i=y.length-(a.selectionStart||0);i=(t=i)>(n=y.length)?n:t<0?0:t,"ArrowLeft"===e.key?(i>y.length-1&&i--,l=y.slice(y.length-1-i)):"ArrowRight"===e.key||"Delete"===e.key?l=y.slice(y.length-i+1):"ArrowUp"===e.key&&(l=y.slice(0));var r=function(e,t){var n=document.createElement("span");n.style.visibility="hidden",n.style.position="absolute",n.style.fontSize=window.getComputedStyle(e).fontSize,n.style.fontFamily=window.getComputedStyle(e).fontFamily,n.innerText=t,document.body.appendChild(n);var a=n.getBoundingClientRect().width;return document.body.removeChild(n),-a}(a,l);E(r)}}}))};const{__:P}=wp.i18n,O=function(){const{isRunning:t,blogId:n}=(0,a.useContext)(o),[l,s]=(0,a.useState)([(0,e.createElement)(k,null,"Waiting for new export..")]);function c(){i()({path:"/simplystatic/v1/activity-log?blog_id="+n+"&is_network_admin="+options.is_network,method:"GET"}).then((t=>{var n=JSON.parse(t),a=[];for(var l in n.data){var i=n.data[l].datetime,r=n.data[l].message;a.push((0,e.createElement)(k,null,"[",i,"] ",(0,e.createElement)("span",{dangerouslySetInnerHTML:{__html:r}})))}s(a)}))}return r((()=>{c()}),t?2500:null),(0,a.useEffect)((()=>{t&&s([(0,e.createElement)(k,null,"Waiting for new export..")]),c()}),[t]),(0,e.createElement)(R,{name:P("Activity Log","simply-static"),height:"250px",colorMode:S.Dark},l)};var T=n(44);const D=function(){const{isRunning:t,blogId:n}=(0,a.useContext)(o),[l,s]=(0,a.useState)([]),[c,u]=(0,a.useState)(!1),[d,p]=(0,a.useState)(25),[m,g]=(0,a.useState)(0),h=[{name:"Code",selector:e=>e.code,sortable:!1,maxWidth:"100px"},{name:"URL",selector:t=>(0,e.createElement)("a",{target:"_blank",href:t.url},t.url),sortable:!1},{name:"Notes",wrap:!0,selector:t=>(0,e.createElement)("span",{dangerouslySetInnerHTML:{__html:t.notes}})}];function y(e,t=!1){var a;((e=null!==(a=e)&&void 0!==a?a:1)!==m||t)&&u(!0),i()({path:`/simplystatic/v1/export-log?page=${e}&per_page=${d}&blog_id=${n}&is_network_admin=${options.is_network}`,method:"GET"}).then((n=>{var a=JSON.parse(n);e!==m||t?(s(a.data),u(!1)):(l.total_static_pages=a.data.total_static_pages,s(l)),g(e)}))}return r((()=>{y()}),t?5e3:null),(0,a.useEffect)((()=>{y(1,!0)}),[t]),(0,e.createElement)(T.ZP,{columns:h,data:l.static_pages,pagination:!0,paginationServer:!0,paginationTotalRows:l.total_static_pages,paginationPerPage:25,paginationRowsPerPageOptions:[25,50,100,200],progressPending:c,onChangeRowsPerPage:(e,t)=>{p(e),y(t,!0)},onChangePage:e=>{y(e)}})},{__:N}=wp.i18n,A=function(){const[t,n]=(0,a.useState)(!1);return(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Button,{variant:"primary",href:options.log_file,download:!0,style:{marginRight:"10px"}},N("Download Log","simply-static")),(0,e.createElement)(c.Button,{variant:"secondary",onClick:()=>{i()({path:"/simplystatic/v1/delete-log",method:"POST"}),n(!0),setTimeout((function(){n(!1)}),2e3)}},N("Clear Log","simply-static")),t&&(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,N("Log file cleared.","simply-static"))))))},{__:I}=wp.i18n,$=function(){const{settings:t,blogId:n,setBlogId:l}=(0,a.useContext)(o),[i,r]=(0,a.useState)(""),[s,u]=(0,a.useState)("");return(0,e.createElement)("div",{className:"inner-settings settings-wide"},!options.is_network&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(O,null),(0,e.createElement)(c.__experimentalSpacer,{margin:5})),(0,e.createElement)(c.Flex,{align:"top"},options.is_network&&(0,e.createElement)(c.FlexItem,{isBlock:!0},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,I("Multisite","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.SelectControl,{label:I("Choose a site to export","simply-static"),value:n,options:options.sites.map((function(e){return{label:`${e.name} (${e.url})`,value:e.blog_id}})),onChange:e=>{l(e),options.sites.some((t=>{t.blog_id===e&&(r(t.settings_url),u(t.activity_log_url))}))}}),i&&(0,e.createElement)("p",null,(0,e.createElement)(c.Button,{isPrimary:!0,href:i},"Switch to Site settings"),(0,e.createElement)(c.Button,{style:{marginLeft:"5px"},isSecondary:!0,href:s},"Check progress"))))),t.debugging_mode&&options.log_file&&!options.is_network&&(0,e.createElement)(c.FlexItem,{isBlock:!0},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,I("Debugging","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(A,null))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,I("Export Log","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(D,null))))},{__:F}=wp.i18n,H=function(){const{settings:t,updateSetting:n,saveSettings:l,settingsSaved:i,setSettingsSaved:r}=(0,a.useContext)(o),[s,u]=(0,a.useState)(!1),[d,p]=(0,a.useState)(!1),[m,g]=(0,a.useState)(!1),[h,y]=(0,a.useState)(!1),[f,b]=(0,a.useState)(!1),[v,E]=(0,a.useState)(!1),[w,_]=(0,a.useState)(!1),[C,S]=(0,a.useState)("wp-content"),[x,k]=(0,a.useState)("wp-includes"),[R,P]=(0,a.useState)("wp-content/uploads"),[O,T]=(0,a.useState)("wp-content/plugins"),[D,N]=(0,a.useState)("wp-content/themes"),[A,I]=(0,a.useState)("style"),[$,H]=(0,a.useState)("author"),[B,L]=(0,a.useState)(!1),[j,M]=(0,a.useState)(!1),[z,W]=(0,a.useState)(!1),[U,G]=(0,a.useState)(!1),[Y,V]=(0,a.useState)(!1),[K,J]=(0,a.useState)(!1),[Z,q]=(0,a.useState)(!1),[X,Q]=(0,a.useState)(!1),[ee,te]=(0,a.useState)(!1),[ne,ae]=(0,a.useState)(!1),[le,ie]=(0,a.useState)(!1),[re,oe]=(0,a.useState)(!1),[se,ce]=(0,a.useState)(!1);return(0,a.useEffect)((()=>{t.use_minify&&u(t.use_minify),t.minify_html&&p(t.minify_html),t.minify_css&&g(t.minify_css),t.minify_inline_css&&y(t.minify_inline_css),t.minify_js&&b(t.minify_js),t.minify_inline_js&&E(t.minify_inline_js),t.wp_content_directory&&S(t.wp_content_directory),t.wp_includes_directory&&k(t.wp_includes_directory),t.wp_uploads_directory&&P(t.wp_uploads_directory),t.wp_plugins_directory&&T(t.wp_plugins_directory),t.rename_plugin_directories&&setRenamePluginDirectorys(t.rename_plugin_directories),t.wp_themes_directory&&N(t.wp_themes_directory),t.theme_style_name&&I(t.theme_style_name),t.author_url&&H(t.author_url),t.hide_rest_api&&L(t.hide_rest_api),t.hide_style_id&&M(t.hide_style_id),t.hide_comments&&W(t.hide_comments),t.hide_version&&G(t.hide_version),t.hide_generator&&J(t.hide_generator),t.hide_prefetch&&V(t.hide_prefetch),t.hide_rsd&&q(t.hide_rsd),t.hide_emotes&&Q(t.hide_emotes),t.disable_xmlrpc&&te(t.disable_xmlrpc),t.disable_embed&&ae(t.disable_embed),t.disable_db_debug&&ie(t.disable_db_debug),t.disable_wlw_manifest&&oe(t.disable_wlw_manifest),t.disable_directory_browsing&&ce(t.disable_directory_browsing)}),[t]),(0,e.createElement)("div",{className:"inner-settings"},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,F("Minify","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.ToggleControl,{label:F("Minify Files?","simply-static"),help:F(s?"Enable minify files on your static website.":"Don't enable minify files on your static website.","simply-static"),checked:s,onChange:e=>{u(e),n("use_minify",e)}}),s&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.ToggleControl,{label:F("Minify HTML","simply-static"),help:F(d?"Minify HTML files.":"Don't minify HTML files.","simply-static"),checked:d,onChange:e=>{p(e),n("minify_html",e)}}),(0,e.createElement)(c.ToggleControl,{label:F("Minify CSS","simply-static"),help:F(m?"Minify CSS files.":"Don't minify CSS files.","simply-static"),checked:m,onChange:e=>{g(e),n("minify_css",e)}}),m&&(0,e.createElement)(c.ToggleControl,{label:F("Minify Inline CSS","simply-static"),help:F(h?"Minify Inline CSS.":"Don't minify Inline CSS.","simply-static"),checked:h,onChange:e=>{y(e),n("minify_inline_css",e)}}),(0,e.createElement)(c.ToggleControl,{label:F("Minify JavaScript","simply-static"),help:F(f?"Minify JavaScript files.":"Don't minify JavaScript files.","simply-static"),checked:f,onChange:e=>{b(e),n("minify_js",e)}}),f&&(0,e.createElement)(c.ToggleControl,{label:F("Minify Inline JavaScript","simply-static"),help:F(v?"Minify Inline JavaScript.":"Don't minify Inline JavaScript.","simply-static"),checked:v,onChange:e=>{E(e),n("minify_inline_js",e)}})))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,F("Replace","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextControl,{label:F("wp-content directory","simply-static"),help:F('Replace the "wp-content" directory.',"simply-static"),type:"text",placeholder:"wp-content",value:C,onChange:e=>{n("wp_content_directory",e)}}),(0,e.createElement)(c.TextControl,{label:F("wp-includes directory","simply-static"),help:F('Replace the "wp-includes" directory.',"simply-static"),type:"text",placeholder:"wp-includes",value:x,onChange:e=>{n("wp_includes_directory",e)}}),(0,e.createElement)(c.TextControl,{label:F("uploads directory","simply-static"),help:F('Replace the "wp-content/uploads" directory.',"simply-static"),type:"text",placeholder:"uploads",value:R,onChange:e=>{P(e),n("wp_uploads_directory",e)}}),(0,e.createElement)(c.TextControl,{label:F("plugins directory","simply-static"),help:F('Replace the "wp-content/plugins" directory.',"simply-static"),type:"text",placeholder:"plugins",value:O,onChange:e=>{T(e),n("wp_plugins_directory",e)}}),(0,e.createElement)(c.ToggleControl,{label:F("Replace Plugin Names?","simply-static"),help:F(w?"Replace plugin names with a random string combinations.":"Keep plugin names.","simply-static"),checked:w,onChange:e=>{_(e),n("rename_plugins",e)}}),(0,e.createElement)(c.TextControl,{label:F("themes directory","simply-static"),help:F('Replace the "wp-content/themes" directory.',"simply-static"),type:"text",placeholder:"themes",value:D,onChange:e=>{N(e),n("wp_themes_directory",e)}}),(0,e.createElement)(c.__experimentalInputControl,{label:F("Theme style name","simply-static"),help:F("Replace the style.css filename.","simply-static"),type:"text",className:"ss-theme-style-name",suffix:".css",placeholder:"style",value:A,onChange:e=>{I(e),n("theme_style_name",e)}}),(0,e.createElement)(c.TextControl,{label:F("Author URL","simply-static"),help:F("Replace the author url.","simply-static"),type:"text",placeholder:"author",value:$,onChange:e=>{H(e),n("author_url",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,F("Hide","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.ToggleControl,{label:F("Hide REST API URLs","simply-static"),checked:B,onChange:e=>{L(e),n("hide_rest_api",e)}}),(0,e.createElement)(c.ToggleControl,{label:F("Hide Style/Script IDs","simply-static"),checked:j,onChange:e=>{M(e),n("hide_style_id",e)}}),(0,e.createElement)(c.ToggleControl,{label:F("Hide HTML Comments","simply-static"),checked:z,onChange:e=>{W(e),n("hide_comments",e)}}),(0,e.createElement)(c.ToggleControl,{label:F("Hide WordPress Version","simply-static"),checked:U,onChange:e=>{G(e),n("hide_version",e)}}),(0,e.createElement)(c.ToggleControl,{label:F("Hide WordPress Generator Meta","simply-static"),checked:K,onChange:e=>{J(e),n("hide_generator",e)}}),(0,e.createElement)(c.ToggleControl,{label:F("Hide DNS Prefetch WordPress link","simply-static"),checked:Y,onChange:e=>{V(e),n("hide_prefetch",e)}}),(0,e.createElement)(c.ToggleControl,{label:F("Hide RSD Header","simply-static"),checked:Z,onChange:e=>{q(e),n("hide_rsd",e)}}),(0,e.createElement)(c.ToggleControl,{label:F("Hide Emojis if you don't use them","simply-static"),checked:X,onChange:e=>{Q(e),n("hide_emotes",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,F("Disable","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.ToggleControl,{label:F("Disable XML-RPC","simply-static"),checked:ee,onChange:e=>{te(e),n("disable_xmlrpc",e)}}),(0,e.createElement)(c.ToggleControl,{label:F("Disable Embed Scripts","simply-static"),checked:ne,onChange:e=>{ae(e),n("disable_embed",e)}}),(0,e.createElement)(c.ToggleControl,{label:F("Disable DB Debug in Frontend","simply-static"),checked:le,onChange:e=>{ie(e),n("disable_db_debug",e)}}),(0,e.createElement)(c.ToggleControl,{label:F("Disable WLW Manifest Scripts","simply-static"),checked:re,onChange:e=>{oe(e),n("disable_wlw_manifest",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),i&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,F("Settings saved successfully.","simply-static"))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5})),(0,e.createElement)("div",{className:"save-settings"},(0,e.createElement)(c.Button,{onClick:()=>{l(),r(!0),setTimeout((function(){r(!1)}),2e3)},variant:"primary"},F("Save Settings","simply-static"))))},{__:B}=wp.i18n,L=function(){const{isRunning:t,setIsRunning:n,blogId:l,migrateSettings:r,saveSettings:s,updateFromNetwork:u}=(0,a.useContext)(o),[m,h]=(0,a.useState)({activeItem:"/"}),[f,v]=(0,a.useState)(options.initial),[w,C]=(0,a.useState)(!1),[S,x]=(0,a.useState)(!1),[k,R]=(0,a.useState)("current"),[P,O]=(0,a.useState)([]),[T,D]=(0,a.useState)(!1);(0,a.useEffect)((()=>{if(w||(C(!0),h(options.initial),v(options.initial)),options.selectable_sites&&!options.is_network&&options.is_multisite){let e=options.selectable_sites.map((function(e){return{label:`${e.name}`,value:e.blog_id}}));e.unshift({label:B("Use current settings","simply-static"),value:"current"}),O(e)}}),[options]);const N=()=>{x(!0),i()({path:"/simplystatic/v1/start-export",method:"POST",data:{blog_id:l}}).then((e=>{n(!0)}))},A=()=>{i()({path:"/simplystatic/v1/cancel-export",method:"POST",data:{blog_id:l}}).then((e=>{n(!1)}))},I=()=>{r(),s(),location.reload()};return(0,a.useEffect)((function(){x(t)}),[t]),(0,e.createElement)("div",{className:"plugin-settings-container"},"yes"===options.need_upgrade?(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"warning",isDismissible:!1,className:"migrate-notice"},(0,e.createElement)("p",null,B("You have to migrate your settings to version 3.x of Simply Static to ensure everything works smoothly with the new interface.","simply-static")),(0,e.createElement)(c.Button,{onClick:I,variant:"primary"},B("Migrate settings","simply-static"))))):"",(0,e.createElement)(c.__experimentalNavigatorProvider,{initialPath:f},(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,options.is_network?(0,e.createElement)(c.Card,{className:"plugin-nav"},(0,e.createElement)("div",{className:"plugin-logo"},(0,e.createElement)("img",{alt:"Logo",src:options.logo})),"pro"===options.plan?(0,e.createElement)("p",null,"Free: ",(0,e.createElement)("b",null,options.version),(0,e.createElement)("br",null),"Pro: ",(0,e.createElement)("b",null,options.version_pro)):(0,e.createElement)("p",null,"Version: ",(0,e.createElement)("b",null,options.version)),(0,e.createElement)("div",{className:"generate-container"},(0,e.createElement)(c.Button,{onClick:()=>{N()},disabled:S,className:"/"===m?"is-active-item generate":"generate"},!S&&[(0,e.createElement)(c.Dashicon,{icon:"update"}),B("Generate Static Files","simply-static")],S&&[(0,e.createElement)(c.Dashicon,{icon:"update spin"}),B("Generating...","simply-static")]),S&&(0,e.createElement)("span",{onClick:()=>{A()},className:"cancel-button"},B("Cancel Export","simply-static"))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Button,{href:"https://simplystatic.com/changelogs/",target:"_blank"},(0,e.createElement)(c.Dashicon,{icon:"editor-ul"})," ",B("Changelog","simply-static")),(0,e.createElement)(c.Button,{href:"https://simplystatic.com/docs/",target:"_blank"},(0,e.createElement)(c.Dashicon,{icon:"admin-links"})," ",B("Documentation","simply-static")),"free"===options.plan&&(0,e.createElement)(c.Button,{href:"https://simplystatic.com",target:"_blank"},(0,e.createElement)(c.Dashicon,{icon:"admin-site-alt3"}),"Simply Static Pro")):(0,e.createElement)(c.Card,{className:"plugin-nav"},(0,e.createElement)("div",{className:"plugin-logo"},(0,e.createElement)("img",{alt:"Logo",src:options.logo})),"pro"===options.plan?(0,e.createElement)("p",null,"Free: ",(0,e.createElement)("b",null,options.version),(0,e.createElement)("br",null),"Pro: ",(0,e.createElement)("b",null,options.version_pro)):(0,e.createElement)("p",null,"Version: ",(0,e.createElement)("b",null,options.version)),(0,e.createElement)("div",{className:"generate-container"},(0,e.createElement)(c.Button,{onClick:()=>{N()},disabled:S,className:"/"===m?"is-active-item generate":"generate"},!S&&[(0,e.createElement)(c.Dashicon,{icon:"update"}),B("Generate Static Files","simply-static")],S&&[(0,e.createElement)(c.Dashicon,{icon:"update spin"}),B("Generating...","simply-static")]),S&&(0,e.createElement)("span",{onClick:()=>{A()},className:"cancel-button"},B("Cancel Export","simply-static"))),(0,e.createElement)(c.CardBody,null,!options.is_network&&options.is_multisite&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)("h4",{className:"settings-headline"}," ",B("Import","simply-static")),(0,e.createElement)(c.SelectControl,{value:k,options:P,help:B("Choose a subsite to import settings from.","simply-static"),onChange:e=>{R(e)}}),"current"!==k&&(0,e.createElement)(c.Button,{isPrimary:!0,onClick:()=>{(e=>{u(e),D(!0),setTimeout((function(){D(!1),window.location.reload()}),2e3)})(k)}},B("Import Settings","simply-static")),T?(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1,className:"upgrade-network-notice"},(0,e.createElement)("p",null,B("Settings successfully imported.","simply-static"))))):""),(0,e.createElement)("h4",{className:"settings-headline"}," ",B("Tools","simply-static")),(0,e.createElement)(c.__experimentalNavigatorButton,{onClick:()=>h("/"),className:"/"===m?"is-active-item generate":"generate",path:"/"},(0,e.createElement)(c.Dashicon,{icon:"update"})," ",B("Activity Log","simply-static")),(0,e.createElement)(c.__experimentalNavigatorButton,{onClick:()=>h("/diagnostics"),className:"/diagnostics"===m?"is-active-item":"",path:"/diagnostics"},(0,e.createElement)(c.Dashicon,{icon:"editor-help"})," ",B("Diagnostics","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("h4",{className:"settings-headline"}," ",B("Settings","simply-static")),(0,e.createElement)(c.__experimentalNavigatorButton,{onClick:()=>h("/general"),className:"/general"===m?"is-active-item":"",path:"/general"},(0,e.createElement)(c.Dashicon,{icon:"admin-generic"})," ",B("General","simply-static")),!options.is_network&&(0,e.createElement)(c.__experimentalNavigatorButton,{onClick:()=>h("/deployment"),className:"/deployment"===m?"is-active-item":"",path:"/deployment"},(0,e.createElement)(c.Dashicon,{icon:"migrate"})," ",B("Deploy","simply-static")),"pro"===options.plan&&!options.is_network&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.__experimentalNavigatorButton,{onClick:()=>h("/forms"),className:"/forms"===m?"is-active-item":"",path:"/forms"},(0,e.createElement)(c.Dashicon,{icon:"align-center"})," ",B("Forms","simply-static")),(0,e.createElement)(c.__experimentalNavigatorButton,{onClick:()=>h("/search"),className:"/search"===m?"is-active-item":"",path:"/search"},(0,e.createElement)(c.Dashicon,{icon:"search"})," ",B("Search","simply-static")),(0,e.createElement)(c.__experimentalNavigatorButton,{onClick:()=>h("/optimize"),className:"/optimize"===m?"is-active-item":"",path:"/optimize"},(0,e.createElement)(c.Dashicon,{icon:"dashboard"})," ",B("Optimize","simply-static")))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("h4",{className:"settings-headline"}," ",B("Advanced","simply-static")),(0,e.createElement)(c.__experimentalNavigatorButton,{onClick:()=>h("/utilities"),className:"/utilities"===m?"is-active-item":"",path:"/utilities"},(0,e.createElement)(c.Dashicon,{icon:"admin-tools"})," ",B("Utilities","simply-static")),(0,e.createElement)(c.__experimentalNavigatorButton,{onClick:()=>h("/misc"),className:"/misc"===m?"is-active-item":"",path:"/misc"},(0,e.createElement)(c.Dashicon,{icon:"block-default"})," ",B("Misc","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("h4",{className:"settings-headline"},"Simply Static"),(0,e.createElement)(c.Button,{href:"https://simplystatic.com/changelogs/",target:"_blank"},(0,e.createElement)(c.Dashicon,{icon:"editor-ul"})," ",B("Changelog","simply-static")),(0,e.createElement)(c.Button,{href:"https://simplystatic.com/docs/",target:"_blank"},(0,e.createElement)(c.Dashicon,{icon:"admin-links"})," ",B("Documentation","simply-static")),"free"===options.plan&&(0,e.createElement)(c.Button,{href:"https://simplystatic.com",target:"_blank"},(0,e.createElement)(c.Dashicon,{icon:"admin-site-alt3"}),"Simply Static Pro")))),"/"===m&&(0,e.createElement)(c.FlexItem,{isBlock:!0},(0,e.createElement)(c.__experimentalNavigatorScreen,{path:"/"},(0,e.createElement)("div",{className:"plugin-settings"},(0,e.createElement)($,null)))),"/diagnostics"===m&&(0,e.createElement)(c.FlexItem,{isBlock:!0},(0,e.createElement)(c.__experimentalNavigatorScreen,{path:"/diagnostics"},(0,e.createElement)("div",{className:"plugin-settings"},(0,e.createElement)(p,null)))),"/general"===m&&(0,e.createElement)(c.FlexItem,{isBlock:!0},(0,e.createElement)(c.__experimentalNavigatorScreen,{path:"/general"},(0,e.createElement)("div",{className:"plugin-settings"},(0,e.createElement)(d,null)))),"/deployment"===m&&(0,e.createElement)(c.FlexItem,{isBlock:!0},(0,e.createElement)(c.__experimentalNavigatorScreen,{path:"/deployment"},(0,e.createElement)("div",{className:"plugin-settings"},(0,e.createElement)(y,null)))),"/forms"===m&&"pro"===options.plan&&(0,e.createElement)(c.FlexItem,{isBlock:!0},(0,e.createElement)(c.__experimentalNavigatorScreen,{path:"/forms"},(0,e.createElement)("div",{className:"plugin-settings"},(0,e.createElement)(b,null)))),"/search"===m&&"pro"===options.plan&&(0,e.createElement)(c.FlexItem,{isBlock:!0},(0,e.createElement)(c.__experimentalNavigatorScreen,{path:"/search"},(0,e.createElement)("div",{className:"plugin-settings"},(0,e.createElement)(E,null)))),"/optimize"===m&&"pro"===options.plan&&(0,e.createElement)(c.FlexItem,{isBlock:!0},(0,e.createElement)(c.__experimentalNavigatorScreen,{path:"/optimize"},(0,e.createElement)("div",{className:"plugin-settings"},(0,e.createElement)(H,null)))),"/utilities"===m&&(0,e.createElement)(c.FlexItem,{isBlock:!0},(0,e.createElement)(c.__experimentalNavigatorScreen,{path:"/utilities"},(0,e.createElement)("div",{className:"plugin-settings"},(0,e.createElement)(g,null)))),"/misc"===m&&(0,e.createElement)(c.FlexItem,{isBlock:!0},(0,e.createElement)(c.__experimentalNavigatorScreen,{path:"/misc"},(0,e.createElement)("div",{className:"plugin-settings"},(0,e.createElement)(_,null)))))))},j=function(){return(0,e.createElement)(s,null,(0,e.createElement)("div",null,(0,e.createElement)(L,null)))};"simplystatic-settings"===options.screen&&(0,a.createRoot)(document.getElementById("simplystatic-settings")).render((0,e.createElement)(j,null))})()})();
+`;var Ae=l.memo((function({rowsPerPage:e,rowCount:t,currentPage:n,direction:o=De.direction,paginationRowsPerPageOptions:a=De.paginationRowsPerPageOptions,paginationIconLastPage:r=De.paginationIconLastPage,paginationIconFirstPage:i=De.paginationIconFirstPage,paginationIconNext:s=De.paginationIconNext,paginationIconPrevious:d=De.paginationIconPrevious,paginationComponentOptions:c=De.paginationComponentOptions,onChangeRowsPerPage:g=De.onChangeRowsPerPage,onChangePage:u=De.onChangePage}){const b=(()=>{const e="object"==typeof window;function t(){return{width:e?window.innerWidth:void 0,height:e?window.innerHeight:void 0}}const[n,o]=l.useState(t);return l.useEffect((()=>{if(!e)return()=>null;function n(){o(t())}return window.addEventListener("resize",n),()=>window.removeEventListener("resize",n)}),[]),n})(),m=re(o),f=b.width&&b.width>599,h=p(t,e),w=n*e,x=w-e+1,C=1===n,y=n===h,v=Object.assign(Object.assign({},He),c),R=n===h?`${x}-${t} ${v.rangeSeparatorText} ${t}`:`${x}-${w} ${v.rangeSeparatorText} ${t}`,S=l.useCallback((()=>u(n-1)),[n,u]),E=l.useCallback((()=>u(n+1)),[n,u]),O=l.useCallback((()=>u(1)),[u]),P=l.useCallback((()=>u(p(t,e))),[u,t,e]),k=l.useCallback((e=>g(Number(e.target.value),n)),[n,g]),D=a.map((e=>l.createElement("option",{key:e,value:e},e)));v.selectAllRowsItem&&D.push(l.createElement("option",{key:-1,value:t},v.selectAllRowsItemText));const H=l.createElement(ke,{onChange:k,defaultValue:e,"aria-label":v.rowsPerPageText},D);return l.createElement($e,{className:"rdt_Pagination"},!v.noRowsPerPage&&f&&l.createElement(l.Fragment,null,l.createElement(Me,null,v.rowsPerPageText),H),f&&l.createElement(Ie,null,R),l.createElement(Fe,null,l.createElement(je,{id:"pagination-first-page",type:"button","aria-label":"First Page","aria-disabled":C,onClick:O,disabled:C,isRTL:m},i),l.createElement(je,{id:"pagination-previous-page",type:"button","aria-label":"Previous Page","aria-disabled":C,onClick:S,disabled:C,isRTL:m},d),!f&&H,l.createElement(je,{id:"pagination-next-page",type:"button","aria-label":"Next Page","aria-disabled":y,onClick:E,disabled:y,isRTL:m},s),l.createElement(je,{id:"pagination-last-page",type:"button","aria-label":"Last Page","aria-disabled":y,onClick:P,disabled:y,isRTL:m},r)))}));const Le=(e,t)=>{const n=l.useRef(!0);l.useEffect((()=>{n.current?n.current=!1:e()}),t)};var _e=function(e){return function(e){return!!e&&"object"==typeof e}(e)&&!function(e){var t=Object.prototype.toString.call(e);return"[object RegExp]"===t||"[object Date]"===t||function(e){return e.$$typeof===ze}(e)}(e)};var ze="function"==typeof Symbol&&Symbol.for?Symbol.for("react.element"):60103;function Ne(e,t){return!1!==t.clone&&t.isMergeableObject(e)?Ue((n=e,Array.isArray(n)?[]:{}),e,t):e;var n}function We(e,t,n){return e.concat(t).map((function(e){return Ne(e,n)}))}function Be(e){return Object.keys(e).concat(function(e){return Object.getOwnPropertySymbols?Object.getOwnPropertySymbols(e).filter((function(t){return e.propertyIsEnumerable(t)})):[]}(e))}function Ge(e,t){try{return t in e}catch(e){return!1}}function Ve(e,t,n){var o={};return n.isMergeableObject(e)&&Be(e).forEach((function(t){o[t]=Ne(e[t],n)})),Be(t).forEach((function(a){(function(e,t){return Ge(e,t)&&!(Object.hasOwnProperty.call(e,t)&&Object.propertyIsEnumerable.call(e,t))})(e,a)||(Ge(e,a)&&n.isMergeableObject(t[a])?o[a]=function(e,t){if(!t.customMerge)return Ue;var n=t.customMerge(e);return"function"==typeof n?n:Ue}(a,n)(e[a],t[a],n):o[a]=Ne(t[a],n))})),o}function Ue(e,t,n){(n=n||{}).arrayMerge=n.arrayMerge||We,n.isMergeableObject=n.isMergeableObject||_e,n.cloneUnlessOtherwiseSpecified=Ne;var o=Array.isArray(t);return o===Array.isArray(e)?o?n.arrayMerge(e,t,n):Ve(e,t,n):Ne(t,n)}Ue.all=function(e,t){if(!Array.isArray(e))throw new Error("first argument should be an array");return e.reduce((function(e,n){return Ue(e,n,t)}),{})};var qe=Ue;const Ye={text:{primary:"rgba(0, 0, 0, 0.87)",secondary:"rgba(0, 0, 0, 0.54)",disabled:"rgba(0, 0, 0, 0.38)"},background:{default:"#FFFFFF"},context:{background:"#e3f2fd",text:"rgba(0, 0, 0, 0.87)"},divider:{default:"rgba(0,0,0,.12)"},button:{default:"rgba(0,0,0,.54)",focus:"rgba(0,0,0,.12)",hover:"rgba(0,0,0,.12)",disabled:"rgba(0, 0, 0, .18)"},selected:{default:"#e3f2fd",text:"rgba(0, 0, 0, 0.87)"},highlightOnHover:{default:"#EEEEEE",text:"rgba(0, 0, 0, 0.87)"},striped:{default:"#FAFAFA",text:"rgba(0, 0, 0, 0.87)"}},Ke={default:Ye,light:Ye,dark:{text:{primary:"#FFFFFF",secondary:"rgba(255, 255, 255, 0.7)",disabled:"rgba(0,0,0,.12)"},background:{default:"#424242"},context:{background:"#E91E63",text:"#FFFFFF"},divider:{default:"rgba(81, 81, 81, 1)"},button:{default:"#FFFFFF",focus:"rgba(255, 255, 255, .54)",hover:"rgba(255, 255, 255, .12)",disabled:"rgba(255, 255, 255, .18)"},selected:{default:"rgba(0, 0, 0, .7)",text:"#FFFFFF"},highlightOnHover:{default:"rgba(0, 0, 0, .7)",text:"#FFFFFF"},striped:{default:"rgba(0, 0, 0, .87)",text:"#FFFFFF"}}};function Je(e,t,n,o){const[r,i]=l.useState((()=>u(e))),[s,d]=l.useState(""),c=l.useRef("");Le((()=>{i(u(e))}),[e]);const g=l.useCallback((e=>{var t,n,o;const{attributes:a}=e.target,l=null===(t=a.getNamedItem("data-column-id"))||void 0===t?void 0:t.value;l&&(c.current=(null===(o=null===(n=r[w(r,l)])||void 0===n?void 0:n.id)||void 0===o?void 0:o.toString())||"",d(c.current))}),[r]),p=l.useCallback((e=>{var n;const{attributes:o}=e.target,a=null===(n=o.getNamedItem("data-column-id"))||void 0===n?void 0:n.value;if(a&&c.current&&a!==c.current){const e=w(r,c.current),n=w(r,a),o=[...r];o[e]=r[n],o[n]=r[e],i(o),t(o)}}),[t,r]),b=l.useCallback((e=>{e.preventDefault()}),[]),m=l.useCallback((e=>{e.preventDefault()}),[]),f=l.useCallback((e=>{e.preventDefault(),c.current="",d("")}),[]),h=function(e=!1){return e?a.ASC:a.DESC}(o),x=l.useMemo((()=>r[w(r,null==n?void 0:n.toString())]||{}),[n,r]);return{tableColumns:r,draggingColumnId:s,handleDragStart:g,handleDragEnter:p,handleDragOver:b,handleDragLeave:m,handleDragEnd:f,defaultSortDirection:h,defaultSortColumn:x}}var Qe=l.memo((function(e){const{data:n=De.data,columns:o=De.columns,title:r=De.title,actions:i=De.actions,keyField:c=De.keyField,striped:g=De.striped,highlightOnHover:u=De.highlightOnHover,pointerOnHover:m=De.pointerOnHover,dense:f=De.dense,selectableRows:w=De.selectableRows,selectableRowsSingle:x=De.selectableRowsSingle,selectableRowsHighlight:y=De.selectableRowsHighlight,selectableRowsNoSelectAll:R=De.selectableRowsNoSelectAll,selectableRowsVisibleOnly:O=De.selectableRowsVisibleOnly,selectableRowSelected:P=De.selectableRowSelected,selectableRowDisabled:k=De.selectableRowDisabled,selectableRowsComponent:D=De.selectableRowsComponent,selectableRowsComponentProps:$=De.selectableRowsComponentProps,onRowExpandToggled:j=De.onRowExpandToggled,onSelectedRowsChange:F=De.onSelectedRowsChange,expandableIcon:T=De.expandableIcon,onChangeRowsPerPage:I=De.onChangeRowsPerPage,onChangePage:M=De.onChangePage,paginationServer:A=De.paginationServer,paginationServerOptions:L=De.paginationServerOptions,paginationTotalRows:_=De.paginationTotalRows,paginationDefaultPage:z=De.paginationDefaultPage,paginationResetDefaultPage:N=De.paginationResetDefaultPage,paginationPerPage:W=De.paginationPerPage,paginationRowsPerPageOptions:B=De.paginationRowsPerPageOptions,paginationIconLastPage:G=De.paginationIconLastPage,paginationIconFirstPage:V=De.paginationIconFirstPage,paginationIconNext:U=De.paginationIconNext,paginationIconPrevious:q=De.paginationIconPrevious,paginationComponent:Y=De.paginationComponent,paginationComponentOptions:K=De.paginationComponentOptions,responsive:Q=De.responsive,progressPending:X=De.progressPending,progressComponent:Z=De.progressComponent,persistTableHead:ee=De.persistTableHead,noDataComponent:te=De.noDataComponent,disabled:ne=De.disabled,noTableHead:ae=De.noTableHead,noHeader:re=De.noHeader,fixedHeader:ie=De.fixedHeader,fixedHeaderScrollHeight:se=De.fixedHeaderScrollHeight,pagination:de=De.pagination,subHeader:ce=De.subHeader,subHeaderAlign:ge=De.subHeaderAlign,subHeaderWrap:ue=De.subHeaderWrap,subHeaderComponent:pe=De.subHeaderComponent,noContextMenu:me=De.noContextMenu,contextMessage:fe=De.contextMessage,contextActions:he=De.contextActions,contextComponent:Ee=De.contextComponent,expandableRows:Oe=De.expandableRows,onRowClicked:Pe=De.onRowClicked,onRowDoubleClicked:ke=De.onRowDoubleClicked,onRowMouseEnter:He=De.onRowMouseEnter,onRowMouseLeave:$e=De.onRowMouseLeave,sortIcon:je=De.sortIcon,onSort:Fe=De.onSort,sortFunction:Te=De.sortFunction,sortServer:Ie=De.sortServer,expandableRowsComponent:Me=De.expandableRowsComponent,expandableRowsComponentProps:_e=De.expandableRowsComponentProps,expandableRowDisabled:ze=De.expandableRowDisabled,expandableRowsHideExpander:Ne=De.expandableRowsHideExpander,expandOnRowClicked:We=De.expandOnRowClicked,expandOnRowDoubleClicked:Be=De.expandOnRowDoubleClicked,expandableRowExpanded:Ge=De.expandableRowExpanded,expandableInheritConditionalStyles:Ve=De.expandableInheritConditionalStyles,defaultSortFieldId:Ue=De.defaultSortFieldId,defaultSortAsc:Ye=De.defaultSortAsc,clearSelectedRows:Qe=De.clearSelectedRows,conditionalRowStyles:Xe=De.conditionalRowStyles,theme:Ze=De.theme,customStyles:et=De.customStyles,direction:tt=De.direction,onColumnOrderChange:nt=De.onColumnOrderChange,className:ot}=e,{tableColumns:at,draggingColumnId:lt,handleDragStart:rt,handleDragEnter:it,handleDragOver:st,handleDragLeave:dt,handleDragEnd:ct,defaultSortDirection:gt,defaultSortColumn:ut}=Je(o,nt,Ue,Ye),[{rowsPerPage:pt,currentPage:bt,selectedRows:mt,allSelected:ft,selectedCount:ht,selectedColumn:wt,sortDirection:xt,toggleOnSelectedRowsChange:Ct},yt]=l.useReducer(C,{allSelected:!1,selectedCount:0,selectedRows:[],selectedColumn:ut,toggleOnSelectedRowsChange:!1,sortDirection:gt,currentPage:z,rowsPerPage:W,selectedRowsFlag:!1,contextMessage:De.contextMessage}),{persistSelectedOnSort:vt=!1,persistSelectedOnPageChange:Rt=!1}=L,St=!(!A||!Rt&&!vt),Et=de&&!X&&n.length>0,Ot=Y||Ae,Pt=l.useMemo((()=>((e={},t="default",n="default")=>{const o=Ke[t]?t:n;return qe({table:{style:{color:(a=Ke[o]).text.primary,backgroundColor:a.background.default}},tableWrapper:{style:{display:"table"}},responsiveWrapper:{style:{}},header:{style:{fontSize:"22px",color:a.text.primary,backgroundColor:a.background.default,minHeight:"56px",paddingLeft:"16px",paddingRight:"8px"}},subHeader:{style:{backgroundColor:a.background.default,minHeight:"52px"}},head:{style:{color:a.text.primary,fontSize:"12px",fontWeight:500}},headRow:{style:{backgroundColor:a.background.default,minHeight:"52px",borderBottomWidth:"1px",borderBottomColor:a.divider.default,borderBottomStyle:"solid"},denseStyle:{minHeight:"32px"}},headCells:{style:{paddingLeft:"16px",paddingRight:"16px"},draggingStyle:{cursor:"move"}},contextMenu:{style:{backgroundColor:a.context.background,fontSize:"18px",fontWeight:400,color:a.context.text,paddingLeft:"16px",paddingRight:"8px",transform:"translate3d(0, -100%, 0)",transitionDuration:"125ms",transitionTimingFunction:"cubic-bezier(0, 0, 0.2, 1)",willChange:"transform"},activeStyle:{transform:"translate3d(0, 0, 0)"}},cells:{style:{paddingLeft:"16px",paddingRight:"16px",wordBreak:"break-word"},draggingStyle:{}},rows:{style:{fontSize:"13px",fontWeight:400,color:a.text.primary,backgroundColor:a.background.default,minHeight:"48px","&:not(:last-of-type)":{borderBottomStyle:"solid",borderBottomWidth:"1px",borderBottomColor:a.divider.default}},denseStyle:{minHeight:"32px"},selectedHighlightStyle:{"&:nth-of-type(n)":{color:a.selected.text,backgroundColor:a.selected.default,borderBottomColor:a.background.default}},highlightOnHoverStyle:{color:a.highlightOnHover.text,backgroundColor:a.highlightOnHover.default,transitionDuration:"0.15s",transitionProperty:"background-color",borderBottomColor:a.background.default,outlineStyle:"solid",outlineWidth:"1px",outlineColor:a.background.default},stripedStyle:{color:a.striped.text,backgroundColor:a.striped.default}},expanderRow:{style:{color:a.text.primary,backgroundColor:a.background.default}},expanderCell:{style:{flex:"0 0 48px"}},expanderButton:{style:{color:a.button.default,fill:a.button.default,backgroundColor:"transparent",borderRadius:"2px",transition:"0.25s",height:"100%",width:"100%","&:hover:enabled":{cursor:"pointer"},"&:disabled":{color:a.button.disabled},"&:hover:not(:disabled)":{cursor:"pointer",backgroundColor:a.button.hover},"&:focus":{outline:"none",backgroundColor:a.button.focus},svg:{margin:"auto"}}},pagination:{style:{color:a.text.secondary,fontSize:"13px",minHeight:"56px",backgroundColor:a.background.default,borderTopStyle:"solid",borderTopWidth:"1px",borderTopColor:a.divider.default},pageButtonsStyle:{borderRadius:"50%",height:"40px",width:"40px",padding:"8px",margin:"px",cursor:"pointer",transition:"0.4s",color:a.button.default,fill:a.button.default,backgroundColor:"transparent","&:disabled":{cursor:"unset",color:a.button.disabled,fill:a.button.disabled},"&:hover:not(:disabled)":{backgroundColor:a.button.hover},"&:focus":{outline:"none",backgroundColor:a.button.focus}}},noData:{style:{display:"flex",alignItems:"center",justifyContent:"center",color:a.text.primary,backgroundColor:a.background.default}},progress:{style:{display:"flex",alignItems:"center",justifyContent:"center",color:a.text.primary,backgroundColor:a.background.default}}},e);var a})(et,Ze)),[et,Ze]),kt=l.useMemo((()=>Object.assign({},"auto"!==tt&&{dir:tt})),[tt]),Dt=l.useMemo((()=>{if(Ie)return n;if((null==wt?void 0:wt.sortFunction)&&"function"==typeof wt.sortFunction){const e=wt.sortFunction,t=xt===a.ASC?e:(t,n)=>-1*e(t,n);return[...n].sort(t)}return function(e,t,n,o){return t?o&&"function"==typeof o?o(e.slice(0),t,n):e.slice(0).sort(((e,o)=>{let a,l;if("string"==typeof t?(a=d(e,t),l=d(o,t)):(a=t(e),l=t(o)),"asc"===n){if(a<l)return-1;if(a>l)return 1}if("desc"===n){if(a>l)return-1;if(a<l)return 1}return 0})):e}(n,null==wt?void 0:wt.selector,xt,Te)}),[Ie,wt,xt,n,Te]),Ht=l.useMemo((()=>{if(de&&!A){const e=bt*pt,t=e-pt;return Dt.slice(t,e)}return Dt}),[bt,de,A,pt,Dt]),$t=l.useCallback((e=>{yt(e)}),[]),jt=l.useCallback((e=>{yt(e)}),[]),Ft=l.useCallback((e=>{yt(e)}),[]),Tt=l.useCallback(((e,t)=>Pe(e,t)),[Pe]),It=l.useCallback(((e,t)=>ke(e,t)),[ke]),Mt=l.useCallback(((e,t)=>He(e,t)),[He]),At=l.useCallback(((e,t)=>$e(e,t)),[$e]),Lt=l.useCallback((e=>yt({type:"CHANGE_PAGE",page:e,paginationServer:A,visibleOnly:O,persistSelectedOnPageChange:Rt})),[A,Rt,O]),_t=l.useCallback((e=>{const t=p(_||Ht.length,e),n=b(bt,t);A||Lt(n),yt({type:"CHANGE_ROWS_PER_PAGE",page:n,rowsPerPage:e})}),[bt,Lt,A,_,Ht.length]);if(de&&!A&&Dt.length>0&&0===Ht.length){const e=p(Dt.length,pt),t=b(bt,e);Lt(t)}Le((()=>{F({allSelected:ft,selectedCount:ht,selectedRows:mt.slice(0)})}),[Ct]),Le((()=>{Fe(wt,xt,Dt.slice(0))}),[wt,xt]),Le((()=>{M(bt,_||Dt.length)}),[bt]),Le((()=>{I(pt,bt)}),[pt]),Le((()=>{Lt(z)}),[z,N]),Le((()=>{if(de&&A&&_>0){const e=p(_,pt),t=b(bt,e);bt!==t&&Lt(t)}}),[_]),l.useEffect((()=>{yt({type:"CLEAR_SELECTED_ROWS",selectedRowsFlag:Qe})}),[x,Qe]),l.useEffect((()=>{if(!P)return;const e=Dt.filter((e=>P(e))),t=x?e.slice(0,1):e;yt({type:"SELECT_MULTIPLE_ROWS",keyField:c,selectedRows:t,totalRows:Dt.length,mergeSelections:St})}),[n,P]);const zt=O?Ht:Dt,Nt=Rt||x||R;return l.createElement(t.ThemeProvider,{theme:Pt},!re&&(!!r||!!i)&&l.createElement(be,{title:r,actions:i,showMenu:!me,selectedCount:ht,direction:tt,contextActions:he,contextComponent:Ee,contextMessage:fe}),ce&&l.createElement(we,{align:ge,wrapContent:ue},pe),l.createElement(Ce,Object.assign({responsive:Q,fixedHeader:ie,fixedHeaderScrollHeight:se,className:ot},kt),l.createElement(ve,null,X&&!ee&&l.createElement(ye,null,Z),l.createElement(v,{disabled:ne,className:"rdt_Table",role:"table"},!ae&&(!!ee||Dt.length>0&&!X)&&l.createElement(S,{className:"rdt_TableHead",role:"rowgroup",fixedHeader:ie},l.createElement(E,{className:"rdt_TableHeadRow",role:"row",dense:f},w&&(Nt?l.createElement(H,{style:{flex:"0 0 48px"}}):l.createElement(le,{allSelected:ft,selectedRows:mt,selectableRowsComponent:D,selectableRowsComponentProps:$,selectableRowDisabled:k,rowData:zt,keyField:c,mergeSelections:St,onSelectAllRows:jt})),Oe&&!Ne&&l.createElement(Re,null),at.map((e=>l.createElement(oe,{key:e.id,column:e,selectedColumn:wt,disabled:X||0===Dt.length,pagination:de,paginationServer:A,persistSelectedOnSort:vt,selectableRowsVisibleOnly:O,sortDirection:xt,sortIcon:je,sortServer:Ie,onSort:$t,onDragStart:rt,onDragOver:st,onDragEnd:ct,onDragEnter:it,onDragLeave:dt,draggingColumnId:lt}))))),!Dt.length&&!X&&l.createElement(Se,null,te),X&&ee&&l.createElement(ye,null,Z),!X&&Dt.length>0&&l.createElement(xe,{className:"rdt_TableBody",role:"rowgroup"},Ht.map(((e,t)=>{const n=s(e,c),o=function(e=""){return"number"!=typeof e&&(!e||0===e.length)}(n)?t:n,a=h(e,mt,c),r=!!(Oe&&Ge&&Ge(e)),i=!!(Oe&&ze&&ze(e));return l.createElement(J,{id:o,key:o,keyField:c,"data-row-id":o,columns:at,row:e,rowCount:Dt.length,rowIndex:t,selectableRows:w,expandableRows:Oe,expandableIcon:T,highlightOnHover:u,pointerOnHover:m,dense:f,expandOnRowClicked:We,expandOnRowDoubleClicked:Be,expandableRowsComponent:Me,expandableRowsComponentProps:_e,expandableRowsHideExpander:Ne,defaultExpanderDisabled:i,defaultExpanded:r,expandableInheritConditionalStyles:Ve,conditionalRowStyles:Xe,selected:a,selectableRowsHighlight:y,selectableRowsComponent:D,selectableRowsComponentProps:$,selectableRowDisabled:k,selectableRowsSingle:x,striped:g,onRowExpandToggled:j,onRowClicked:Tt,onRowDoubleClicked:It,onRowMouseEnter:Mt,onRowMouseLeave:At,onSelectedRow:Ft,draggingColumnId:lt,onDragStart:rt,onDragOver:st,onDragEnd:ct,onDragEnter:it,onDragLeave:dt})})))))),Et&&l.createElement("div",null,l.createElement(Ot,{onChangePage:Lt,onChangeRowsPerPage:_t,rowCount:_||Dt.length,currentPage:bt,rowsPerPage:pt,direction:tt,paginationRowsPerPageOptions:B,paginationIconLastPage:G,paginationIconFirstPage:V,paginationIconNext:U,paginationIconPrevious:q,paginationComponentOptions:K})))}));exports.STOP_PROP_TAG="allowRowEvents",exports.createTheme=function(e="default",t,n="default"){return Ke[e]||(Ke[e]=qe(Ke[n],t||{})),Ke[e]=qe(Ke[e],t||{}),Ke[e]},exports["default"]=Qe,exports.defaultThemes=Ke;
+//# sourceMappingURL=index.cjs.js.map
+
+
+/***/ }),
+
+/***/ "./node_modules/react-terminal-ui/build/index.es.js":
+/*!**********************************************************!*\
+  !*** ./node_modules/react-terminal-ui/build/index.es.js ***!
+  \**********************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   ColorMode: () => (/* binding */ o),
+/* harmony export */   TerminalInput: () => (/* binding */ i),
+/* harmony export */   TerminalOutput: () => (/* binding */ l),
+/* harmony export */   "default": () => (/* binding */ c)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+function a(n,e){var t="function"==typeof Symbol&&n[Symbol.iterator];if(!t)return n;var r,a,i=t.call(n),l=[];try{for(;(void 0===e||e-- >0)&&!(r=i.next()).done;)l.push(r.value)}catch(n){a={error:n}}finally{try{r&&!r.done&&(t=i.return)&&t.call(i)}finally{if(a)throw a.error}}return l}var i=function(e){var t=e.children;return react__WEBPACK_IMPORTED_MODULE_0___default().createElement("div",{className:"react-terminal-line react-terminal-input"},t)},l=function(e){var t=e.children;return react__WEBPACK_IMPORTED_MODULE_0___default().createElement("div",{className:"react-terminal-line"},t)};var o;!function(n,e){void 0===e&&(e={});var t=e.insertAt;if(n&&"undefined"!=typeof document){var r=document.head||document.getElementsByTagName("head")[0],a=document.createElement("style");a.type="text/css","top"===t&&r.firstChild?r.insertBefore(a,r.firstChild):r.appendChild(a),a.styleSheet?a.styleSheet.cssText=n:a.appendChild(document.createTextNode(n))}}("/**\n * Modfied version of [termynal.js](https://github.com/ines/termynal/blob/master/termynal.css).\n *\n * @author Ines Montani <ines@ines.io>\n * @version 0.0.1\n * @license MIT\n */\n .react-terminal-wrapper {\n  width: 100%;\n  background: #252a33;\n  color: #eee;\n  font-size: 18px;\n  font-family: 'Fira Mono', Consolas, Menlo, Monaco, 'Courier New', Courier, monospace;\n  border-radius: 4px;\n  padding: 75px 45px 35px;\n  position: relative;\n  -webkit-box-sizing: border-box;\n          box-sizing: border-box;\n }\n\n.react-terminal {\n  overflow: auto;\n  display: flex;\n  flex-direction: column;\n}\n\n.react-terminal-wrapper.react-terminal-light {\n  background: #ddd;\n  color: #1a1e24;\n}\n\n.react-terminal-window-buttons {\n  position: absolute;\n  top: 15px;\n  left: 15px;\n  display: flex;\n  flex-direction: row;\n  gap: 10px;\n}\n\n.react-terminal-window-buttons button {\n  width: 15px;\n  height: 15px;\n  border-radius: 50%;\n  border: 0;\n}\n\n.react-terminal-window-buttons button.clickable {\n  cursor: pointer;\n}\n\n.react-terminal-window-buttons button.red-btn {\n  background: #d9515d;\n}\n\n.react-terminal-window-buttons button.yellow-btn {\n  background: #f4c025;\n}\n\n.react-terminal-window-buttons button.green-btn {\n  background: #3ec930;\n}\n\n.react-terminal-wrapper:after {\n  content: attr(data-terminal-name);\n  position: absolute;\n  color: #a2a2a2;\n  top: 5px;\n  left: 0;\n  width: 100%;\n  text-align: center;\n  pointer-events: none;\n}\n\n.react-terminal-wrapper.react-terminal-light:after {\n  color: #D76D77;\n}\n\n.react-terminal-line {\n  white-space: pre;\n}\n\n.react-terminal-line:before {\n  /* Set up defaults and ensure empty lines are displayed. */\n  content: '';\n  display: inline-block;\n  vertical-align: middle;\n  color: #a2a2a2;\n}\n\n.react-terminal-light .react-terminal-line:before {\n  color: #D76D77;\n}\n\n.react-terminal-input:before {\n  margin-right: 0.75em;\n  content: '$';\n}\n\n.react-terminal-input[data-terminal-prompt]:before {\n  content: attr(data-terminal-prompt);\n}\n\n.react-terminal-wrapper:focus-within .react-terminal-active-input .cursor {\n  position: relative;\n  display: inline-block;\n  width: 0.55em;\n  height: 1em;\n  top: 0.225em;\n  background: #fff;\n  -webkit-animation: blink 1s infinite;\n          animation: blink 1s infinite;\n}\n\n/* Cursor animation */\n\n@-webkit-keyframes blink {\n  50% {\n      opacity: 0;\n  }\n}\n\n@keyframes blink {\n  50% {\n      opacity: 0;\n  }\n}\n\n.terminal-hidden-input {\n    position: fixed;\n    left: -1000px;\n}\n\n/* .react-terminal-progress {\n  display: flex;\n  margin: .5rem 0;\n}\n\n.react-terminal-progress-bar {\n  background-color: #fff;\n  border-radius: .25rem;\n  width: 25%;\n}\n\n.react-terminal-wrapper.react-terminal-light .react-terminal-progress-bar {\n  background-color: #000;\n} */\n"),function(n){n[n.Light=0]="Light",n[n.Dark=1]="Dark"}(o||(o={}));var c=function(i){var l=i.name,c=i.prompt,d=i.height,m=void 0===d?"600px":d,s=i.colorMode,u=i.onInput,p=i.children,f=i.startingInputValue,b=void 0===f?"":f,h=i.redBtnCallback,y=i.yellowBtnCallback,v=i.greenBtnCallback,w=a((0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(""),2),g=w[0],k=w[1],x=a((0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(0),2),E=x[0],C=x[1],N=(0,react__WEBPACK_IMPORTED_MODULE_0__.useRef)(null);(0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)((function(){k(b.trim())}),[b]);var S=(0,react__WEBPACK_IMPORTED_MODULE_0__.useRef)(!1);(0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)((function(){S.current&&setTimeout((function(){var n;return null===(n=null==N?void 0:N.current)||void 0===n?void 0:n.scrollIntoView({behavior:"auto",block:"nearest"})}),500),S.current=!0}),[p]),(0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)((function(){var n,e;if(null!=u){var t=[],r=function(n){var e=function(){var e;return null===(e=null==n?void 0:n.querySelector(".terminal-hidden-input"))||void 0===e?void 0:e.focus()};null==n||n.addEventListener("click",e),t.push({terminalEl:n,listener:e})};try{for(var a=function(n){var e="function"==typeof Symbol&&Symbol.iterator,t=e&&n[e],r=0;if(t)return t.call(n);if(n&&"number"==typeof n.length)return{next:function(){return n&&r>=n.length&&(n=void 0),{value:n&&n[r++],done:!n}}};throw new TypeError(e?"Object is not iterable.":"Symbol.iterator is not defined.")}(document.getElementsByClassName("react-terminal-wrapper")),i=a.next();!i.done;i=a.next()){r(i.value)}}catch(e){n={error:e}}finally{try{i&&!i.done&&(e=a.return)&&e.call(a)}finally{if(n)throw n.error}}return function(){t.forEach((function(n){n.terminalEl.removeEventListener("click",n.listener)}))}}}),[u]);var D=["react-terminal-wrapper"];return s===o.Light&&D.push("react-terminal-light"),react__WEBPACK_IMPORTED_MODULE_0___default().createElement("div",{className:D.join(" "),"data-terminal-name":l},react__WEBPACK_IMPORTED_MODULE_0___default().createElement("div",{className:"react-terminal-window-buttons"},react__WEBPACK_IMPORTED_MODULE_0___default().createElement("button",{className:(y?"clickable":"")+" red-btn",disabled:!h,onClick:h}),react__WEBPACK_IMPORTED_MODULE_0___default().createElement("button",{className:(y?"clickable":"")+" yellow-btn",disabled:!y,onClick:y}),react__WEBPACK_IMPORTED_MODULE_0___default().createElement("button",{className:(v?"clickable":"")+" green-btn",disabled:!v,onClick:v})),react__WEBPACK_IMPORTED_MODULE_0___default().createElement("div",{className:"react-terminal",style:{height:m}},p,u&&react__WEBPACK_IMPORTED_MODULE_0___default().createElement("div",{className:"react-terminal-line react-terminal-input react-terminal-active-input","data-terminal-prompt":c||"$",key:"terminal-line-prompt"},g,react__WEBPACK_IMPORTED_MODULE_0___default().createElement("span",{className:"cursor",style:{left:E+1+"px"}})),react__WEBPACK_IMPORTED_MODULE_0___default().createElement("div",{ref:N})),react__WEBPACK_IMPORTED_MODULE_0___default().createElement("input",{className:"terminal-hidden-input",placeholder:"Terminal Hidden Input",value:g,autoFocus:null!=u,onChange:function(n){k(n.target.value)},onKeyDown:function(n){var e,t,r;if(u)if("Enter"===n.key)u(g),C(0),k("");else if(["ArrowLeft","ArrowRight","ArrowDown","ArrowUp","Delete"].includes(n.key)){var a=n.currentTarget,i="",l=g.length-(a.selectionStart||0);e=l,t=0,r=g.length,l=e>r?r:e<t?t:e,"ArrowLeft"===n.key?(l>g.length-1&&l--,i=g.slice(g.length-1-l)):"ArrowRight"===n.key||"Delete"===n.key?i=g.slice(g.length-l+1):"ArrowUp"===n.key&&(i=g.slice(0));var o=function(n,e){var t=document.createElement("span");t.style.visibility="hidden",t.style.position="absolute",t.style.fontSize=window.getComputedStyle(n).fontSize,t.style.fontFamily=window.getComputedStyle(n).fontFamily,t.innerText=e,document.body.appendChild(t);var r=t.getBoundingClientRect().width;return document.body.removeChild(t),-r}(a,i);C(o)}}}))};
+//# sourceMappingURL=index.es.js.map
+
+
+/***/ }),
+
+/***/ "./node_modules/shallowequal/index.js":
+/*!********************************************!*\
+  !*** ./node_modules/shallowequal/index.js ***!
+  \********************************************/
+/***/ ((module) => {
+
+//
+
+module.exports = function shallowEqual(objA, objB, compare, compareContext) {
+  var ret = compare ? compare.call(compareContext, objA, objB) : void 0;
+
+  if (ret !== void 0) {
+    return !!ret;
+  }
+
+  if (objA === objB) {
+    return true;
+  }
+
+  if (typeof objA !== "object" || !objA || typeof objB !== "object" || !objB) {
+    return false;
+  }
+
+  var keysA = Object.keys(objA);
+  var keysB = Object.keys(objB);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  var bHasOwnProperty = Object.prototype.hasOwnProperty.bind(objB);
+
+  // Test for A's keys different from B.
+  for (var idx = 0; idx < keysA.length; idx++) {
+    var key = keysA[idx];
+
+    if (!bHasOwnProperty(key)) {
+      return false;
+    }
+
+    var valueA = objA[key];
+    var valueB = objB[key];
+
+    ret = compare ? compare.call(compareContext, valueA, valueB, key) : void 0;
+
+    if (ret === false || (ret === void 0 && valueA !== valueB)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/dist/styled-components.browser.esm.js":
+/*!******************************************************************************!*\
+  !*** ./node_modules/styled-components/dist/styled-components.browser.esm.js ***!
+  \******************************************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   ServerStyleSheet: () => (/* binding */ ut),
+/* harmony export */   StyleSheetConsumer: () => (/* binding */ je),
+/* harmony export */   StyleSheetContext: () => (/* binding */ ke),
+/* harmony export */   StyleSheetManager: () => (/* binding */ Me),
+/* harmony export */   ThemeConsumer: () => (/* binding */ Ue),
+/* harmony export */   ThemeContext: () => (/* binding */ He),
+/* harmony export */   ThemeProvider: () => (/* binding */ Xe),
+/* harmony export */   __PRIVATE__: () => (/* binding */ pt),
+/* harmony export */   createGlobalStyle: () => (/* binding */ at),
+/* harmony export */   css: () => (/* binding */ nt),
+/* harmony export */   "default": () => (/* binding */ st),
+/* harmony export */   isStyledComponent: () => (/* binding */ ee),
+/* harmony export */   keyframes: () => (/* binding */ ct),
+/* harmony export */   styled: () => (/* binding */ st),
+/* harmony export */   useTheme: () => (/* binding */ Je),
+/* harmony export */   version: () => (/* binding */ m),
+/* harmony export */   withTheme: () => (/* binding */ lt)
+/* harmony export */ });
+/* harmony import */ var tslib__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! tslib */ "./node_modules/tslib/tslib.es6.mjs");
+/* harmony import */ var _emotion_is_prop_valid__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @emotion/is-prop-valid */ "./node_modules/@emotion/is-prop-valid/dist/emotion-is-prop-valid.esm.js");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var shallowequal__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! shallowequal */ "./node_modules/shallowequal/index.js");
+/* harmony import */ var shallowequal__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(shallowequal__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var stylis__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! stylis */ "./node_modules/styled-components/node_modules/stylis/src/Enum.js");
+/* harmony import */ var stylis__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! stylis */ "./node_modules/styled-components/node_modules/stylis/src/Middleware.js");
+/* harmony import */ var stylis__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(/*! stylis */ "./node_modules/styled-components/node_modules/stylis/src/Serializer.js");
+/* harmony import */ var stylis__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(/*! stylis */ "./node_modules/styled-components/node_modules/stylis/src/Parser.js");
+/* harmony import */ var _emotion_unitless__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! @emotion/unitless */ "./node_modules/@emotion/unitless/dist/emotion-unitless.esm.js");
+var f="undefined"!=typeof process&&void 0!==process.env&&(process.env.REACT_APP_SC_ATTR||process.env.SC_ATTR)||"data-styled",m="6.0.3",y="undefined"!=typeof window&&"HTMLElement"in window,v=Boolean("boolean"==typeof SC_DISABLE_SPEEDY?SC_DISABLE_SPEEDY:"undefined"!=typeof process&&void 0!==process.env&&void 0!==process.env.REACT_APP_SC_DISABLE_SPEEDY&&""!==process.env.REACT_APP_SC_DISABLE_SPEEDY?"false"!==process.env.REACT_APP_SC_DISABLE_SPEEDY&&process.env.REACT_APP_SC_DISABLE_SPEEDY:"undefined"!=typeof process&&void 0!==process.env&&void 0!==process.env.SC_DISABLE_SPEEDY&&""!==process.env.SC_DISABLE_SPEEDY?"false"!==process.env.SC_DISABLE_SPEEDY&&process.env.SC_DISABLE_SPEEDY:"production"!=="development"),g={},S=/invalid hook call/i,w=new Set,E=function(t,n){if(true){var o=n?' with the id of "'.concat(n,'"'):"",s="The component ".concat(t).concat(o," has been created dynamically.\n")+"You may see this warning because you've called styled inside another component.\nTo resolve this only create new StyledComponents outside of any render method and function component.",i=console.error;try{var a=!0;console.error=function(t){for(var n=[],o=1;o<arguments.length;o++)n[o-1]=arguments[o];S.test(t)?(a=!1,w.delete(s)):i.apply(void 0,(0,tslib__WEBPACK_IMPORTED_MODULE_4__.__spreadArray)([t],n,!1))},(0,react__WEBPACK_IMPORTED_MODULE_1__.useRef)(),a&&!w.has(s)&&(console.warn(s),w.add(s))}catch(e){S.test(e.message)&&w.delete(s)}finally{console.error=i}}},b=Object.freeze([]),N=Object.freeze({});function P(e,t,n){return void 0===n&&(n=N),e.theme!==n.theme&&e.theme||t||n.theme}var _=new Set(["a","abbr","address","area","article","aside","audio","b","base","bdi","bdo","big","blockquote","body","br","button","canvas","caption","cite","code","col","colgroup","data","datalist","dd","del","details","dfn","dialog","div","dl","dt","em","embed","fieldset","figcaption","figure","footer","form","h1","h2","h3","h4","h5","h6","head","header","hgroup","hr","html","i","iframe","img","input","ins","kbd","keygen","label","legend","li","link","main","map","mark","menu","menuitem","meta","meter","nav","noscript","object","ol","optgroup","option","output","p","param","picture","pre","progress","q","rp","rt","ruby","s","samp","script","section","select","small","source","span","strong","style","sub","summary","sup","table","tbody","td","textarea","tfoot","th","thead","time","title","tr","track","u","ul","use","var","video","wbr","circle","clipPath","defs","ellipse","foreignObject","g","image","line","linearGradient","marker","mask","path","pattern","polygon","polyline","radialGradient","rect","stop","svg","text","tspan"]),C=/[!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~-]+/g,I=/(^-|-$)/g;function A(e){return e.replace(C,"-").replace(I,"")}var O=/(a)(d)/gi,D=function(e){return String.fromCharCode(e+(e>25?39:97))};function R(e){var t,n="";for(t=Math.abs(e);t>52;t=t/52|0)n=D(t%52)+n;return(D(t%52)+n).replace(O,"$1-$2")}var T,k=function(e,t){for(var n=t.length;n;)e=33*e^t.charCodeAt(--n);return e},j=function(e){return k(5381,e)};function x(e){return R(j(e)>>>0)}function V(e){return true&&"string"==typeof e&&e||e.displayName||e.name||"Component"}function M(e){return"string"==typeof e&&( false||e.charAt(0)===e.charAt(0).toLowerCase())}var F="function"==typeof Symbol&&Symbol.for,$=F?Symbol.for("react.memo"):60115,z=F?Symbol.for("react.forward_ref"):60112,B={childContextTypes:!0,contextType:!0,contextTypes:!0,defaultProps:!0,displayName:!0,getDefaultProps:!0,getDerivedStateFromError:!0,getDerivedStateFromProps:!0,mixins:!0,propTypes:!0,type:!0},L={name:!0,length:!0,prototype:!0,caller:!0,callee:!0,arguments:!0,arity:!0},G={$$typeof:!0,compare:!0,defaultProps:!0,displayName:!0,propTypes:!0,type:!0},Y=((T={})[z]={$$typeof:!0,render:!0,defaultProps:!0,displayName:!0,propTypes:!0},T[$]=G,T);function W(e){return("type"in(t=e)&&t.type.$$typeof)===$?G:"$$typeof"in e?Y[e.$$typeof]:B;var t}var q=Object.defineProperty,H=Object.getOwnPropertyNames,U=Object.getOwnPropertySymbols,J=Object.getOwnPropertyDescriptor,X=Object.getPrototypeOf,Z=Object.prototype;function K(e,t,n){if("string"!=typeof t){if(Z){var o=X(t);o&&o!==Z&&K(e,o,n)}var r=H(t);U&&(r=r.concat(U(t)));for(var s=W(e),i=W(t),a=0;a<r.length;++a){var c=r[a];if(!(c in L||n&&n[c]||i&&c in i||s&&c in s)){var l=J(t,c);try{q(e,c,l)}catch(e){}}}}return e}function Q(e){return"function"==typeof e}function ee(e){return"object"==typeof e&&"styledComponentId"in e}function te(e,t){return e&&t?"".concat(e," ").concat(t):e||t||""}function ne(e,t){if(0===e.length)return"";for(var n=e[0],o=1;o<e.length;o++)n+=t?t+e[o]:e[o];return n}function oe(e){return null!==e&&"object"==typeof e&&e.constructor.name===Object.name&&!("props"in e&&e.$$typeof)}function re(e,t,n){if(void 0===n&&(n=!1),!n&&!oe(e)&&!Array.isArray(e))return t;if(Array.isArray(t))for(var o=0;o<t.length;o++)e[o]=re(e[o],t[o]);else if(oe(t))for(var o in t)e[o]=re(e[o],t[o]);return e}function se(e,t){Object.defineProperty(e,"toString",{value:t})}var ie= true?{1:"Cannot create styled-component for component: %s.\n\n",2:"Can't collect styles once you've consumed a `ServerStyleSheet`'s styles! `ServerStyleSheet` is a one off instance for each server-side render cycle.\n\n- Are you trying to reuse it across renders?\n- Are you accidentally calling collectStyles twice?\n\n",3:"Streaming SSR is only supported in a Node.js environment; Please do not try to call this method in the browser.\n\n",4:"The `StyleSheetManager` expects a valid target or sheet prop!\n\n- Does this error occur on the client and is your target falsy?\n- Does this error occur on the server and is the sheet falsy?\n\n",5:"The clone method cannot be used on the client!\n\n- Are you running in a client-like environment on the server?\n- Are you trying to run SSR on the client?\n\n",6:"Trying to insert a new style tag, but the given Node is unmounted!\n\n- Are you using a custom target that isn't mounted?\n- Does your document not have a valid head element?\n- Have you accidentally removed a style tag manually?\n\n",7:'ThemeProvider: Please return an object from your "theme" prop function, e.g.\n\n```js\ntheme={() => ({})}\n```\n\n',8:'ThemeProvider: Please make your "theme" prop an object.\n\n',9:"Missing document `<head>`\n\n",10:"Cannot find a StyleSheet instance. Usually this happens if there are multiple copies of styled-components loaded at once. Check out this issue for how to troubleshoot and fix the common cases where this situation can happen: https://github.com/styled-components/styled-components/issues/1941#issuecomment-417862021\n\n",11:"_This error was replaced with a dev-time warning, it will be deleted for v4 final._ [createGlobalStyle] received children which will not be rendered. Please use the component without passing children elements.\n\n",12:"It seems you are interpolating a keyframe declaration (%s) into an untagged string. This was supported in styled-components v3, but is not longer supported in v4 as keyframes are now injected on-demand. Please wrap your string in the css\\`\\` helper which ensures the styles are injected correctly. See https://www.styled-components.com/docs/api#css\n\n",13:"%s is not a styled component and cannot be referred to via component selector. See https://www.styled-components.com/docs/advanced#referring-to-other-components for more details.\n\n",14:'ThemeProvider: "theme" prop is required.\n\n',15:"A stylis plugin has been supplied that is not named. We need a name for each plugin to be able to prevent styling collisions between different stylis configurations within the same app. Before you pass your plugin to `<StyleSheetManager stylisPlugins={[]}>`, please make sure each plugin is uniquely-named, e.g.\n\n```js\nObject.defineProperty(importedPlugin, 'name', { value: 'some-unique-name' });\n```\n\n",16:"Reached the limit of how many styled components may be created at group %s.\nYou may only create up to 1,073,741,824 components. If you're creating components dynamically,\nas for instance in your render method then you may be running into this limitation.\n\n",17:"CSSStyleSheet could not be found on HTMLStyleElement.\nHas styled-components' style tag been unmounted or altered by another script?\n",18:"ThemeProvider: Please make sure your useTheme hook is within a `<ThemeProvider>`"}:0;function ae(){for(var e=[],t=0;t<arguments.length;t++)e[t]=arguments[t];for(var n=e[0],o=[],r=1,s=e.length;r<s;r+=1)o.push(e[r]);return o.forEach(function(e){n=n.replace(/%[a-z]/,e)}),n}function ce(t){for(var n=[],o=1;o<arguments.length;o++)n[o-1]=arguments[o];return false?0:new Error(ae.apply(void 0,(0,tslib__WEBPACK_IMPORTED_MODULE_4__.__spreadArray)([ie[t]],n,!1)).trim())}var le=function(){function e(e){this.groupSizes=new Uint32Array(512),this.length=512,this.tag=e}return e.prototype.indexOfGroup=function(e){for(var t=0,n=0;n<e;n++)t+=this.groupSizes[n];return t},e.prototype.insertRules=function(e,t){if(e>=this.groupSizes.length){for(var n=this.groupSizes,o=n.length,r=o;e>=r;)if((r<<=1)<0)throw ce(16,"".concat(e));this.groupSizes=new Uint32Array(r),this.groupSizes.set(n),this.length=r;for(var s=o;s<r;s++)this.groupSizes[s]=0}for(var i=this.indexOfGroup(e+1),a=(s=0,t.length);s<a;s++)this.tag.insertRule(i,t[s])&&(this.groupSizes[e]++,i++)},e.prototype.clearGroup=function(e){if(e<this.length){var t=this.groupSizes[e],n=this.indexOfGroup(e),o=n+t;this.groupSizes[e]=0;for(var r=n;r<o;r++)this.tag.deleteRule(n)}},e.prototype.getGroup=function(e){var t="";if(e>=this.length||0===this.groupSizes[e])return t;for(var n=this.groupSizes[e],o=this.indexOfGroup(e),r=o+n,s=o;s<r;s++)t+="".concat(this.tag.getRule(s)).concat("/*!sc*/\n");return t},e}(),ue=new Map,pe=new Map,de=1,he=function(e){if(ue.has(e))return ue.get(e);for(;pe.has(de);)de++;var t=de++;if( true&&((0|t)<0||t>1073741824))throw ce(16,"".concat(t));return ue.set(e,t),pe.set(t,e),t},fe=function(e,t){ue.set(e,t),pe.set(t,e)},me="style[".concat(f,"][").concat("data-styled-version",'="').concat("6.0.3",'"]'),ye=new RegExp("^".concat(f,'\\.g(\\d+)\\[id="([\\w\\d-]+)"\\].*?"([^"]*)')),ve=function(e,t,n){for(var o,r=n.split(","),s=0,i=r.length;s<i;s++)(o=r[s])&&e.registerName(t,o)},ge=function(e,t){for(var n,o=(null!==(n=t.textContent)&&void 0!==n?n:"").split("/*!sc*/\n"),r=[],s=0,i=o.length;s<i;s++){var a=o[s].trim();if(a){var c=a.match(ye);if(c){var l=0|parseInt(c[1],10),u=c[2];0!==l&&(fe(u,l),ve(e,u,c[3]),e.getTag().insertRules(l,r)),r.length=0}else r.push(a)}}};function Se(){return true?__webpack_require__.nc:0}var we=function(e){var t=document.head,n=e||t,o=document.createElement("style"),r=function(e){var t=Array.from(e.querySelectorAll("style[".concat(f,"]")));return t[t.length-1]}(n),s=void 0!==r?r.nextSibling:null;o.setAttribute(f,"active"),o.setAttribute("data-styled-version","6.0.3");var i=Se();return i&&o.setAttribute("nonce",i),n.insertBefore(o,s),o},Ee=function(){function e(e){this.element=we(e),this.element.appendChild(document.createTextNode("")),this.sheet=function(e){if(e.sheet)return e.sheet;for(var t=document.styleSheets,n=0,o=t.length;n<o;n++){var r=t[n];if(r.ownerNode===e)return r}throw ce(17)}(this.element),this.length=0}return e.prototype.insertRule=function(e,t){try{return this.sheet.insertRule(t,e),this.length++,!0}catch(e){return!1}},e.prototype.deleteRule=function(e){this.sheet.deleteRule(e),this.length--},e.prototype.getRule=function(e){var t=this.sheet.cssRules[e];return t&&t.cssText?t.cssText:""},e}(),be=function(){function e(e){this.element=we(e),this.nodes=this.element.childNodes,this.length=0}return e.prototype.insertRule=function(e,t){if(e<=this.length&&e>=0){var n=document.createTextNode(t);return this.element.insertBefore(n,this.nodes[e]||null),this.length++,!0}return!1},e.prototype.deleteRule=function(e){this.element.removeChild(this.nodes[e]),this.length--},e.prototype.getRule=function(e){return e<this.length?this.nodes[e].textContent:""},e}(),Ne=function(){function e(e){this.rules=[],this.length=0}return e.prototype.insertRule=function(e,t){return e<=this.length&&(this.rules.splice(e,0,t),this.length++,!0)},e.prototype.deleteRule=function(e){this.rules.splice(e,1),this.length--},e.prototype.getRule=function(e){return e<this.length?this.rules[e]:""},e}(),Pe=y,_e={isServer:!y,useCSSOMInjection:!v},Ce=function(){function e(e,n,o){void 0===e&&(e=N),void 0===n&&(n={});var r=this;this.options=(0,tslib__WEBPACK_IMPORTED_MODULE_4__.__assign)((0,tslib__WEBPACK_IMPORTED_MODULE_4__.__assign)({},_e),e),this.gs=n,this.names=new Map(o),this.server=!!e.isServer,!this.server&&y&&Pe&&(Pe=!1,function(e){for(var t=document.querySelectorAll(me),n=0,o=t.length;n<o;n++){var r=t[n];r&&"active"!==r.getAttribute(f)&&(ge(e,r),r.parentNode&&r.parentNode.removeChild(r))}}(this)),se(this,function(){return function(e){for(var t=e.getTag(),n=t.length,o="",r=function(n){var r=function(e){return pe.get(e)}(n);if(void 0===r)return"continue";var s=e.names.get(r),i=t.getGroup(n);if(void 0===s||0===i.length)return"continue";var a="".concat(f,".g").concat(n,'[id="').concat(r,'"]'),c="";void 0!==s&&s.forEach(function(e){e.length>0&&(c+="".concat(e,","))}),o+="".concat(i).concat(a,'{content:"').concat(c,'"}').concat("/*!sc*/\n")},s=0;s<n;s++)r(s);return o}(r)})}return e.registerId=function(e){return he(e)},e.prototype.reconstructWithOptions=function(n,o){return void 0===o&&(o=!0),new e((0,tslib__WEBPACK_IMPORTED_MODULE_4__.__assign)((0,tslib__WEBPACK_IMPORTED_MODULE_4__.__assign)({},this.options),n),this.gs,o&&this.names||void 0)},e.prototype.allocateGSInstance=function(e){return this.gs[e]=(this.gs[e]||0)+1},e.prototype.getTag=function(){return this.tag||(this.tag=(e=function(e){var t=e.useCSSOMInjection,n=e.target;return e.isServer?new Ne(n):t?new Ee(n):new be(n)}(this.options),new le(e)));var e},e.prototype.hasNameForId=function(e,t){return this.names.has(e)&&this.names.get(e).has(t)},e.prototype.registerName=function(e,t){if(he(e),this.names.has(e))this.names.get(e).add(t);else{var n=new Set;n.add(t),this.names.set(e,n)}},e.prototype.insertRules=function(e,t,n){this.registerName(e,t),this.getTag().insertRules(he(e),n)},e.prototype.clearNames=function(e){this.names.has(e)&&this.names.get(e).clear()},e.prototype.clearRules=function(e){this.getTag().clearGroup(he(e)),this.clearNames(e)},e.prototype.clearTag=function(){this.tag=void 0},e}(),Ie=/&/g,Ae=/^\s*\/\/.*$/gm;function Oe(e,t){return e.map(function(e){return"rule"===e.type&&(e.value="".concat(t," ").concat(e.value),e.value=e.value.replaceAll(",",",".concat(t," ")),e.props=e.props.map(function(e){return"".concat(t," ").concat(e)})),Array.isArray(e.children)&&"@keyframes"!==e.type&&(e.children=Oe(e.children,t)),e})}function De(e){var t,n,o,r=void 0===e?N:e,s=r.options,i=void 0===s?N:s,a=r.plugins,c=void 0===a?b:a,l=function(e,o,r){return r===n||r.startsWith(n)&&r.endsWith(n)&&r.replaceAll(n,"").length>0?".".concat(t):e},u=c.slice();u.push(function(e){e.type===stylis__WEBPACK_IMPORTED_MODULE_5__.RULESET&&e.value.includes("&")&&(e.props[0]=e.props[0].replace(Ie,n).replace(o,l))}),i.prefix&&u.push(stylis__WEBPACK_IMPORTED_MODULE_6__.prefixer),u.push(stylis__WEBPACK_IMPORTED_MODULE_7__.stringify);var p=function(e,r,s,a){void 0===r&&(r=""),void 0===s&&(s=""),void 0===a&&(a="&"),t=a,n=r,o=new RegExp("\\".concat(n,"\\b"),"g");var c=e.replace(Ae,""),l=stylis__WEBPACK_IMPORTED_MODULE_8__.compile(s||r?"".concat(s," ").concat(r," { ").concat(c," }"):c);i.namespace&&(l=Oe(l,i.namespace));var p=[];return stylis__WEBPACK_IMPORTED_MODULE_7__.serialize(l,stylis__WEBPACK_IMPORTED_MODULE_6__.middleware(u.concat(stylis__WEBPACK_IMPORTED_MODULE_6__.rulesheet(function(e){return p.push(e)})))),p};return p.hash=c.length?c.reduce(function(e,t){return t.name||ce(15),k(e,t.name)},5381).toString():"",p}var Re=new Ce,Te=De(),ke=react__WEBPACK_IMPORTED_MODULE_1___default().createContext({shouldForwardProp:void 0,styleSheet:Re,stylis:Te}),je=ke.Consumer,xe=react__WEBPACK_IMPORTED_MODULE_1___default().createContext(void 0);function Ve(){return (0,react__WEBPACK_IMPORTED_MODULE_1__.useContext)(ke)}function Me(e){var t=(0,react__WEBPACK_IMPORTED_MODULE_1__.useState)(e.stylisPlugins),n=t[0],r=t[1],c=Ve().styleSheet,l=(0,react__WEBPACK_IMPORTED_MODULE_1__.useMemo)(function(){var t=c;return e.sheet?t=e.sheet:e.target&&(t=t.reconstructWithOptions({target:e.target},!1)),e.disableCSSOMInjection&&(t=t.reconstructWithOptions({useCSSOMInjection:!1})),t},[e.disableCSSOMInjection,e.sheet,e.target,c]),u=(0,react__WEBPACK_IMPORTED_MODULE_1__.useMemo)(function(){return De({options:{namespace:e.namespace,prefix:e.enableVendorPrefixes},plugins:n})},[e.enableVendorPrefixes,e.namespace,n]);return (0,react__WEBPACK_IMPORTED_MODULE_1__.useEffect)(function(){shallowequal__WEBPACK_IMPORTED_MODULE_2___default()(n,e.stylisPlugins)||r(e.stylisPlugins)},[e.stylisPlugins]),react__WEBPACK_IMPORTED_MODULE_1___default().createElement(ke.Provider,{value:{shouldForwardProp:e.shouldForwardProp,styleSheet:l,stylis:u}},react__WEBPACK_IMPORTED_MODULE_1___default().createElement(xe.Provider,{value:u},e.children))}var Fe=function(){function e(e,t){var n=this;this.inject=function(e,t){void 0===t&&(t=Te);var o=n.name+t.hash;e.hasNameForId(n.id,o)||e.insertRules(n.id,o,t(n.rules,o,"@keyframes"))},this.name=e,this.id="sc-keyframes-".concat(e),this.rules=t,se(this,function(){throw ce(12,String(n.name))})}return e.prototype.getName=function(e){return void 0===e&&(e=Te),this.name+e.hash},e}(),$e=function(e){return e>="A"&&e<="Z"};function ze(e){for(var t="",n=0;n<e.length;n++){var o=e[n];if(1===n&&"-"===o&&"-"===e[0])return e;$e(o)?t+="-"+o.toLowerCase():t+=o}return t.startsWith("ms-")?"-"+t:t}var Be=function(e){return null==e||!1===e||""===e},Le=function(t){var n,o,r=[];for(var s in t){var i=t[s];t.hasOwnProperty(s)&&!Be(i)&&(Array.isArray(i)&&i.isCss||Q(i)?r.push("".concat(ze(s),":"),i,";"):oe(i)?r.push.apply(r,(0,tslib__WEBPACK_IMPORTED_MODULE_4__.__spreadArray)((0,tslib__WEBPACK_IMPORTED_MODULE_4__.__spreadArray)(["".concat(s," {")],Le(i),!1),["}"],!1)):r.push("".concat(ze(s),": ").concat((n=s,null==(o=i)||"boolean"==typeof o||""===o?"":"number"!=typeof o||0===o||n in _emotion_unitless__WEBPACK_IMPORTED_MODULE_3__["default"]||n.startsWith("--")?String(o).trim():"".concat(o,"px")),";")))}return r};function Ge(e,t,n,o){if(Be(e))return[];if(ee(e))return[".".concat(e.styledComponentId)];if(Q(e)){if(!Q(s=e)||s.prototype&&s.prototype.isReactComponent||!t)return[e];var r=e(t);return false||"object"!=typeof r||Array.isArray(r)||r instanceof Fe||oe(r)||null===r||console.error("".concat(V(e)," is not a styled component and cannot be referred to via component selector. See https://www.styled-components.com/docs/advanced#referring-to-other-components for more details.")),Ge(r,t,n,o)}var s;return e instanceof Fe?n?(e.inject(n,o),[e.getName(o)]):[e]:oe(e)?Le(e):Array.isArray(e)?Array.prototype.concat.apply(b,e.map(function(e){return Ge(e,t,n,o)})):[e.toString()]}function Ye(e){for(var t=0;t<e.length;t+=1){var n=e[t];if(Q(n)&&!ee(n))return!1}return!0}var We=j("6.0.3"),qe=function(){function e(e,t,n){this.rules=e,this.staticRulesId="",this.isStatic= false&&0,this.componentId=t,this.baseHash=k(We,t),this.baseStyle=n,Ce.registerId(t)}return e.prototype.generateAndInjectStyles=function(e,t,n){var o=this.baseStyle?this.baseStyle.generateAndInjectStyles(e,t,n):"";if(this.isStatic&&!n.hash)if(this.staticRulesId&&t.hasNameForId(this.componentId,this.staticRulesId))o=te(o,this.staticRulesId);else{var r=ne(Ge(this.rules,e,t,n)),s=R(k(this.baseHash,r)>>>0);if(!t.hasNameForId(this.componentId,s)){var i=n(r,".".concat(s),void 0,this.componentId);t.insertRules(this.componentId,s,i)}o=te(o,s),this.staticRulesId=s}else{for(var a=k(this.baseHash,n.hash),c="",l=0;l<this.rules.length;l++){var u=this.rules[l];if("string"==typeof u)c+=u, true&&(a=k(a,u));else if(u){var p=ne(Ge(u,e,t,n));a=k(a,p),c+=p}}if(c){var d=R(a>>>0);t.hasNameForId(this.componentId,d)||t.insertRules(this.componentId,d,n(c,".".concat(d),void 0,this.componentId)),o=te(o,d)}}return o},e}(),He=react__WEBPACK_IMPORTED_MODULE_1___default().createContext(void 0),Ue=He.Consumer;function Je(){var e=(0,react__WEBPACK_IMPORTED_MODULE_1__.useContext)(He);if(!e)throw ce(18);return e}function Xe(e){var n=react__WEBPACK_IMPORTED_MODULE_1___default().useContext(He),r=(0,react__WEBPACK_IMPORTED_MODULE_1__.useMemo)(function(){return function(e,n){if(!e)throw ce(14);if(Q(e)){var o=e(n);if( true&&(null===o||Array.isArray(o)||"object"!=typeof o))throw ce(7);return o}if(Array.isArray(e)||"object"!=typeof e)throw ce(8);return n?(0,tslib__WEBPACK_IMPORTED_MODULE_4__.__assign)((0,tslib__WEBPACK_IMPORTED_MODULE_4__.__assign)({},n),e):e}(e.theme,n)},[e.theme,n]);return e.children?react__WEBPACK_IMPORTED_MODULE_1___default().createElement(He.Provider,{value:r},e.children):null}var Ze={},Ke=new Set;function Qe(e,r,s){var i=ee(e),a=e,c=!M(e),p=r.attrs,d=void 0===p?b:p,h=r.componentId,f=void 0===h?function(e,t){var n="string"!=typeof e?"sc":A(e);Ze[n]=(Ze[n]||0)+1;var o="".concat(n,"-").concat(x("6.0.3"+n+Ze[n]));return t?"".concat(t,"-").concat(o):o}(r.displayName,r.parentComponentId):h,m=r.displayName,y=void 0===m?function(e){return M(e)?"styled.".concat(e):"Styled(".concat(V(e),")")}(e):m,v=r.displayName&&r.componentId?"".concat(A(r.displayName),"-").concat(r.componentId):r.componentId||f,g=i&&a.attrs?a.attrs.concat(d).filter(Boolean):d,S=r.shouldForwardProp;if(i&&a.shouldForwardProp){var w=a.shouldForwardProp;if(r.shouldForwardProp){var C=r.shouldForwardProp;S=function(e,t){return w(e,t)&&C(e,t)}}else S=w}var I=new qe(s,v,i?a.componentStyle:void 0);function O(e,r){return function(e,r,s){var i=e.attrs,a=e.componentStyle,c=e.defaultProps,p=e.foldedComponentIds,d=e.styledComponentId,h=e.target,f=react__WEBPACK_IMPORTED_MODULE_1___default().useContext(He),m=Ve(),y=e.shouldForwardProp||m.shouldForwardProp; true&&(0,react__WEBPACK_IMPORTED_MODULE_1__.useDebugValue)(d);var v=function(e,n,o){for(var r,s=(0,tslib__WEBPACK_IMPORTED_MODULE_4__.__assign)((0,tslib__WEBPACK_IMPORTED_MODULE_4__.__assign)({},n),{className:void 0,theme:o}),i=0;i<e.length;i+=1){var a=Q(r=e[i])?r(s):r;for(var c in a)s[c]="className"===c?te(s[c],a[c]):"style"===c?(0,tslib__WEBPACK_IMPORTED_MODULE_4__.__assign)((0,tslib__WEBPACK_IMPORTED_MODULE_4__.__assign)({},s[c]),a[c]):a[c]}return n.className&&(s.className=te(s.className,n.className)),s}(i,r,P(r,f,c)||N),g=v.as||h,S={};for(var w in v)void 0===v[w]||"$"===w[0]||"as"===w||"theme"===w||("forwardedAs"===w?S.as=v.forwardedAs:y&&!y(w,g)||(S[w]=v[w],y||"development"!=="development"||(0,_emotion_is_prop_valid__WEBPACK_IMPORTED_MODULE_0__["default"])(w)||Ke.has(w)||(Ke.add(w),console.warn('styled-components: it looks like an unknown prop "'.concat(w,'" is being sent through to the DOM, which will likely trigger a React console error. If you would like automatic filtering of unknown props, you can opt-into that behavior via `<StyleSheetManager shouldForwardProp={...}>` (connect an API like `@emotion/is-prop-valid`) or consider using transient props (`$` prefix for automatic filtering.)')))));var E=function(e,t){var n=Ve(),o=e.generateAndInjectStyles(t,n.styleSheet,n.stylis);return true&&(0,react__WEBPACK_IMPORTED_MODULE_1__.useDebugValue)(o),o}(a,v); true&&e.warnTooManyClasses&&e.warnTooManyClasses(E);var b=te(p,d);return E&&(b+=" "+E),v.className&&(b+=" "+v.className),S[M(g)&&!_.has(g)?"class":"className"]=b,S.ref=s,(0,react__WEBPACK_IMPORTED_MODULE_1__.createElement)(g,S)}(D,e,r)} true&&(O.displayName=y);var D=react__WEBPACK_IMPORTED_MODULE_1___default().forwardRef(O);return D.attrs=g,D.componentStyle=I,D.shouldForwardProp=S, true&&(D.displayName=y),D.foldedComponentIds=i?te(a.foldedComponentIds,a.styledComponentId):"",D.styledComponentId=v,D.target=i?a.target:e,Object.defineProperty(D,"defaultProps",{get:function(){return this._foldedDefaultProps},set:function(e){this._foldedDefaultProps=i?function(e){for(var t=[],n=1;n<arguments.length;n++)t[n-1]=arguments[n];for(var o=0,r=t;o<r.length;o++)re(e,r[o],!0);return e}({},a.defaultProps,e):e}}), true&&(E(y,v),D.warnTooManyClasses=function(e,t){var n={},o=!1;return function(r){if(!o&&(n[r]=!0,Object.keys(n).length>=200)){var s=t?' with the id of "'.concat(t,'"'):"";console.warn("Over ".concat(200," classes were generated for component ").concat(e).concat(s,".\n")+"Consider using the attrs method, together with a style object for frequently changed styles.\nExample:\n  const Component = styled.div.attrs(props => ({\n    style: {\n      background: props.background,\n    },\n  }))`width: 100%;`\n\n  <Component />"),o=!0,n={}}}}(y,v)),se(D,function(){return".".concat(D.styledComponentId)}),c&&K(D,e,{attrs:!0,componentStyle:!0,displayName:!0,foldedComponentIds:!0,shouldForwardProp:!0,styledComponentId:!0,target:!0}),D}function et(e,t){for(var n=[e[0]],o=0,r=t.length;o<r;o+=1)n.push(t[o],e[o+1]);return n}var tt=function(e){return Object.assign(e,{isCss:!0})};function nt(t){for(var n=[],o=1;o<arguments.length;o++)n[o-1]=arguments[o];if(Q(t)||oe(t)){var r=t;return tt(Ge(et(b,(0,tslib__WEBPACK_IMPORTED_MODULE_4__.__spreadArray)([r],n,!0))))}var s=t;return 0===n.length&&1===s.length&&"string"==typeof s[0]?Ge(s):tt(Ge(et(s,n)))}function ot(n,o,r){if(void 0===r&&(r=N),!o)throw ce(1,o);var s=function(t){for(var s=[],i=1;i<arguments.length;i++)s[i-1]=arguments[i];return n(o,r,nt.apply(void 0,(0,tslib__WEBPACK_IMPORTED_MODULE_4__.__spreadArray)([t],s,!1)))};return s.attrs=function(e){return ot(n,o,(0,tslib__WEBPACK_IMPORTED_MODULE_4__.__assign)((0,tslib__WEBPACK_IMPORTED_MODULE_4__.__assign)({},r),{attrs:Array.prototype.concat(r.attrs,e).filter(Boolean)}))},s.withConfig=function(e){return ot(n,o,(0,tslib__WEBPACK_IMPORTED_MODULE_4__.__assign)((0,tslib__WEBPACK_IMPORTED_MODULE_4__.__assign)({},r),e))},s}var rt=function(e){return ot(Qe,e)},st=rt;_.forEach(function(e){st[e]=rt(e)});var it=function(){function e(e,t){this.rules=e,this.componentId=t,this.isStatic=Ye(e),Ce.registerId(this.componentId+1)}return e.prototype.createStyles=function(e,t,n,o){var r=o(ne(Ge(this.rules,t,n,o)),""),s=this.componentId+e;n.insertRules(s,s,r)},e.prototype.removeStyles=function(e,t){t.clearRules(this.componentId+e)},e.prototype.renderStyles=function(e,t,n,o){e>2&&Ce.registerId(this.componentId+e),this.removeStyles(e,n),this.createStyles(e,t,n,o)},e}();function at(n){for(var r=[],s=1;s<arguments.length;s++)r[s-1]=arguments[s];var i=nt.apply(void 0,(0,tslib__WEBPACK_IMPORTED_MODULE_4__.__spreadArray)([n],r,!1)),a="sc-global-".concat(x(JSON.stringify(i))),c=new it(i,a); true&&E(a);var l=function(e){var t=Ve(),n=react__WEBPACK_IMPORTED_MODULE_1___default().useContext(He),r=react__WEBPACK_IMPORTED_MODULE_1___default().useRef(t.styleSheet.allocateGSInstance(a)).current;return true&&react__WEBPACK_IMPORTED_MODULE_1___default().Children.count(e.children)&&console.warn("The global style component ".concat(a," was given child JSX. createGlobalStyle does not render children.")), true&&i.some(function(e){return"string"==typeof e&&-1!==e.indexOf("@import")})&&console.warn("Please do not use @import CSS syntax in createGlobalStyle at this time, as the CSSOM APIs we use in production do not handle it well. Instead, we recommend using a library such as react-helmet to inject a typical <link> meta tag to the stylesheet, or simply embedding it manually in your index.html <head> section for a simpler app."),t.styleSheet.server&&u(r,e,t.styleSheet,n,t.stylis),((react__WEBPACK_IMPORTED_MODULE_1___default().useInsertionEffect)||(react__WEBPACK_IMPORTED_MODULE_1___default().useLayoutEffect))(function(){if(!t.styleSheet.server)return u(r,e,t.styleSheet,n,t.stylis),function(){return c.removeStyles(r,t.styleSheet)}},[r,e,t.styleSheet,n,t.stylis]),null};function u(e,n,o,r,s){if(c.isStatic)c.renderStyles(e,g,o,s);else{var i=(0,tslib__WEBPACK_IMPORTED_MODULE_4__.__assign)((0,tslib__WEBPACK_IMPORTED_MODULE_4__.__assign)({},n),{theme:P(n,r,l.defaultProps)});c.renderStyles(e,i,o,s)}}return react__WEBPACK_IMPORTED_MODULE_1___default().memo(l)}function ct(t){for(var n=[],o=1;o<arguments.length;o++)n[o-1]=arguments[o]; true&&"undefined"!=typeof navigator&&"ReactNative"===navigator.product&&console.warn("`keyframes` cannot be used on ReactNative, only on the web. To do animation in ReactNative please use Animated.");var r=ne(nt.apply(void 0,(0,tslib__WEBPACK_IMPORTED_MODULE_4__.__spreadArray)([t],n,!1))),s=x(r);return new Fe(s,r)}function lt(e){var n=react__WEBPACK_IMPORTED_MODULE_1___default().forwardRef(function(n,r){var s=P(n,react__WEBPACK_IMPORTED_MODULE_1___default().useContext(He),e.defaultProps);return true&&void 0===s&&console.warn('[withTheme] You are not using a ThemeProvider nor passing a theme prop or a theme in defaultProps in component class "'.concat(V(e),'"')),react__WEBPACK_IMPORTED_MODULE_1___default().createElement(e,(0,tslib__WEBPACK_IMPORTED_MODULE_4__.__assign)({},n,{theme:s,ref:r}))});return true&&(n.displayName="WithTheme(".concat(V(e),")")),K(n,e)}var ut=function(){function e(){var e=this;this._emitSheetCSS=function(){var t=e.instance.toString(),n=Se(),o=ne([n&&'nonce="'.concat(n,'"'),"".concat(f,'="true"'),"".concat("data-styled-version",'="').concat("6.0.3",'"')].filter(Boolean)," ");return"<style ".concat(o,">").concat(t,"</style>")},this.getStyleTags=function(){if(e.sealed)throw ce(2);return e._emitSheetCSS()},this.getStyleElement=function(){var n;if(e.sealed)throw ce(2);var r=((n={})[f]="",n["data-styled-version"]="6.0.3",n.dangerouslySetInnerHTML={__html:e.instance.toString()},n),s=Se();return s&&(r.nonce=s),[react__WEBPACK_IMPORTED_MODULE_1___default().createElement("style",(0,tslib__WEBPACK_IMPORTED_MODULE_4__.__assign)({},r,{key:"sc-0-0"}))]},this.seal=function(){e.sealed=!0},this.instance=new Ce({isServer:!0}),this.sealed=!1}return e.prototype.collectStyles=function(e){if(this.sealed)throw ce(2);return react__WEBPACK_IMPORTED_MODULE_1___default().createElement(Me,{sheet:this.instance},e)},e.prototype.interleaveWithNodeStream=function(e){throw ce(3)},e}(),pt={StyleSheet:Ce,mainSheet:Re}; true&&"undefined"!=typeof navigator&&"ReactNative"===navigator.product&&console.warn("It looks like you've imported 'styled-components' on React Native.\nPerhaps you're looking to import 'styled-components/native'?\nRead more about this at https://www.styled-components.com/docs/basics#react-native");var dt="__sc-".concat(f,"__"); true&&"undefined"!=typeof window&&(window[dt]||(window[dt]=0),1===window[dt]&&console.warn("It looks like there are several instances of 'styled-components' initialized in this application. This may cause dynamic styles to not render properly, errors during the rehydration process, a missing theme prop, and makes your application bigger without good reason.\n\nSee https://s-c.sh/2BAXzed for more info."),window[dt]+=1);
+//# sourceMappingURL=styled-components.browser.esm.js.map
+
+
+/***/ }),
+
+/***/ "react":
+/*!************************!*\
+  !*** external "React" ***!
+  \************************/
+/***/ ((module) => {
+
+"use strict";
+module.exports = window["React"];
+
+/***/ }),
+
+/***/ "@wordpress/api-fetch":
+/*!**********************************!*\
+  !*** external ["wp","apiFetch"] ***!
+  \**********************************/
+/***/ ((module) => {
+
+"use strict";
+module.exports = window["wp"]["apiFetch"];
+
+/***/ }),
+
+/***/ "@wordpress/components":
+/*!************************************!*\
+  !*** external ["wp","components"] ***!
+  \************************************/
+/***/ ((module) => {
+
+"use strict";
+module.exports = window["wp"]["components"];
+
+/***/ }),
+
+/***/ "@wordpress/element":
+/*!*********************************!*\
+  !*** external ["wp","element"] ***!
+  \*********************************/
+/***/ ((module) => {
+
+"use strict";
+module.exports = window["wp"]["element"];
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/node_modules/stylis/src/Enum.js":
+/*!************************************************************************!*\
+  !*** ./node_modules/styled-components/node_modules/stylis/src/Enum.js ***!
+  \************************************************************************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   CHARSET: () => (/* binding */ CHARSET),
+/* harmony export */   COMMENT: () => (/* binding */ COMMENT),
+/* harmony export */   COUNTER_STYLE: () => (/* binding */ COUNTER_STYLE),
+/* harmony export */   DECLARATION: () => (/* binding */ DECLARATION),
+/* harmony export */   DOCUMENT: () => (/* binding */ DOCUMENT),
+/* harmony export */   FONT_FACE: () => (/* binding */ FONT_FACE),
+/* harmony export */   FONT_FEATURE_VALUES: () => (/* binding */ FONT_FEATURE_VALUES),
+/* harmony export */   IMPORT: () => (/* binding */ IMPORT),
+/* harmony export */   KEYFRAMES: () => (/* binding */ KEYFRAMES),
+/* harmony export */   LAYER: () => (/* binding */ LAYER),
+/* harmony export */   MEDIA: () => (/* binding */ MEDIA),
+/* harmony export */   MOZ: () => (/* binding */ MOZ),
+/* harmony export */   MS: () => (/* binding */ MS),
+/* harmony export */   NAMESPACE: () => (/* binding */ NAMESPACE),
+/* harmony export */   PAGE: () => (/* binding */ PAGE),
+/* harmony export */   RULESET: () => (/* binding */ RULESET),
+/* harmony export */   SUPPORTS: () => (/* binding */ SUPPORTS),
+/* harmony export */   VIEWPORT: () => (/* binding */ VIEWPORT),
+/* harmony export */   WEBKIT: () => (/* binding */ WEBKIT)
+/* harmony export */ });
+var MS = '-ms-'
+var MOZ = '-moz-'
+var WEBKIT = '-webkit-'
+
+var COMMENT = 'comm'
+var RULESET = 'rule'
+var DECLARATION = 'decl'
+
+var PAGE = '@page'
+var MEDIA = '@media'
+var IMPORT = '@import'
+var CHARSET = '@charset'
+var VIEWPORT = '@viewport'
+var SUPPORTS = '@supports'
+var DOCUMENT = '@document'
+var NAMESPACE = '@namespace'
+var KEYFRAMES = '@keyframes'
+var FONT_FACE = '@font-face'
+var COUNTER_STYLE = '@counter-style'
+var FONT_FEATURE_VALUES = '@font-feature-values'
+var LAYER = '@layer'
+
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/node_modules/stylis/src/Middleware.js":
+/*!******************************************************************************!*\
+  !*** ./node_modules/styled-components/node_modules/stylis/src/Middleware.js ***!
+  \******************************************************************************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   middleware: () => (/* binding */ middleware),
+/* harmony export */   namespace: () => (/* binding */ namespace),
+/* harmony export */   prefixer: () => (/* binding */ prefixer),
+/* harmony export */   rulesheet: () => (/* binding */ rulesheet)
+/* harmony export */ });
+/* harmony import */ var _Enum_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./Enum.js */ "./node_modules/styled-components/node_modules/stylis/src/Enum.js");
+/* harmony import */ var _Utility_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./Utility.js */ "./node_modules/styled-components/node_modules/stylis/src/Utility.js");
+/* harmony import */ var _Tokenizer_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./Tokenizer.js */ "./node_modules/styled-components/node_modules/stylis/src/Tokenizer.js");
+/* harmony import */ var _Serializer_js__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./Serializer.js */ "./node_modules/styled-components/node_modules/stylis/src/Serializer.js");
+/* harmony import */ var _Prefixer_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./Prefixer.js */ "./node_modules/styled-components/node_modules/stylis/src/Prefixer.js");
+
+
+
+
+
+
+/**
+ * @param {function[]} collection
+ * @return {function}
+ */
+function middleware (collection) {
+	var length = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.sizeof)(collection)
+
+	return function (element, index, children, callback) {
+		var output = ''
+
+		for (var i = 0; i < length; i++)
+			output += collection[i](element, index, children, callback) || ''
+
+		return output
+	}
+}
+
+/**
+ * @param {function} callback
+ * @return {function}
+ */
+function rulesheet (callback) {
+	return function (element) {
+		if (!element.root)
+			if (element = element.return)
+				callback(element)
+	}
+}
+
+/**
+ * @param {object} element
+ * @param {number} index
+ * @param {object[]} children
+ * @param {function} callback
+ */
+function prefixer (element, index, children, callback) {
+	if (element.length > -1)
+		if (!element.return)
+			switch (element.type) {
+				case _Enum_js__WEBPACK_IMPORTED_MODULE_1__.DECLARATION: element.return = (0,_Prefixer_js__WEBPACK_IMPORTED_MODULE_2__.prefix)(element.value, element.length, children)
+					return
+				case _Enum_js__WEBPACK_IMPORTED_MODULE_1__.KEYFRAMES:
+					return (0,_Serializer_js__WEBPACK_IMPORTED_MODULE_3__.serialize)([(0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_4__.copy)(element, {value: (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(element.value, '@', '@' + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT)})], callback)
+				case _Enum_js__WEBPACK_IMPORTED_MODULE_1__.RULESET:
+					if (element.length)
+						return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.combine)(children = element.props, function (value) {
+							switch ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.match)(value, callback = /(::plac\w+|:read-\w+)/)) {
+								// :read-(only|write)
+								case ':read-only': case ':read-write':
+									(0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_4__.lift)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_4__.copy)(element, {props: [(0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, /:(read-\w+)/, ':' + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MOZ + '$1')]}))
+									;(0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_4__.lift)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_4__.copy)(element, {props: [value]}))
+									;(0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.assign)(element, {props: (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.filter)(children, callback)})
+									break
+								// :placeholder
+								case '::placeholder':
+									;(0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_4__.lift)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_4__.copy)(element, {props: [(0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, /:(plac\w+)/, ':' + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + 'input-$1')]}))
+									;(0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_4__.lift)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_4__.copy)(element, {props: [(0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, /:(plac\w+)/, ':' + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MOZ + '$1')]}))
+									;(0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_4__.lift)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_4__.copy)(element, {props: [(0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, /:(plac\w+)/, _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + 'input-$1')]}))
+									;(0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_4__.lift)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_4__.copy)(element, {props: [value]}))
+									;(0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.assign)(element, {props: (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.filter)(children, callback)})
+									break
+							}
+
+							return ''
+						})
+			}
+}
+
+/**
+ * @param {object} element
+ * @param {number} index
+ * @param {object[]} children
+ */
+function namespace (element) {
+	switch (element.type) {
+		case _Enum_js__WEBPACK_IMPORTED_MODULE_1__.RULESET:
+			element.props = element.props.map(function (value) {
+				return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.combine)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_4__.tokenize)(value), function (value, index, children) {
+					switch ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.charat)(value, 0)) {
+						// \f
+						case 12:
+							return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.substr)(value, 1, (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.strlen)(value))
+						// \0 ( + > ~
+						case 0: case 40: case 43: case 62: case 126:
+							return value
+						// :
+						case 58:
+							if (children[++index] === 'global')
+								children[index] = '', children[++index] = '\f' + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.substr)(children[index], index = 1, -1)
+						// \s
+						case 32:
+							return index === 1 ? '' : value
+						default:
+							switch (index) {
+								case 0: element = value
+									return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.sizeof)(children) > 1 ? '' : value
+								case index = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.sizeof)(children) - 1: case 2:
+									return index === 2 ? value + element + element : value + element
+								default:
+									return value
+							}
+					}
+				})
+			})
+	}
+}
+
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/node_modules/stylis/src/Parser.js":
+/*!**************************************************************************!*\
+  !*** ./node_modules/styled-components/node_modules/stylis/src/Parser.js ***!
+  \**************************************************************************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   comment: () => (/* binding */ comment),
+/* harmony export */   compile: () => (/* binding */ compile),
+/* harmony export */   declaration: () => (/* binding */ declaration),
+/* harmony export */   parse: () => (/* binding */ parse),
+/* harmony export */   ruleset: () => (/* binding */ ruleset)
+/* harmony export */ });
+/* harmony import */ var _Enum_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./Enum.js */ "./node_modules/styled-components/node_modules/stylis/src/Enum.js");
+/* harmony import */ var _Utility_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./Utility.js */ "./node_modules/styled-components/node_modules/stylis/src/Utility.js");
+/* harmony import */ var _Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./Tokenizer.js */ "./node_modules/styled-components/node_modules/stylis/src/Tokenizer.js");
+
+
+
+
+/**
+ * @param {string} value
+ * @return {object[]}
+ */
+function compile (value) {
+	return (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.dealloc)(parse('', null, null, null, [''], value = (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.alloc)(value), 0, [0], value))
+}
+
+/**
+ * @param {string} value
+ * @param {object} root
+ * @param {object?} parent
+ * @param {string[]} rule
+ * @param {string[]} rules
+ * @param {string[]} rulesets
+ * @param {number[]} pseudo
+ * @param {number[]} points
+ * @param {string[]} declarations
+ * @return {object}
+ */
+function parse (value, root, parent, rule, rules, rulesets, pseudo, points, declarations) {
+	var index = 0
+	var offset = 0
+	var length = pseudo
+	var atrule = 0
+	var property = 0
+	var previous = 0
+	var variable = 1
+	var scanning = 1
+	var ampersand = 1
+	var character = 0
+	var type = ''
+	var props = rules
+	var children = rulesets
+	var reference = rule
+	var characters = type
+
+	while (scanning)
+		switch (previous = character, character = (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.next)()) {
+			// (
+			case 40:
+				if (previous != 108 && (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.charat)(characters, length - 1) == 58) {
+					if ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.indexof)(characters += (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.delimit)(character), '&', '&\f'), '&\f') != -1)
+						ampersand = -1
+					break
+				}
+			// " ' [
+			case 34: case 39: case 91:
+				characters += (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.delimit)(character)
+				break
+			// \t \n \r \s
+			case 9: case 10: case 13: case 32:
+				characters += (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.whitespace)(previous)
+				break
+			// \
+			case 92:
+				characters += (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.escaping)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.caret)() - 1, 7)
+				continue
+			// /
+			case 47:
+				switch ((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.peek)()) {
+					case 42: case 47:
+						;(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.append)(comment((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.commenter)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.next)(), (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.caret)()), root, parent, declarations), declarations)
+						break
+					default:
+						characters += '/'
+				}
+				break
+			// {
+			case 123 * variable:
+				points[index++] = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.strlen)(characters) * ampersand
+			// } ; \0
+			case 125 * variable: case 59: case 0:
+				switch (character) {
+					// \0 }
+					case 0: case 125: scanning = 0
+					// ;
+					case 59 + offset: if (ampersand == -1) characters = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(characters, /\f/g, '')
+						if (property > 0 && ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.strlen)(characters) - length))
+							(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.append)(property > 32 ? declaration(characters + ';', rule, parent, length - 1, declarations) : declaration((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(characters, ' ', '') + ';', rule, parent, length - 2, declarations), declarations)
+						break
+					// @ ;
+					case 59: characters += ';'
+					// { rule/at-rule
+					default:
+						;(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.append)(reference = ruleset(characters, root, parent, index, offset, rules, points, type, props = [], children = [], length, rulesets), rulesets)
+
+						if (character === 123)
+							if (offset === 0)
+								parse(characters, root, reference, reference, props, rulesets, length, points, children)
+							else
+								switch (atrule === 99 && (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.charat)(characters, 3) === 110 ? 100 : atrule) {
+									// d l m s
+									case 100: case 108: case 109: case 115:
+										parse(value, reference, reference, rule && (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.append)(ruleset(value, reference, reference, 0, 0, rules, points, type, rules, props = [], length, children), children), rules, children, length, points, rule ? props : children)
+										break
+									default:
+										parse(characters, reference, reference, reference, [''], children, 0, points, children)
+								}
+				}
+
+				index = offset = property = 0, variable = ampersand = 1, type = characters = '', length = pseudo
+				break
+			// :
+			case 58:
+				length = 1 + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.strlen)(characters), property = previous
+			default:
+				if (variable < 1)
+					if (character == 123)
+						--variable
+					else if (character == 125 && variable++ == 0 && (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.prev)() == 125)
+						continue
+
+				switch (characters += (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.from)(character), character * variable) {
+					// &
+					case 38:
+						ampersand = offset > 0 ? 1 : (characters += '\f', -1)
+						break
+					// ,
+					case 44:
+						points[index++] = ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.strlen)(characters) - 1) * ampersand, ampersand = 1
+						break
+					// @
+					case 64:
+						// -
+						if ((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.peek)() === 45)
+							characters += (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.delimit)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.next)())
+
+						atrule = (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.peek)(), offset = length = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.strlen)(type = characters += (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.identifier)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.caret)())), character++
+						break
+					// -
+					case 45:
+						if (previous === 45 && (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.strlen)(characters) == 2)
+							variable = 0
+				}
+		}
+
+	return rulesets
+}
+
+/**
+ * @param {string} value
+ * @param {object} root
+ * @param {object?} parent
+ * @param {number} index
+ * @param {number} offset
+ * @param {string[]} rules
+ * @param {number[]} points
+ * @param {string} type
+ * @param {string[]} props
+ * @param {string[]} children
+ * @param {number} length
+ * @param {object[]} siblings
+ * @return {object}
+ */
+function ruleset (value, root, parent, index, offset, rules, points, type, props, children, length, siblings) {
+	var post = offset - 1
+	var rule = offset === 0 ? rules : ['']
+	var size = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.sizeof)(rule)
+
+	for (var i = 0, j = 0, k = 0; i < index; ++i)
+		for (var x = 0, y = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.substr)(value, post + 1, post = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.abs)(j = points[i])), z = value; x < size; ++x)
+			if (z = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.trim)(j > 0 ? rule[x] + ' ' + y : (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(y, /&\f/g, rule[x])))
+				props[k++] = z
+
+	return (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.node)(value, root, parent, offset === 0 ? _Enum_js__WEBPACK_IMPORTED_MODULE_2__.RULESET : type, props, children, length, siblings)
+}
+
+/**
+ * @param {number} value
+ * @param {object} root
+ * @param {object?} parent
+ * @param {object[]} siblings
+ * @return {object}
+ */
+function comment (value, root, parent, siblings) {
+	return (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.node)(value, root, parent, _Enum_js__WEBPACK_IMPORTED_MODULE_2__.COMMENT, (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.from)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.char)()), (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.substr)(value, 2, -2), 0, siblings)
+}
+
+/**
+ * @param {string} value
+ * @param {object} root
+ * @param {object?} parent
+ * @param {number} length
+ * @param {object[]} siblings
+ * @return {object}
+ */
+function declaration (value, root, parent, length, siblings) {
+	return (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_0__.node)(value, root, parent, _Enum_js__WEBPACK_IMPORTED_MODULE_2__.DECLARATION, (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.substr)(value, 0, length), (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.substr)(value, length + 1, -1), length, siblings)
+}
+
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/node_modules/stylis/src/Prefixer.js":
+/*!****************************************************************************!*\
+  !*** ./node_modules/styled-components/node_modules/stylis/src/Prefixer.js ***!
+  \****************************************************************************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   prefix: () => (/* binding */ prefix)
+/* harmony export */ });
+/* harmony import */ var _Enum_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./Enum.js */ "./node_modules/styled-components/node_modules/stylis/src/Enum.js");
+/* harmony import */ var _Utility_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./Utility.js */ "./node_modules/styled-components/node_modules/stylis/src/Utility.js");
+
+
+
+/**
+ * @param {string} value
+ * @param {number} length
+ * @param {object[]} children
+ * @return {string}
+ */
+function prefix (value, length, children) {
+	switch ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.hash)(value, length)) {
+		// color-adjust
+		case 5103:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + 'print-' + value + value
+		// animation, animation-(delay|direction|duration|fill-mode|iteration-count|name|play-state|timing-function)
+		case 5737: case 4201: case 3177: case 3433: case 1641: case 4457: case 2921:
+		// text-decoration, filter, clip-path, backface-visibility, column, box-decoration-break
+		case 5572: case 6356: case 5844: case 3191: case 6645: case 3005:
+		// mask, mask-image, mask-(mode|clip|size), mask-(repeat|origin), mask-position, mask-composite,
+		case 6391: case 5879: case 5623: case 6135: case 4599: case 4855:
+		// background-clip, columns, column-(count|fill|gap|rule|rule-color|rule-style|rule-width|span|width)
+		case 4215: case 6389: case 5109: case 5365: case 5621: case 3829:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + value + value
+		// tab-size
+		case 4789:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MOZ + value + value
+		// appearance, user-select, transform, hyphens, text-size-adjust
+		case 5349: case 4246: case 4810: case 6968: case 2756:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MOZ + value + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + value + value
+		// writing-mode
+		case 5936:
+			switch ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.charat)(value, length + 11)) {
+				// vertical-l(r)
+				case 114:
+					return _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, /[svh]\w+-[tblr]{2}/, 'tb') + value
+				// vertical-r(l)
+				case 108:
+					return _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, /[svh]\w+-[tblr]{2}/, 'tb-rl') + value
+				// horizontal(-)tb
+				case 45:
+					return _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, /[svh]\w+-[tblr]{2}/, 'lr') + value
+				// default: fallthrough to below
+			}
+		// flex, flex-direction, scroll-snap-type, writing-mode
+		case 6828: case 4268: case 2903:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + value + value
+		// order
+		case 6165:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + 'flex-' + value + value
+		// align-items
+		case 5187:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + value + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, /(\w+).+(:[^]+)/, _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + 'box-$1$2' + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + 'flex-$1$2') + value
+		// align-self
+		case 5443:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + 'flex-item-' + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, /flex-|-self/g, '') + (!(0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.match)(value, /flex-|baseline/) ? _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + 'grid-row-' + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, /flex-|-self/g, '') : '') + value
+		// align-content
+		case 4675:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + 'flex-line-pack' + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, /align-content|flex-|-self/g, '') + value
+		// flex-shrink
+		case 5548:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, 'shrink', 'negative') + value
+		// flex-basis
+		case 5292:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, 'basis', 'preferred-size') + value
+		// flex-grow
+		case 6060:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + 'box-' + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, '-grow', '') + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, 'grow', 'positive') + value
+		// transition
+		case 4554:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, /([^-])(transform)/g, '$1' + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + '$2') + value
+		// cursor
+		case 6187:
+			return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)((0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)((0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, /(zoom-|grab)/, _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + '$1'), /(image-set)/, _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + '$1'), value, '') + value
+		// background, background-image
+		case 5495: case 3959:
+			return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, /(image-set\([^]*)/, _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + '$1' + '$`$1')
+		// justify-content
+		case 4968:
+			return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)((0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, /(.+:)(flex-)?(.*)/, _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + 'box-pack:$3' + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + 'flex-pack:$3'), /s.+-b[^;]+/, 'justify') + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + value + value
+		// justify-self
+		case 4200:
+			if (!(0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.match)(value, /flex-|baseline/)) return _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + 'grid-column-align' + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.substr)(value, length) + value
+			break
+		// grid-template-(columns|rows)
+		case 2592: case 3360:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, 'template-', '') + value
+		// grid-(row|column)-start
+		case 4384: case 3616:
+			if (children && children.some(function (element, index) { return length = index, (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.match)(element.props, /grid-\w+-end/) })) {
+				return ~(0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.indexof)(value + (children = children[length].value), 'span') ? value : (_Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, '-start', '') + value + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + 'grid-row-span:' + (~(0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.indexof)(children, 'span') ? (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.match)(children, /\d+/) : +(0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.match)(children, /\d+/) - +(0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.match)(value, /\d+/)) + ';')
+			}
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, '-start', '') + value
+		// grid-(row|column)-end
+		case 4896: case 4128:
+			return (children && children.some(function (element) { return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.match)(element.props, /grid-\w+-start/) })) ? value : _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)((0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, '-end', '-span'), 'span ', '') + value
+		// (margin|padding)-inline-(start|end)
+		case 4095: case 3583: case 4068: case 2532:
+			return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, /(.+)-inline(.+)/, _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + '$1$2') + value
+		// (min|max)?(width|height|inline-size|block-size)
+		case 8116: case 7059: case 5753: case 5535:
+		case 5445: case 5701: case 4933: case 4677:
+		case 5533: case 5789: case 5021: case 4765:
+			// stretch, max-content, min-content, fill-available
+			if ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.strlen)(value) - 1 - length > 6)
+				switch ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.charat)(value, length + 1)) {
+					// (m)ax-content, (m)in-content
+					case 109:
+						// -
+						if ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.charat)(value, length + 4) !== 45)
+							break
+					// (f)ill-available, (f)it-content
+					case 102:
+						return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, /(.+:)(.+)-([^]+)/, '$1' + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + '$2-$3' + '$1' + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MOZ + ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.charat)(value, length + 3) == 108 ? '$3' : '$2-$3')) + value
+					// (s)tretch
+					case 115:
+						return ~(0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.indexof)(value, 'stretch') ? prefix((0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, 'stretch', 'fill-available'), length, children) + value : value
+				}
+			break
+		// grid-(column|row)
+		case 5152: case 5920:
+			return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, /(.+?):(\d+)(\s*\/\s*(span)?\s*(\d+))?(.*)/, function (_, a, b, c, d, e, f) { return (_Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + a + ':' + b + f) + (c ? (_Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + a + '-span:' + (d ? e : +e - +b)) + f : '') + value })
+		// position: sticky
+		case 4949:
+			// stick(y)?
+			if ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.charat)(value, length + 6) === 121)
+				return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, ':', ':' + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT) + value
+			break
+		// display: (flex|inline-flex|grid|inline-grid)
+		case 6444:
+			switch ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.charat)(value, (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.charat)(value, 14) === 45 ? 18 : 11)) {
+				// (inline-)?fle(x)
+				case 120:
+					return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, /(.+:)([^;\s!]+)(;|(\s+)?!.+)?/, '$1' + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.charat)(value, 14) === 45 ? 'inline-' : '') + 'box$3' + '$1' + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.WEBKIT + '$2$3' + '$1' + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS + '$2box$3') + value
+				// (inline-)?gri(d)
+				case 100:
+					return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, ':', ':' + _Enum_js__WEBPACK_IMPORTED_MODULE_1__.MS) + value
+			}
+			break
+		// scroll-margin, scroll-margin-(top|right|bottom|left)
+		case 5719: case 2647: case 2135: case 3927: case 2391:
+			return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.replace)(value, 'scroll-', 'scroll-snap-') + value
+	}
+
+	return value
+}
+
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/node_modules/stylis/src/Serializer.js":
+/*!******************************************************************************!*\
+  !*** ./node_modules/styled-components/node_modules/stylis/src/Serializer.js ***!
+  \******************************************************************************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   serialize: () => (/* binding */ serialize),
+/* harmony export */   stringify: () => (/* binding */ stringify)
+/* harmony export */ });
+/* harmony import */ var _Enum_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./Enum.js */ "./node_modules/styled-components/node_modules/stylis/src/Enum.js");
+/* harmony import */ var _Utility_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./Utility.js */ "./node_modules/styled-components/node_modules/stylis/src/Utility.js");
+
+
+
+/**
+ * @param {object[]} children
+ * @param {function} callback
+ * @return {string}
+ */
+function serialize (children, callback) {
+	var output = ''
+
+	for (var i = 0; i < children.length; i++)
+		output += callback(children[i], i, children, callback) || ''
+
+	return output
+}
+
+/**
+ * @param {object} element
+ * @param {number} index
+ * @param {object[]} children
+ * @param {function} callback
+ * @return {string}
+ */
+function stringify (element, index, children, callback) {
+	switch (element.type) {
+		case _Enum_js__WEBPACK_IMPORTED_MODULE_0__.LAYER: if (element.children.length) break
+		case _Enum_js__WEBPACK_IMPORTED_MODULE_0__.IMPORT: case _Enum_js__WEBPACK_IMPORTED_MODULE_0__.DECLARATION: return element.return = element.return || element.value
+		case _Enum_js__WEBPACK_IMPORTED_MODULE_0__.COMMENT: return ''
+		case _Enum_js__WEBPACK_IMPORTED_MODULE_0__.KEYFRAMES: return element.return = element.value + '{' + serialize(element.children, callback) + '}'
+		case _Enum_js__WEBPACK_IMPORTED_MODULE_0__.RULESET: if (!(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.strlen)(element.value = element.props.join(','))) return ''
+	}
+
+	return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.strlen)(children = serialize(element.children, callback)) ? element.return = element.value + '{' + children + '}' : ''
+}
+
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/node_modules/stylis/src/Tokenizer.js":
+/*!*****************************************************************************!*\
+  !*** ./node_modules/styled-components/node_modules/stylis/src/Tokenizer.js ***!
+  \*****************************************************************************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   alloc: () => (/* binding */ alloc),
+/* harmony export */   caret: () => (/* binding */ caret),
+/* harmony export */   char: () => (/* binding */ char),
+/* harmony export */   character: () => (/* binding */ character),
+/* harmony export */   characters: () => (/* binding */ characters),
+/* harmony export */   column: () => (/* binding */ column),
+/* harmony export */   commenter: () => (/* binding */ commenter),
+/* harmony export */   copy: () => (/* binding */ copy),
+/* harmony export */   dealloc: () => (/* binding */ dealloc),
+/* harmony export */   delimit: () => (/* binding */ delimit),
+/* harmony export */   delimiter: () => (/* binding */ delimiter),
+/* harmony export */   escaping: () => (/* binding */ escaping),
+/* harmony export */   identifier: () => (/* binding */ identifier),
+/* harmony export */   length: () => (/* binding */ length),
+/* harmony export */   lift: () => (/* binding */ lift),
+/* harmony export */   line: () => (/* binding */ line),
+/* harmony export */   next: () => (/* binding */ next),
+/* harmony export */   node: () => (/* binding */ node),
+/* harmony export */   peek: () => (/* binding */ peek),
+/* harmony export */   position: () => (/* binding */ position),
+/* harmony export */   prev: () => (/* binding */ prev),
+/* harmony export */   slice: () => (/* binding */ slice),
+/* harmony export */   token: () => (/* binding */ token),
+/* harmony export */   tokenize: () => (/* binding */ tokenize),
+/* harmony export */   tokenizer: () => (/* binding */ tokenizer),
+/* harmony export */   whitespace: () => (/* binding */ whitespace)
+/* harmony export */ });
+/* harmony import */ var _Utility_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./Utility.js */ "./node_modules/styled-components/node_modules/stylis/src/Utility.js");
+
+
+var line = 1
+var column = 1
+var length = 0
+var position = 0
+var character = 0
+var characters = ''
+
+/**
+ * @param {string} value
+ * @param {object | null} root
+ * @param {object | null} parent
+ * @param {string} type
+ * @param {string[] | string} props
+ * @param {object[] | string} children
+ * @param {object[]} siblings
+ * @param {number} length
+ */
+function node (value, root, parent, type, props, children, length, siblings) {
+	return {value: value, root: root, parent: parent, type: type, props: props, children: children, line: line, column: column, length: length, return: '', siblings: siblings}
+}
+
+/**
+ * @param {object} root
+ * @param {object} props
+ * @return {object}
+ */
+function copy (root, props) {
+	return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.assign)(node('', null, null, '', null, null, 0, root.siblings), root, {length: -root.length}, props)
+}
+
+/**
+ * @param {object} root
+ */
+function lift (root) {
+	while (root.root)
+		root = copy(root.root, {children: [root]})
+
+	;(0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.append)(root, root.siblings)
+}
+
+/**
+ * @return {number}
+ */
+function char () {
+	return character
+}
+
+/**
+ * @return {number}
+ */
+function prev () {
+	character = position > 0 ? (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.charat)(characters, --position) : 0
+
+	if (column--, character === 10)
+		column = 1, line--
+
+	return character
+}
+
+/**
+ * @return {number}
+ */
+function next () {
+	character = position < length ? (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.charat)(characters, position++) : 0
+
+	if (column++, character === 10)
+		column = 1, line++
+
+	return character
+}
+
+/**
+ * @return {number}
+ */
+function peek () {
+	return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.charat)(characters, position)
+}
+
+/**
+ * @return {number}
+ */
+function caret () {
+	return position
+}
+
+/**
+ * @param {number} begin
+ * @param {number} end
+ * @return {string}
+ */
+function slice (begin, end) {
+	return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.substr)(characters, begin, end)
+}
+
+/**
+ * @param {number} type
+ * @return {number}
+ */
+function token (type) {
+	switch (type) {
+		// \0 \t \n \r \s whitespace token
+		case 0: case 9: case 10: case 13: case 32:
+			return 5
+		// ! + , / > @ ~ isolate token
+		case 33: case 43: case 44: case 47: case 62: case 64: case 126:
+		// ; { } breakpoint token
+		case 59: case 123: case 125:
+			return 4
+		// : accompanied token
+		case 58:
+			return 3
+		// " ' ( [ opening delimit token
+		case 34: case 39: case 40: case 91:
+			return 2
+		// ) ] closing delimit token
+		case 41: case 93:
+			return 1
+	}
+
+	return 0
+}
+
+/**
+ * @param {string} value
+ * @return {any[]}
+ */
+function alloc (value) {
+	return line = column = 1, length = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.strlen)(characters = value), position = 0, []
+}
+
+/**
+ * @param {any} value
+ * @return {any}
+ */
+function dealloc (value) {
+	return characters = '', value
+}
+
+/**
+ * @param {number} type
+ * @return {string}
+ */
+function delimit (type) {
+	return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.trim)(slice(position - 1, delimiter(type === 91 ? type + 2 : type === 40 ? type + 1 : type)))
+}
+
+/**
+ * @param {string} value
+ * @return {string[]}
+ */
+function tokenize (value) {
+	return dealloc(tokenizer(alloc(value)))
+}
+
+/**
+ * @param {number} type
+ * @return {string}
+ */
+function whitespace (type) {
+	while (character = peek())
+		if (character < 33)
+			next()
+		else
+			break
+
+	return token(type) > 2 || token(character) > 3 ? '' : ' '
+}
+
+/**
+ * @param {string[]} children
+ * @return {string[]}
+ */
+function tokenizer (children) {
+	while (next())
+		switch (token(character)) {
+			case 0: (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.append)(identifier(position - 1), children)
+				break
+			case 2: ;(0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.append)(delimit(character), children)
+				break
+			default: ;(0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.append)((0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.from)(character), children)
+		}
+
+	return children
+}
+
+/**
+ * @param {number} index
+ * @param {number} count
+ * @return {string}
+ */
+function escaping (index, count) {
+	while (--count && next())
+		// not 0-9 A-F a-f
+		if (character < 48 || character > 102 || (character > 57 && character < 65) || (character > 70 && character < 97))
+			break
+
+	return slice(index, caret() + (count < 6 && peek() == 32 && next() == 32))
+}
+
+/**
+ * @param {number} type
+ * @return {number}
+ */
+function delimiter (type) {
+	while (next())
+		switch (character) {
+			// ] ) " '
+			case type:
+				return position
+			// " '
+			case 34: case 39:
+				if (type !== 34 && type !== 39)
+					delimiter(character)
+				break
+			// (
+			case 40:
+				if (type === 41)
+					delimiter(type)
+				break
+			// \
+			case 92:
+				next()
+				break
+		}
+
+	return position
+}
+
+/**
+ * @param {number} type
+ * @param {number} index
+ * @return {number}
+ */
+function commenter (type, index) {
+	while (next())
+		// //
+		if (type + character === 47 + 10)
+			break
+		// /*
+		else if (type + character === 42 + 42 && peek() === 47)
+			break
+
+	return '/*' + slice(index, position - 1) + '*' + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.from)(type === 47 ? type : next())
+}
+
+/**
+ * @param {number} index
+ * @return {string}
+ */
+function identifier (index) {
+	while (!token(peek()))
+		next()
+
+	return slice(index, position)
+}
+
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/node_modules/stylis/src/Utility.js":
+/*!***************************************************************************!*\
+  !*** ./node_modules/styled-components/node_modules/stylis/src/Utility.js ***!
+  \***************************************************************************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   abs: () => (/* binding */ abs),
+/* harmony export */   append: () => (/* binding */ append),
+/* harmony export */   assign: () => (/* binding */ assign),
+/* harmony export */   charat: () => (/* binding */ charat),
+/* harmony export */   combine: () => (/* binding */ combine),
+/* harmony export */   filter: () => (/* binding */ filter),
+/* harmony export */   from: () => (/* binding */ from),
+/* harmony export */   hash: () => (/* binding */ hash),
+/* harmony export */   indexof: () => (/* binding */ indexof),
+/* harmony export */   match: () => (/* binding */ match),
+/* harmony export */   replace: () => (/* binding */ replace),
+/* harmony export */   sizeof: () => (/* binding */ sizeof),
+/* harmony export */   strlen: () => (/* binding */ strlen),
+/* harmony export */   substr: () => (/* binding */ substr),
+/* harmony export */   trim: () => (/* binding */ trim)
+/* harmony export */ });
+/**
+ * @param {number}
+ * @return {number}
+ */
+var abs = Math.abs
+
+/**
+ * @param {number}
+ * @return {string}
+ */
+var from = String.fromCharCode
+
+/**
+ * @param {object}
+ * @return {object}
+ */
+var assign = Object.assign
+
+/**
+ * @param {string} value
+ * @param {number} length
+ * @return {number}
+ */
+function hash (value, length) {
+	return charat(value, 0) ^ 45 ? (((((((length << 2) ^ charat(value, 0)) << 2) ^ charat(value, 1)) << 2) ^ charat(value, 2)) << 2) ^ charat(value, 3) : 0
+}
+
+/**
+ * @param {string} value
+ * @return {string}
+ */
+function trim (value) {
+	return value.trim()
+}
+
+/**
+ * @param {string} value
+ * @param {RegExp} pattern
+ * @return {string?}
+ */
+function match (value, pattern) {
+	return (value = pattern.exec(value)) ? value[0] : value
+}
+
+/**
+ * @param {string} value
+ * @param {(string|RegExp)} pattern
+ * @param {string} replacement
+ * @return {string}
+ */
+function replace (value, pattern, replacement) {
+	return value.replace(pattern, replacement)
+}
+
+/**
+ * @param {string} value
+ * @param {string} search
+ * @return {number}
+ */
+function indexof (value, search) {
+	return value.indexOf(search)
+}
+
+/**
+ * @param {string} value
+ * @param {number} index
+ * @return {number}
+ */
+function charat (value, index) {
+	return value.charCodeAt(index) | 0
+}
+
+/**
+ * @param {string} value
+ * @param {number} begin
+ * @param {number} end
+ * @return {string}
+ */
+function substr (value, begin, end) {
+	return value.slice(begin, end)
+}
+
+/**
+ * @param {string} value
+ * @return {number}
+ */
+function strlen (value) {
+	return value.length
+}
+
+/**
+ * @param {any[]} value
+ * @return {number}
+ */
+function sizeof (value) {
+	return value.length
+}
+
+/**
+ * @param {any} value
+ * @param {any[]} array
+ * @return {any}
+ */
+function append (value, array) {
+	return array.push(value), value
+}
+
+/**
+ * @param {string[]} array
+ * @param {function} callback
+ * @return {string}
+ */
+function combine (array, callback) {
+	return array.map(callback).join('')
+}
+
+/**
+ * @param {string[]} array
+ * @param {RegExp} pattern
+ * @return {string[]}
+ */
+function filter (array, pattern) {
+	return array.filter(function (value) { return !match(value, pattern) })
+}
+
+
+/***/ }),
+
+/***/ "./node_modules/tslib/tslib.es6.mjs":
+/*!******************************************!*\
+  !*** ./node_modules/tslib/tslib.es6.mjs ***!
+  \******************************************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   __addDisposableResource: () => (/* binding */ __addDisposableResource),
+/* harmony export */   __assign: () => (/* binding */ __assign),
+/* harmony export */   __asyncDelegator: () => (/* binding */ __asyncDelegator),
+/* harmony export */   __asyncGenerator: () => (/* binding */ __asyncGenerator),
+/* harmony export */   __asyncValues: () => (/* binding */ __asyncValues),
+/* harmony export */   __await: () => (/* binding */ __await),
+/* harmony export */   __awaiter: () => (/* binding */ __awaiter),
+/* harmony export */   __classPrivateFieldGet: () => (/* binding */ __classPrivateFieldGet),
+/* harmony export */   __classPrivateFieldIn: () => (/* binding */ __classPrivateFieldIn),
+/* harmony export */   __classPrivateFieldSet: () => (/* binding */ __classPrivateFieldSet),
+/* harmony export */   __createBinding: () => (/* binding */ __createBinding),
+/* harmony export */   __decorate: () => (/* binding */ __decorate),
+/* harmony export */   __disposeResources: () => (/* binding */ __disposeResources),
+/* harmony export */   __esDecorate: () => (/* binding */ __esDecorate),
+/* harmony export */   __exportStar: () => (/* binding */ __exportStar),
+/* harmony export */   __extends: () => (/* binding */ __extends),
+/* harmony export */   __generator: () => (/* binding */ __generator),
+/* harmony export */   __importDefault: () => (/* binding */ __importDefault),
+/* harmony export */   __importStar: () => (/* binding */ __importStar),
+/* harmony export */   __makeTemplateObject: () => (/* binding */ __makeTemplateObject),
+/* harmony export */   __metadata: () => (/* binding */ __metadata),
+/* harmony export */   __param: () => (/* binding */ __param),
+/* harmony export */   __propKey: () => (/* binding */ __propKey),
+/* harmony export */   __read: () => (/* binding */ __read),
+/* harmony export */   __rest: () => (/* binding */ __rest),
+/* harmony export */   __runInitializers: () => (/* binding */ __runInitializers),
+/* harmony export */   __setFunctionName: () => (/* binding */ __setFunctionName),
+/* harmony export */   __spread: () => (/* binding */ __spread),
+/* harmony export */   __spreadArray: () => (/* binding */ __spreadArray),
+/* harmony export */   __spreadArrays: () => (/* binding */ __spreadArrays),
+/* harmony export */   __values: () => (/* binding */ __values),
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/******************************************************************************
+Copyright (c) Microsoft Corporation.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+***************************************************************************** */
+/* global Reflect, Promise, SuppressedError, Symbol */
+
+var extendStatics = function(d, b) {
+  extendStatics = Object.setPrototypeOf ||
+      ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+      function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+  return extendStatics(d, b);
+};
+
+function __extends(d, b) {
+  if (typeof b !== "function" && b !== null)
+      throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+  extendStatics(d, b);
+  function __() { this.constructor = d; }
+  d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+}
+
+var __assign = function() {
+  __assign = Object.assign || function __assign(t) {
+      for (var s, i = 1, n = arguments.length; i < n; i++) {
+          s = arguments[i];
+          for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+      }
+      return t;
+  }
+  return __assign.apply(this, arguments);
+}
+
+function __rest(s, e) {
+  var t = {};
+  for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+      t[p] = s[p];
+  if (s != null && typeof Object.getOwnPropertySymbols === "function")
+      for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+          if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+              t[p[i]] = s[p[i]];
+      }
+  return t;
+}
+
+function __decorate(decorators, target, key, desc) {
+  var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+  if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+  else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+  return c > 3 && r && Object.defineProperty(target, key, r), r;
+}
+
+function __param(paramIndex, decorator) {
+  return function (target, key) { decorator(target, key, paramIndex); }
+}
+
+function __esDecorate(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+      var context = {};
+      for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+      for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+      context.addInitializer = function (f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+      var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+      if (kind === "accessor") {
+          if (result === void 0) continue;
+          if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+          if (_ = accept(result.get)) descriptor.get = _;
+          if (_ = accept(result.set)) descriptor.set = _;
+          if (_ = accept(result.init)) initializers.unshift(_);
+      }
+      else if (_ = accept(result)) {
+          if (kind === "field") initializers.unshift(_);
+          else descriptor[key] = _;
+      }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+
+function __runInitializers(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+      value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+
+function __propKey(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+
+function __setFunctionName(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+
+function __metadata(metadataKey, metadataValue) {
+  if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(metadataKey, metadataValue);
+}
+
+function __awaiter(thisArg, _arguments, P, generator) {
+  function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+  return new (P || (P = Promise))(function (resolve, reject) {
+      function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+      function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+      function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+  });
+}
+
+function __generator(thisArg, body) {
+  var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+  return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+  function verb(n) { return function (v) { return step([n, v]); }; }
+  function step(op) {
+      if (f) throw new TypeError("Generator is already executing.");
+      while (g && (g = 0, op[0] && (_ = 0)), _) try {
+          if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+          if (y = 0, t) op = [op[0] & 2, t.value];
+          switch (op[0]) {
+              case 0: case 1: t = op; break;
+              case 4: _.label++; return { value: op[1], done: false };
+              case 5: _.label++; y = op[1]; op = [0]; continue;
+              case 7: op = _.ops.pop(); _.trys.pop(); continue;
+              default:
+                  if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                  if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                  if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                  if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                  if (t[2]) _.ops.pop();
+                  _.trys.pop(); continue;
+          }
+          op = body.call(thisArg, _);
+      } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+      if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+  }
+}
+
+var __createBinding = Object.create ? (function(o, m, k, k2) {
+  if (k2 === undefined) k2 = k;
+  var desc = Object.getOwnPropertyDescriptor(m, k);
+  if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+  }
+  Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+  if (k2 === undefined) k2 = k;
+  o[k2] = m[k];
+});
+
+function __exportStar(m, o) {
+  for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(o, p)) __createBinding(o, m, p);
+}
+
+function __values(o) {
+  var s = typeof Symbol === "function" && Symbol.iterator, m = s && o[s], i = 0;
+  if (m) return m.call(o);
+  if (o && typeof o.length === "number") return {
+      next: function () {
+          if (o && i >= o.length) o = void 0;
+          return { value: o && o[i++], done: !o };
+      }
+  };
+  throw new TypeError(s ? "Object is not iterable." : "Symbol.iterator is not defined.");
+}
+
+function __read(o, n) {
+  var m = typeof Symbol === "function" && o[Symbol.iterator];
+  if (!m) return o;
+  var i = m.call(o), r, ar = [], e;
+  try {
+      while ((n === void 0 || n-- > 0) && !(r = i.next()).done) ar.push(r.value);
+  }
+  catch (error) { e = { error: error }; }
+  finally {
+      try {
+          if (r && !r.done && (m = i["return"])) m.call(i);
+      }
+      finally { if (e) throw e.error; }
+  }
+  return ar;
+}
+
+/** @deprecated */
+function __spread() {
+  for (var ar = [], i = 0; i < arguments.length; i++)
+      ar = ar.concat(__read(arguments[i]));
+  return ar;
+}
+
+/** @deprecated */
+function __spreadArrays() {
+  for (var s = 0, i = 0, il = arguments.length; i < il; i++) s += arguments[i].length;
+  for (var r = Array(s), k = 0, i = 0; i < il; i++)
+      for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
+          r[k] = a[j];
+  return r;
+}
+
+function __spreadArray(to, from, pack) {
+  if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+      if (ar || !(i in from)) {
+          if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+          ar[i] = from[i];
+      }
+  }
+  return to.concat(ar || Array.prototype.slice.call(from));
+}
+
+function __await(v) {
+  return this instanceof __await ? (this.v = v, this) : new __await(v);
+}
+
+function __asyncGenerator(thisArg, _arguments, generator) {
+  if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+  var g = generator.apply(thisArg, _arguments || []), i, q = [];
+  return i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i;
+  function verb(n) { if (g[n]) i[n] = function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]) > 1 || resume(n, v); }); }; }
+  function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(q[0][3], e); } }
+  function step(r) { r.value instanceof __await ? Promise.resolve(r.value.v).then(fulfill, reject) : settle(q[0][2], r); }
+  function fulfill(value) { resume("next", value); }
+  function reject(value) { resume("throw", value); }
+  function settle(f, v) { if (f(v), q.shift(), q.length) resume(q[0][0], q[0][1]); }
+}
+
+function __asyncDelegator(o) {
+  var i, p;
+  return i = {}, verb("next"), verb("throw", function (e) { throw e; }), verb("return"), i[Symbol.iterator] = function () { return this; }, i;
+  function verb(n, f) { i[n] = o[n] ? function (v) { return (p = !p) ? { value: __await(o[n](v)), done: false } : f ? f(v) : v; } : f; }
+}
+
+function __asyncValues(o) {
+  if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+  var m = o[Symbol.asyncIterator], i;
+  return m ? m.call(o) : (o = typeof __values === "function" ? __values(o) : o[Symbol.iterator](), i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i);
+  function verb(n) { i[n] = o[n] && function (v) { return new Promise(function (resolve, reject) { v = o[n](v), settle(resolve, reject, v.done, v.value); }); }; }
+  function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
+}
+
+function __makeTemplateObject(cooked, raw) {
+  if (Object.defineProperty) { Object.defineProperty(cooked, "raw", { value: raw }); } else { cooked.raw = raw; }
+  return cooked;
+};
+
+var __setModuleDefault = Object.create ? (function(o, v) {
+  Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+  o["default"] = v;
+};
+
+function __importStar(mod) {
+  if (mod && mod.__esModule) return mod;
+  var result = {};
+  if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+  __setModuleDefault(result, mod);
+  return result;
+}
+
+function __importDefault(mod) {
+  return (mod && mod.__esModule) ? mod : { default: mod };
+}
+
+function __classPrivateFieldGet(receiver, state, kind, f) {
+  if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+  if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+  return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+}
+
+function __classPrivateFieldSet(receiver, state, value, kind, f) {
+  if (kind === "m") throw new TypeError("Private method is not writable");
+  if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+  if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+  return (kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value)), value;
+}
+
+function __classPrivateFieldIn(state, receiver) {
+  if (receiver === null || (typeof receiver !== "object" && typeof receiver !== "function")) throw new TypeError("Cannot use 'in' operator on non-object");
+  return typeof state === "function" ? receiver === state : state.has(receiver);
+}
+
+function __addDisposableResource(env, value, async) {
+  if (value !== null && value !== void 0) {
+    if (typeof value !== "object") throw new TypeError("Object expected.");
+    var dispose;
+    if (async) {
+        if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+        dispose = value[Symbol.asyncDispose];
+    }
+    if (dispose === void 0) {
+        if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+        dispose = value[Symbol.dispose];
+    }
+    if (typeof dispose !== "function") throw new TypeError("Object not disposable.");
+    env.stack.push({ value: value, dispose: dispose, async: async });
+  }
+  else if (async) {
+    env.stack.push({ async: true });
+  }
+  return value;
+}
+
+var _SuppressedError = typeof SuppressedError === "function" ? SuppressedError : function (error, suppressed, message) {
+  var e = new Error(message);
+  return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
+};
+
+function __disposeResources(env) {
+  function fail(e) {
+    env.error = env.hasError ? new _SuppressedError(e, env.error, "An error was suppressed during disposal.") : e;
+    env.hasError = true;
+  }
+  function next() {
+    while (env.stack.length) {
+      var rec = env.stack.pop();
+      try {
+        var result = rec.dispose && rec.dispose.call(rec.value);
+        if (rec.async) return Promise.resolve(result).then(next, function(e) { fail(e); return next(); });
+      }
+      catch (e) {
+          fail(e);
+      }
+    }
+    if (env.hasError) throw env.error;
+  }
+  return next();
+}
+
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({
+  __extends,
+  __assign,
+  __rest,
+  __decorate,
+  __param,
+  __metadata,
+  __awaiter,
+  __generator,
+  __createBinding,
+  __exportStar,
+  __values,
+  __read,
+  __spread,
+  __spreadArrays,
+  __spreadArray,
+  __await,
+  __asyncGenerator,
+  __asyncDelegator,
+  __asyncValues,
+  __makeTemplateObject,
+  __importStar,
+  __importDefault,
+  __classPrivateFieldGet,
+  __classPrivateFieldSet,
+  __classPrivateFieldIn,
+  __addDisposableResource,
+  __disposeResources,
+});
+
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	(() => {
+/******/ 		// getDefaultExport function for compatibility with non-harmony modules
+/******/ 		__webpack_require__.n = (module) => {
+/******/ 			var getter = module && module.__esModule ?
+/******/ 				() => (module['default']) :
+/******/ 				() => (module);
+/******/ 			__webpack_require__.d(getter, { a: getter });
+/******/ 			return getter;
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	(() => {
+/******/ 		// define getter functions for harmony exports
+/******/ 		__webpack_require__.d = (exports, definition) => {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	(() => {
+/******/ 		__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/make namespace object */
+/******/ 	(() => {
+/******/ 		// define __esModule on exports
+/******/ 		__webpack_require__.r = (exports) => {
+/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 			}
+/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/nonce */
+/******/ 	(() => {
+/******/ 		__webpack_require__.nc = undefined;
+/******/ 	})();
+/******/ 	
+/************************************************************************/
+var __webpack_exports__ = {};
+// This entry need to be wrapped in an IIFE because it need to be in strict mode.
+(() => {
+"use strict";
+/*!**********************!*\
+  !*** ./src/index.js ***!
+  \**********************/
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _settings_Settings__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./settings/Settings */ "./src/settings/Settings.js");
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+
+
+if (options.screen === 'simplystatic-settings') {
+  let settings = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createRoot)(document.getElementById('simplystatic-settings'));
+  settings.render((0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_settings_Settings__WEBPACK_IMPORTED_MODULE_1__["default"], null));
+}
+})();
+
+/******/ })()
+;
+//# sourceMappingURL=index.js.map

--- a/src/admin/inc/class-ss-admin-settings.php
+++ b/src/admin/inc/class-ss-admin-settings.php
@@ -524,6 +524,8 @@ class Admin_Settings {
 
 		do_action( 'ss_before_perform_archive_action', $blog_id, 'start', Plugin::instance()->get_archive_creation_job() );
 
+        $type = apply_filters( 'ss_export_type', $type );
+
 		Plugin::instance()->run_static_export( $blog_id, $type );
 
 		do_action( 'ss_after_perform_archive_action', $blog_id, 'start', Plugin::instance()->get_archive_creation_job() );

--- a/src/admin/inc/class-ss-admin-settings.php
+++ b/src/admin/inc/class-ss-admin-settings.php
@@ -520,10 +520,11 @@ class Admin_Settings {
 	public function start_export( $request ) {
 		$params  = $request->get_params();
 		$blog_id = ! empty( $params['blog_id'] ) ? $params['blog_id'] : 0;
+		$type    = ! empty( $params['type'] ) ? $params['type'] : 'export';
 
 		do_action( 'ss_before_perform_archive_action', $blog_id, 'start', Plugin::instance()->get_archive_creation_job() );
 
-		Plugin::instance()->run_static_export( $blog_id );
+		Plugin::instance()->run_static_export( $blog_id, $type );
 
 		do_action( 'ss_after_perform_archive_action', $blog_id, 'start', Plugin::instance()->get_archive_creation_job() );
 

--- a/src/admin/src/settings/components/SettingsPage.jsx
+++ b/src/admin/src/settings/components/SettingsPage.jsx
@@ -113,7 +113,15 @@ function SettingsPage() {
 
     useEffect(function () {
         setDisabledButton(isRunning);
-    }, [isRunning])
+    }, [isRunning]);
+
+    let buildOptions = '';
+    if ( Object.keys(options.builds).length ) {
+        const builds = Object.keys(options.builds).map((id) => <option value={id}>{options.builds[id]}</option>);
+        buildOptions = <optgroup label="Builds">
+            {builds}
+        </optgroup>
+    }
 
     return (
         <div className={"plugin-settings-container"}>
@@ -152,22 +160,15 @@ function SettingsPage() {
                                 <div className={"generate-container"}>
                                     {'pro' === options.plan && <p>
                                         <SelectControl
-
                                             value={selectedExportType}
-                                            options={[
-                                                {
-                                                    label:  __( 'Export', 'simply-static' ),
-                                                    value: 'export'
-                                                },
-                                                {
-                                                    label:  __( 'Update', 'simply-static' ),
-                                                    value: 'update'
-                                                }
-                                            ]}
                                             onChange={(value) => {
                                                 setSelectedExportType(value);
                                             }}
-                                        />
+                                        >
+                                            <option value="export">{ __( 'Export', 'simply-static' ) }</option>
+                                            <option value="update">{ __( 'Update', 'simply-static' ) }</option>
+                                            {buildOptions}
+                                        </SelectControl>
                                     </p>}
                                     <Button onClick={() => {
                                         startExport();
@@ -222,20 +223,16 @@ function SettingsPage() {
                                     {'pro' === options.plan && <SelectControl
                                             className={'generate-type'}
                                             value={selectedExportType}
-                                            options={[
-                                                {
-                                                    label:  __( 'Export', 'simply-static' ),
-                                                    value: 'export'
-                                                },
-                                                {
-                                                    label:  __( 'Update', 'simply-static' ),
-                                                    value: 'update'
-                                                }
-                                            ]}
+
                                             onChange={(value) => {
                                                 setSelectedExportType(value);
                                             }}
-                                        />}
+                                        >
+
+                                            <option value="export">{ __( 'Export', 'simply-static' ) }</option>
+                                            <option value="update">{ __( 'Update', 'simply-static' ) }</option>
+                                            {buildOptions}
+                                        </SelectControl>}
                                     <Button onClick={() => {
                                         startExport();
                                     }}

--- a/src/admin/src/settings/components/SettingsPage.jsx
+++ b/src/admin/src/settings/components/SettingsPage.jsx
@@ -17,7 +17,7 @@ import {
     CardBody,
     Spinner,
     Notice,
-    Animate, __experimentalSpacer as Spacer, SelectControl
+    Animate, __experimentalSpacer as Spacer, SelectControl, ToggleControl
 } from '@wordpress/components';
 import DeploymentSettings from "../pages/DeploymentSettings";
 import FormSettings from "../pages/FormSettings";
@@ -46,6 +46,7 @@ function SettingsPage() {
     const [selectedCopySite, setSelectedCopySite] = useState('current');
     const [selectablesSites, setSelectableSites] = useState([]);
     const [isUpdatingFromNetwork, setIsUpdatingFromNetwork] = useState(false);
+    const [selectedExportType, setSelectedExportType] = useState('export');
 
 
     const runUpdateFromNetwork = (blogId) => {
@@ -85,6 +86,7 @@ function SettingsPage() {
             method: 'POST',
             data: {
                 'blog_id': blogId,
+                'type': selectedExportType
             }
         }).then(resp => {
             setIsRunning(true);
@@ -148,6 +150,25 @@ function SettingsPage() {
                                     <p>Version: <b>{options.version}</b></p>
                                 }
                                 <div className={"generate-container"}>
+                                    {'pro' === options.plan && <p>
+                                        <SelectControl
+
+                                            value={selectedExportType}
+                                            options={[
+                                                {
+                                                    label:  __( 'Export', 'simply-static' ),
+                                                    value: 'export'
+                                                },
+                                                {
+                                                    label:  __( 'Update', 'simply-static' ),
+                                                    value: 'update'
+                                                }
+                                            ]}
+                                            onChange={(value) => {
+                                                setSelectedExportType(value);
+                                            }}
+                                        />
+                                    </p>}
                                     <Button onClick={() => {
                                         startExport();
                                     }}
@@ -198,6 +219,23 @@ function SettingsPage() {
                                     <p>Version: <b>{options.version}</b></p>
                                 }
                                 <div className={"generate-container"}>
+                                    {'pro' === options.plan && <SelectControl
+                                            className={'generate-type'}
+                                            value={selectedExportType}
+                                            options={[
+                                                {
+                                                    label:  __( 'Export', 'simply-static' ),
+                                                    value: 'export'
+                                                },
+                                                {
+                                                    label:  __( 'Update', 'simply-static' ),
+                                                    value: 'update'
+                                                }
+                                            ]}
+                                            onChange={(value) => {
+                                                setSelectedExportType(value);
+                                            }}
+                                        />}
                                     <Button onClick={() => {
                                         startExport();
                                     }}

--- a/src/admin/src/settings/context/SettingsContext.jsx
+++ b/src/admin/src/settings/context/SettingsContext.jsx
@@ -105,7 +105,8 @@ function SettingsContextProvider(props) {
         'disable_xmlrpc': false,
         'disable_embed': false,
         'disable_db_debug': false,
-        'disable_wlw_manifest': false
+        'disable_wlw_manifest': false,
+        'incremental_export': false
     }
     const [isRunning, setIsRunning] = useState(false);
     const [settingsSaved, setSettingsSaved] = useState(false);

--- a/src/admin/src/settings/settings.scss
+++ b/src/admin/src/settings/settings.scss
@@ -58,6 +58,12 @@ toplevel_page_simply-static img {
     .generate-container {
       margin-top: 30px;
 
+      .generate-type {
+        height: 40px;
+        line-height: 40px;
+        max-width: 200px;
+      }
+
       button {
         background: #6804cc;
         border: solid 1px #50059b;

--- a/src/class-ss-archive-creation-job.php
+++ b/src/class-ss-archive-creation-job.php
@@ -70,7 +70,7 @@ class Archive_Creation_Job extends \WP_Background_Process {
 	 * Helper method for starting the Archive_Creation_Job
 	 * @return boolean true if we were able to successfully start generating an archive
 	 */
-	public function start( $blog_id = 0 ) {
+	public function start( $blog_id = 0, $type = 'export' ) {
 		// Clear log before running the job.
 		Util::clear_debug_log();
 
@@ -86,13 +86,17 @@ class Archive_Creation_Job extends \WP_Background_Process {
 			do_action( 'ss_archive_creation_job_before_start_queue', $blog_id, $this );
 
 			$first_task   = $task_list[0];
-			$archive_name = join( '-', array( Plugin::SLUG, $blog_id, time() ) );
+
+			if ( 'update' !== $type ) {
+				$archive_name = join( '-', array( Plugin::SLUG, $blog_id, time() ) );
+				$this->options->set( 'archive_name', $archive_name );
+			}
 
 			$this->options
 				->set( 'archive_status_messages', array() )
-				->set( 'archive_name', $archive_name )
 				->set( 'archive_start_time', Util::formatted_datetime() )
 				->set( 'archive_end_time', null )
+				->set( 'generate_type', $type )
 				->save();
 
 			Util::debug_log( "Pushing first task to queue: " . $first_task );

--- a/src/class-ss-plugin.php
+++ b/src/class-ss-plugin.php
@@ -142,6 +142,7 @@ class Plugin {
 		require_once $path . 'src/class-ss-url-extractor.php';
 		require_once $path . 'src/class-ss-url-fetcher.php';
 		require_once $path . 'src/class-ss-archive-creation-job.php';
+		require_once $path . 'src/tasks/traits/trait-can-process-pages.php';
 		require_once $path . 'src/tasks/class-ss-task.php';
 		require_once $path . 'src/tasks/class-ss-setup-task.php';
 		require_once $path . 'src/tasks/class-ss-fetch-urls-task.php';
@@ -183,13 +184,13 @@ class Plugin {
 	 *
 	 * @return void
 	 */
-	public function run_static_export( $blog_id = 0 ) {
+	public function run_static_export( $blog_id = 0, $type = 'export' ) {
 		if ( ! $blog_id ) {
 			$blog_id = get_current_blog_id();
 		}
-		do_action( 'ss_before_static_export', $blog_id );
+		do_action( 'ss_before_static_export', $blog_id, $type );
 
-		$this->archive_creation_job->start( $blog_id );
+		$this->archive_creation_job->start( $blog_id, $type );
 	}
 
 	/**

--- a/src/class-ss-query.php
+++ b/src/class-ss-query.php
@@ -213,6 +213,10 @@ class Query {
 		return $wpdb->get_var( $query );
 	}
 
+	public function get_raw_sql( $fields ) {
+		return $this->compose_select_query( $fields );
+	}
+
 	/**
 	 * Set the maximum number of rows to return
 	 * @param  integer $limit

--- a/src/models/class-ss-page.php
+++ b/src/models/class-ss-page.php
@@ -111,7 +111,8 @@ class Page extends Model {
 	 * @return boolean          Is the hash a match?
 	 */
 	public function is_content_identical( $sha1 ) {
-		return $sha1 === $this->content_hash;
+		Util::debug_log('Checking Content Identical:' . $sha1 . '===' . $this->content_hash . '. Value: ' . ( strpos( $sha1, $this->content_hash ) === 0 ? 'TRUE' : 'FALSE' ) );
+		return strpos( $sha1, $this->content_hash ) === 0;
 	}
 
 	/**
@@ -133,11 +134,27 @@ class Page extends Model {
 	 * @param string $message The error message.
 	 */
 	public function set_error_message( $message ) {
+		// Already has the same message.
+		if ( $this->has_error_message( $message ) ) {
+			return;
+		}
+
 		if ( $this->error_message ) {
 			$this->error_message = $this->error_message . '; ' . $message;
 		} else {
 			$this->error_message = $message;
 		}
+	}
+
+	protected function has_error_message( $message ) {
+		if ( ! $this->error_message ) {
+			return false;
+		}
+
+		$errors = explode( '; ', $this->error_message );
+		$index  = array_search( $message, $errors, true );
+
+		return false !== $index && $index >= 0;
 	}
 
 	/**

--- a/src/tasks/class-ss-fetch-urls-task.php
+++ b/src/tasks/class-ss-fetch-urls-task.php
@@ -154,6 +154,7 @@ class Fetch_Urls_Task extends Task {
 		if ( $save_file ) {
 			Util::debug_log( "We're saving this URL; keeping the static file" );
 			$sha1 = sha1_file( $file );
+			Util::debug_log( "SHA1 BINARY: " . sha1_file( $file, true ) );
 
 			// if the content is identical, move on to the next file
 			if ( $static_page->is_content_identical( $sha1 ) ) {

--- a/src/tasks/class-ss-setup-task.php
+++ b/src/tasks/class-ss-setup-task.php
@@ -42,8 +42,13 @@ class Setup_Task extends Task {
 		// sections below.
 		$use_single = get_option( 'simply-static-use-single' );
 		$use_build  = get_option( 'simply-static-use-build' );
+		$type       = $this->options->get( 'generate_type' );
 
-		if ( empty( $use_build ) && empty( $use_single ) ) {
+		if ( ! $type ) {
+			$type = 'export';
+		}
+
+		if ( empty( $use_build ) && empty( $use_single ) && 'export' === $type ) {
 			Page::query()->delete_all();
 		}
 
@@ -192,7 +197,7 @@ class Setup_Task extends Task {
 		$options = Options::instance();
 		$dir     = $options->get( 'temp_files_dir' );
 
-		if ( false === file_exists( $dir ) ) {
+		if ( false === file_exists( $dir ) || 'update' === $options->get('generate_type') ) {
 			return false;
 		}
 

--- a/src/tasks/class-ss-simply-cdn-task.php
+++ b/src/tasks/class-ss-simply-cdn-task.php
@@ -98,7 +98,6 @@ class Simply_Cdn_Task extends Task {
 			// Clear cache.
 			Simply_CDN_Api::clear_cache();
 
-
 			self::delete_transients();
 		}
 

--- a/src/tasks/class-ss-simply-cdn-task.php
+++ b/src/tasks/class-ss-simply-cdn-task.php
@@ -6,6 +6,9 @@ namespace Simply_Static;
  * Class which upload files to SimplyCDN.
  */
 class Simply_Cdn_Task extends Task {
+
+	use canProcessPages;
+
 	/**
 	 * The task name.
 	 *
@@ -34,6 +37,8 @@ class Simply_Cdn_Task extends Task {
 	 */
 	private $temp_dir;
 
+	protected $cdn_path = '';
+
 	/**
 	 * Constructor
 	 */
@@ -47,6 +52,24 @@ class Simply_Cdn_Task extends Task {
 		$this->data     = Simply_CDN_Api::get_data( $ss_options['ssh_security_token'] );
 		$this->options  = $options;
 		$this->temp_dir = $options->get_archive_dir();
+
+		if ( ! empty( $this->cdn->data->cdn->sub_directory ) ) {
+			$this->cdn_path = $this->cdn->data->cdn->sub_directory . '/';
+		}
+	}
+
+	protected function process_page( $static_page ) {
+		$file_path = $this->temp_dir . $static_page->file_path;
+
+		if ( ! is_dir( $file_path ) && file_exists( $file_path ) ) {
+			$this->cdn->upload_file( $this->data->cdn->access_key, $this->data->cdn->pull_zone->name, $this->cdn_path . $static_page->file_path, $file_path );
+			Util::debug_log( "Uploading: " . $file_path );
+		}
+
+		do_action( 'ss_file_transferred_to_cdn', $static_page, $this->temp_dir );
+
+		$static_page->last_transferred_at = Util::formatted_datetime();
+		$static_page->save();
 	}
 
 	/**
@@ -55,8 +78,9 @@ class Simply_Cdn_Task extends Task {
 	 * @return boolean true if done, false if not done.
 	 */
 	public function perform() {
-		list( $pages_processed, $total_pages ) = $this->upload_static_files( $this->temp_dir );
+		$done = $this->process_pages();
 
+		/*
 		if ( $pages_processed !== 0 ) {
 			$message = sprintf( __( "Uploading %d of %d pages/files", 'simply-static' ), $pages_processed, $total_pages );
 			$this->save_status_message( $message );
@@ -72,9 +96,15 @@ class Simply_Cdn_Task extends Task {
 				$this->save_status_message( $message );
 			}
 		}
+*/
+		if ( $done ) {
 
-		// return true when done (no more pages).
-		if ( $pages_processed >= $total_pages ) {
+			if ( $this->options->get( 'destination_url_type' ) == 'absolute' ) {
+				$destination_url = trailingslashit( $this->options->get_destination_url() );
+				$message         = __( 'Destination URL:', 'simply-static' ) . ' <a href="' . $destination_url . '" target="_blank">' . $destination_url . '</a>';
+				$this->save_status_message( $message, 'destination_url' );
+			}
+
 			do_action( 'ss_finished_cdn_transfer', $this->temp_dir );
 
 			// Maybe add 404.
@@ -82,9 +112,12 @@ class Simply_Cdn_Task extends Task {
 
 			// Clear cache.
 			Simply_CDN_Api::clear_cache();
+
+
+			self::delete_transients();
 		}
 
-		return $pages_processed >= $total_pages;
+		return $done;
 	}
 
 	/**

--- a/src/tasks/class-ss-simply-cdn-task.php
+++ b/src/tasks/class-ss-simply-cdn-task.php
@@ -8,8 +8,6 @@ namespace Simply_Static;
 class Simply_Cdn_Task extends Task {
 
 	use canProcessPages;
-
-
 	use canTransfer;
 
 	/**
@@ -84,23 +82,6 @@ class Simply_Cdn_Task extends Task {
 	public function perform() {
 		$done = $this->process_pages();
 
-		/*
-		if ( $pages_processed !== 0 ) {
-			$message = sprintf( __( "Uploading %d of %d pages/files", 'simply-static' ), $pages_processed, $total_pages );
-			$this->save_status_message( $message );
-		}
-
-		if ( $pages_processed >= $total_pages ) {
-			if ( $this->options->get( 'destination_url_type' ) == 'absolute' ) {
-				$destination_url = trailingslashit( $this->options->get_destination_url() );
-				$message         = __( 'Destination URL:', 'simply-static' ) . ' <a href="' . $destination_url . '" target="_blank">' . $destination_url . '</a>';
-				$this->save_status_message( $message, 'destination_url' );
-			} else {
-				$message = sprintf( __( "Uploaded %d of %d pages/files", 'simply-static' ), $pages_processed, $total_pages );
-				$this->save_status_message( $message );
-			}
-		}
-*/
 		if ( $done ) {
 
 			if ( $this->options->get( 'destination_url_type' ) == 'absolute' ) {
@@ -128,6 +109,8 @@ class Simply_Cdn_Task extends Task {
 	 * Upload files to CDN.
 	 *
 	 * @param string $destination_dir The directory to put the files..
+	 *
+	 * @deprecated Using process_page.
 	 *
 	 * @return array
 	 */

--- a/src/tasks/class-ss-transfer-files-locally-task.php
+++ b/src/tasks/class-ss-transfer-files-locally-task.php
@@ -7,6 +7,8 @@ namespace Simply_Static;
  */
 class Transfer_Files_Locally_Task extends Task {
 
+	use canProcessPages;
+
 	/**
 	 * Task name.
 	 *
@@ -14,6 +16,19 @@ class Transfer_Files_Locally_Task extends Task {
 	 */
 	protected static $task_name = 'transfer_files_locally';
 
+	/**
+	 * Destination Folder.
+	 *
+	 * @var string
+	 */
+	protected $destination_dir = '';
+
+	/**
+	 * Archive Folder.
+	 *
+	 * @var string
+	 */
+	protected $archive_dir = '';
 
 	/**
 	 * Copy a batch of files from the temp dir to the destination dir
@@ -21,35 +36,97 @@ class Transfer_Files_Locally_Task extends Task {
 	 * @return boolean true if done, false if not done.
 	 */
 	public function perform() {
-		$local_dir = apply_filters( 'ss_local_dir', $this->options->get( 'local_dir' ) );
+		$this->destination_dir = apply_filters( 'ss_local_dir', $this->options->get( 'local_dir' ) );
+		$this->archive_dir     = $this->options->get_archive_dir();
 
-		list( $pages_processed, $total_pages ) = $this->copy_static_files( $local_dir );
+		$done = $this->process_pages();
 
-		if ( $pages_processed !== 0 ) {
-			$message = sprintf( __( "Copied %d of %d files", 'simply-static' ), $pages_processed, $total_pages );
-			$this->save_status_message( $message );
-		}
+		if ( $done ) {
 
-		if ( $pages_processed >= $total_pages ) {
+			$this->transfer_404_page( $this->destination_dir );
+
 			if ( $this->options->get( 'destination_url_type' ) == 'absolute' ) {
 				$destination_url = trailingslashit( $this->options->get_destination_url() );
 				$message         = __( 'Destination URL:', 'simply-static' ) . ' <a href="' . $destination_url . '" target="_blank">' . $destination_url . '</a>';
 				$this->save_status_message( $message, 'destination_url' );
 			}
+
+			do_action( 'ss_finished_transferring_files_locally', $this->destination_dir );
+
+			self::delete_transients();
 		}
 
-		// return true when done (no more pages).
-		if ( $pages_processed >= $total_pages ) {
-			do_action( 'ss_finished_transferring_files_locally', $local_dir );
+		return $done;
+	}
+
+	/**
+	 * Message to set when processed pages.
+	 *
+	 * @param integer $processed Number of pages processed.
+	 * @param integer $total Number of total pages to process.
+	 *
+	 * @return string
+	 */
+	protected function processed_pages_message( $processed, $total ) {
+		Util::debug_log('[Transfer] Total Pages:' . $total . '. Processed Pages: ' . $processed );
+		if ( ! $total && 'update' === $this->get_generate_type() ) {
+			return __( 'No new/updated pages to transfer', 'simply-static' );
 		}
 
-		return $pages_processed >= $total_pages;
+		return sprintf( __( "Transferred %d of %d files", 'simply-static' ), $processed, $total );
+	}
+
+	/**
+	 * Message to see when starting to process new pages.
+	 *
+	 * @param integer $to_process Number of pages to process.
+	 * @param integer $total Total of pages.
+	 *
+	 * @return string
+	 */
+	protected function processing_pages_message( $to_process, $total ) {
+		return sprintf( __( "Transferring %d of %d files", 'simply-static' ), $to_process, $total );
+	}
+
+	/**
+	 * @param Page $static_page Page object.
+	 *
+	 * @return void
+	 */
+	protected function process_page( $static_page ) {
+		$path_info = Util::url_path_info( $static_page->file_path );
+		$path      = Util::combine_path( $this->destination_dir, $path_info['dirname'] );
+		Util::debug_log( "Trying to transfer: " . $path );
+		if ( wp_mkdir_p( $path ) === false ) {
+			Util::debug_log( "Cannot create directory: " . $path );
+			$static_page->set_error_message( 'Unable to create destination directory' );
+		} else {
+			chmod( $path, 0755 );
+			$origin_file_path      = Util::combine_path( $this->archive_dir, $static_page->file_path );
+			$destination_file_path = Util::combine_path( $this->destination_dir, $static_page->file_path );
+
+			// check that destination file doesn't exist OR exists but is writeable
+			if ( ! file_exists( $destination_file_path ) || is_writable( $destination_file_path ) ) {
+				$copy = copy( $origin_file_path, $destination_file_path );
+				if ( $copy === false ) {
+					Util::debug_log( "Cannot copy " . $origin_file_path . " to " . $destination_file_path );
+					$static_page->set_error_message( 'Unable to copy file to destination' );
+				}
+			} else {
+				Util::debug_log( "File exists and is unwriteable: " . $destination_file_path );
+				$static_page->set_error_message( 'Destination file exists and is unwriteable' );
+			}
+		}
+
+		do_action( 'simply_static_page_file_transferred', $static_page, $this->destination_dir );
 	}
 
 	/**
 	 * Copy temporary static files to a local directory.
 	 *
-	 * @param string $destination_dir The directory to put the files..
+	 * @param string $destination_dir The directory to put the files.
+	 *
+	 * @depecated Using process_page now.
 	 *
 	 * @return array
 	 */
@@ -60,7 +137,7 @@ class Transfer_Files_Locally_Task extends Task {
 
 		// TODO: also check for recent modification time
 		// last_modified_at > ? AND
-		$static_pages    = Page::query()
+		$static_pages    =  Page::query()
 		                       ->where( "file_path IS NOT NULL" )
 		                       ->where( "file_path != ''" )
 		                       ->where( "( last_transferred_at < ? OR last_transferred_at IS NULL )", $archive_start_time )

--- a/src/tasks/traits/trait-can-process-pages.php
+++ b/src/tasks/traits/trait-can-process-pages.php
@@ -1,0 +1,231 @@
+<?php
+namespace Simply_Static;
+
+trait canProcessPages {
+
+	/**
+	 * Start Time of the Task to process pages.
+	 *
+	 * @var null
+	 */
+	protected $start_time = null;
+
+	/**
+	 * Batch Size.
+	 *
+	 * @var int
+	 */
+	protected $batch_size = 50;
+
+	/**
+	 * Get batch size.
+	 *
+	 * @return mixed
+	 */
+	protected function get_batch_size() {
+		return apply_filters( 'simply_static_' . static::$task_name . '_batch_size', $this->batch_size );
+	}
+
+	/**
+	 * Set Start Time
+	 *
+	 * @return void
+	 */
+	public function set_start_time() {
+		$this->start_time = $this->options->get( 'archive_start_time' );
+	}
+
+	/**
+	 * Get the start time.
+	 * If null, it'll set the start time as well.
+	 *
+	 * @return null
+	 */
+	public function get_start_time() {
+		if ( null === $this->start_time ) {
+			$this->set_start_time();
+		}
+
+		return $this->start_time;
+	}
+
+	/**
+	 * Get generation type (export, update, build)
+	 *
+	 * @return mixed|string|null
+	 */
+	public function get_generate_type() {
+		$type = $this->options->get('generate_type');
+
+		if ( ! $type ) {
+			$type = 'export';
+		}
+
+		return $type;
+	}
+
+	/**
+	 * Process Pages that have to be processed/transferred.
+	 *
+	 * @return bool If true, it's done with all pages. If false, there are still pages to process/transfer.
+	 */
+	public function process_pages() {
+		$pages_to_process       = $this->get_pages_to_process();
+		$total_pages            = $this->get_total_pages();
+		$pages_to_process_count = count( $pages_to_process );
+
+		if ( $pages_to_process_count === 0 ) {
+			$processed_pages = $this->get_processed_pages();
+			$message         = $this->processed_pages_message( $processed_pages, $total_pages );
+			$this->save_status_message( $message );
+			return true; // No Pages to process anymore. It's done.
+		}
+
+		$message = $this->processing_pages_message( $pages_to_process_count, $total_pages );
+		$this->save_status_message( $message );
+
+		while ( $static_page = array_shift( $pages_to_process ) ) {
+			try {
+				$this->process_page( $static_page );
+
+				$static_page->last_transferred_at = Util::formatted_datetime();
+				$static_page->save();
+			} catch (\Exception $e) {
+				Util::debug_log( 'Page URL: ' . $static_page->url . ' not being processed. Error: ' . $e->getMessage() );
+				$static_page->set_error_message( $e->getMessage() );
+				$static_page->save();
+			}
+		}
+
+		$processed_pages = $this->get_processed_pages();
+		$message         = $this->processed_pages_message( $processed_pages, $total_pages );
+		$this->save_status_message( $message );
+		Util::debug_log( "Total pages: " . $total_pages . '; Pages remaining: ' . ( $total_pages - $processed_pages ) );
+
+		return $processed_pages >= $total_pages;
+	}
+
+	/**
+	 * @param Page $static_page Page object.
+	 *
+	 * @return void
+	 */
+	protected function process_page( $static_page ) {}
+
+	/**
+	 * Message to see when starting to process new pages.
+	 *
+	 * @param integer $to_process Number of pages to process.
+	 * @param integer $total Total of pages.
+	 *
+	 * @return string
+	 */
+	protected function processing_pages_message( $to_process, $total ) {
+		return sprintf( __( "Processing %d of %d files", 'simply-static' ), $to_process, $total );
+	}
+
+	/**
+	 * Message to set when processed pages.
+	 *
+	 * @param integer $processed Number of pages processed.
+	 * @param integer $total Number of total pages to process.
+	 *
+	 * @return string
+	 */
+	protected function processed_pages_message( $processed, $total ) {
+		return sprintf( __( "Processed %d of %d files", 'simply-static' ), $processed, $total );
+	}
+
+	/**
+	 * Return the number of processed pages.
+	 *
+	 * @return int|null
+	 * @throws \Exception
+	 */
+	public function get_processed_pages() {
+		$start_time = $this->get_start_time();
+		$query      = $this->get_main_query();
+
+		if ( 'export' === $this->get_generate_type() ) {
+			$query->where("last_transferred_at >= ?", $start_time );
+		}
+
+		if ( 'update' === $this->get_generate_type() ) {
+			$query->where("last_transferred_at >= last_modified_at" );
+			$query->where("last_transferred_at >= ?", $start_time );
+		}
+
+		return $query->count();
+	}
+
+	/**
+	 * Get pages to process, in batches.
+	 *
+	 * @return array|null
+	 * @throws \Exception
+	 */
+	public function get_pages_to_process() {
+		$start_time = $this->get_start_time();
+		$batch_size = $this->get_batch_size();
+		$query      = $this->get_main_query();
+
+		if ( 'export' === $this->get_generate_type() ) {
+			$query->where("( last_transferred_at < ? OR last_transferred_at IS NULL )", $start_time );
+		}
+
+		if ( 'update' === $this->get_generate_type() ) {
+			$query->where("( ( last_transferred_at < last_modified_at AND last_transferred_at < ? ) OR last_transferred_at IS NULL )", $start_time );
+		}
+
+		return $query->limit( $batch_size )->find();
+	}
+
+	public function get_total_pages( $cached = true ) {
+		if ( ! $cached ) {
+			return $this->get_total_pages_sql();
+		}
+
+		$count = get_transient( 'simply_static_' . static::$task_name . '_total_pages' );
+		if ( false === $count ) {
+			$count = $this->get_total_pages_sql();
+			set_transient( 'simply_static_' . static::$task_name . '_total_pages', $count );
+		}
+
+		return $count;
+	}
+
+	public static function delete_transients() {
+		delete_transient( 'simply_static_' . static::$task_name . '_total_pages' );
+	}
+
+	/**
+	 * Get number of total pages.
+	 *
+	 * @return int|null
+	 * @throws \Exception
+	 */
+	public function get_total_pages_sql() {
+		$query = $this->get_main_query();
+		$start_time = $this->get_start_time();
+
+		// Caching totals so this is fetched on first run (all pages already fetched).
+		if ( 'update' === $this->get_generate_type() ) {
+			$query->where("( ( last_transferred_at < last_modified_at AND last_transferred_at < ? ) OR last_transferred_at IS NULL )", $start_time );
+			Util::debug_log('Total Pages Query: ' . $query->get_raw_sql("COUNT(*)") );
+		}
+
+		return $query->count();
+	}
+
+	/**
+	 * Get the main Query.
+	 *
+	 * @return Query|\Simply_Static\Query
+	 * @throws \Exception
+	 */
+	public function get_main_query() {
+		return Page::query()
+		           ->where( "file_path IS NOT NULL" )
+		           ->where( "file_path != ''" );
+	}
+}

--- a/src/tasks/traits/trait-can-process-pages.php
+++ b/src/tasks/traits/trait-can-process-pages.php
@@ -121,7 +121,7 @@ trait canProcessPages {
 	 * @return string
 	 */
 	protected function processing_pages_message( $to_process, $total ) {
-		return sprintf( __( "Processing %d of %d files", 'simply-static' ), $to_process, $total );
+		return sprintf( __( "Uploading %d of %d files", 'simply-static' ), $to_process, $total );
 	}
 
 	/**
@@ -133,7 +133,7 @@ trait canProcessPages {
 	 * @return string
 	 */
 	protected function processed_pages_message( $processed, $total ) {
-		return sprintf( __( "Processed %d of %d files", 'simply-static' ), $processed, $total );
+		return sprintf( __( "Uploaded %d of %d files", 'simply-static' ), $processed, $total );
 	}
 
 	/**


### PR DESCRIPTION
### Changes

Adds a way to choose between export & update.

If a delivery method allows the incremental export, the 'update' option will deploy only pages that have been changed.


### Tests

- [ ] Create an export with Local Transfer or SimplyCDN
- [ ] Change a few pages
- [ ] Choose 'Update' and start the export again
- [ ] The "Uploaded" message should contain a much smaller number of pages that will be transferred (usually for 1 page, there are at least 2 pages transferred, 1 HTML, 1 RSS)