### PR TITLE
Use origin_url instead for 404 page

### DIFF
--- a/src/tasks/class-ss-generate-404-task.php
+++ b/src/tasks/class-ss-generate-404-task.php
@@ -46,7 +46,7 @@ class Generate_404_Task extends Task {
 			$static_page->post_id  = 0;
 			$static_page->id  = 0;
 			$static_page->build_id = 0;
-			$static_page->url      = home_url( (string) $page_slug );
+			$static_page->url      = Util::origin_url() . "/" . $page_slug;
 			$static_page->handler  = Handler_404::class;
 			$static_page->error_message = '';
 			$static_page->found_on_id = 0;


### PR DESCRIPTION
Ran into an issue when using origin_url + 404 generation. I noticed it was trying to call the home_url which is not reachable within the server.

This PR fixes this to use the origin_url instead, which is in alignment with expectations of setting an origin_url.