### PR TITLE
Adding Redirection Integration

### DIFF
--- a/src/class-ss-integrations.php
+++ b/src/class-ss-integrations.php
@@ -37,7 +37,8 @@ class Integrations {
 			'jetpack'       => Jetpack_Integration::class,
 			'multilingual'  => Multilingual_Integration::class,
 			'github'        => Github_Integration::class,
-			'shortpixel'    => Shortpixel_Integration::class
+			'shortpixel'    => Shortpixel_Integration::class,
+			'redirection'   => Redirection_Integration::class
 		] );
 	}
 
@@ -58,6 +59,7 @@ class Integrations {
 		require_once $path . 'class-cookie-yes-integration.php';
 		require_once $path . 'class-brizy-integration.php';
 		require_once $path . 'class-jetpack-integration.php';
+		require_once $path . 'class-redirection-integration.php';
 
 		// Simply Static Pro integrations.
 		require_once $path . 'class-pro-integration.php';

--- a/src/integrations/class-redirection-integration.php
+++ b/src/integrations/class-redirection-integration.php
@@ -1,0 +1,70 @@
+<?php
+namespace Simply_Static;
+
+class Redirection_Integration extends Integration {
+	/**
+	 * Given plugin handler ID.
+	 *
+	 * @var string Handler ID.
+	 */
+	protected $id = 'redirection';
+
+	public function __construct() {
+		$this->name = __( 'Redirection', 'simply-static' );
+		$this->description = __( 'Integrates redirections from the "Redirection" Plugin automatically on each export.', 'simply-static' );
+	}
+
+	/**
+	 * Return if the dependency is active.
+	 *
+	 * @return boolean
+	 */
+	public function dependency_active() {
+		return defined( 'REDIRECTION_FILE' );
+	}
+
+	/**
+	 * Adding Redirection URLs
+	 * @return void
+	 */
+	public function run() {
+		add_action( 'ss_after_setup_task', [ $this, 'register_redirections' ] );
+	}
+
+	/**
+	 * Register all redirections.
+	 *
+	 * @return void
+	 */
+	public function register_redirections() {
+
+		$redirections = $this->get_redirects();
+
+		if ( ! $redirections ) {
+			return;
+		}
+
+		foreach ( $redirections as $redirection ) {
+			$url = home_url( $redirection['url'] );
+			Util::debug_log( 'Adding redirection URL to queue: ' . $url );
+			/** @var \Simply_Static\Page $static_page */
+			$static_page = Page::query()->find_or_initialize_by( 'url', $url );
+			$static_page->set_status_message( __( 'Redirection URL', 'simply-static' ) );
+			$static_page->found_on_id = 0;
+			$static_page->save();
+		}
+
+	}
+
+	/**
+	 * Get Redirections.
+	 * @return array|object|\stdClass[]|null
+	 */
+	protected function get_redirects() {
+		global $wpdb;
+
+		$results = $wpdb->get_results( "SELECT url FROM {$wpdb->prefix}redirection_items", ARRAY_A );
+
+		return empty( $results ) ? null : $results;
+	}
+}


### PR DESCRIPTION
Closes #211 

### Changes

Adds the integration for the "Redirection" plugin and automatically adds all redirections created by the plugin as records in the static pages table.

Once they are fetched and processed, it creates the "redirect" HTML required for redirects.

### Test

- [x] Install and activate Redirections plugin
- [x] Go to "Integrations" page and activate "Redirections" integration
- [x] Add redirections or change post/page "slug" for redirections to be created
- [x] Export the site
- [x] Check if there are folders for redirections with the redirect HTML