### PR TITLE
Adding SFTP key field

### DIFF
--- a/src/admin/build/index.asset.php
+++ b/src/admin/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => '5c0e5c53217c3506dc0b');
+<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => '5b2a5c49f308563cefe2');

--- a/src/admin/build/index.js
+++ b/src/admin/build/index.js
@@ -954,6 +954,7 @@ function SettingsContextProvider(props) {
     'sftp_host': '',
     'sftp_user': '',
     'sftp_pass': '',
+    'sftp_private_key': '',
     'sftp_folder': '',
     'sftp_port': 22,
     'shortpixel_enabled': false,
@@ -1869,6 +1870,14 @@ function DeploymentSettings() {
     value: settings.sftp_pass,
     onChange: pass => {
       updateSetting('sftp_pass', pass);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextareaControl, {
+    label: __('SFTP private key', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    help: __('Enter your SFTP private key if you want password.less upload and the server is configured to allow it. You can set it as a constant in wp-config.php by using define(\'SSP_SFTP_KEY\', \'YOUR_KEY\')', 'simply-static'),
+    value: settings.sftp_private_key,
+    onChange: pass => {
+      updateSetting('sftp_private_key', pass);
     }
   }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
     label: __('SFTP folder', 'simply-static'),

--- a/src/admin/src/settings/context/SettingsContext.jsx
+++ b/src/admin/src/settings/context/SettingsContext.jsx
@@ -113,6 +113,7 @@ function SettingsContextProvider(props) {
         'sftp_host': '',
         'sftp_user': '',
         'sftp_pass': '',
+        'sftp_private_key': '',
         'sftp_folder': '',
         'sftp_port': 22,
         'shortpixel_enabled': false,

--- a/src/admin/src/settings/pages/DeploymentSettings.jsx
+++ b/src/admin/src/settings/pages/DeploymentSettings.jsx
@@ -7,7 +7,7 @@ import {
     __experimentalSpacer as Spacer,
     Notice,
     Animate,
-    TextControl, SelectControl, ToggleControl, FlexItem, Flex, ExternalLink
+    TextControl, SelectControl, ToggleControl, FlexItem, Flex, ExternalLink, TextareaControl
 } from "@wordpress/components";
 import {useContext, useEffect, useState} from '@wordpress/element';
 import {SettingsContext} from "../context/SettingsContext";
@@ -738,6 +738,16 @@ function DeploymentSettings() {
                             value={settings.sftp_pass}
                             onChange={(pass) => {
                                 updateSetting('sftp_pass', pass);
+                            }}
+                        />
+
+                        <TextareaControl
+                            label={__('SFTP private key', 'simply-static')}
+                            disabled={('free' === options.plan || !isPro())}
+                            help={__('Enter your SFTP private key if you want password.less upload and the server is configured to allow it. You can set it as a constant in wp-config.php by using define(\'SSP_SFTP_KEY\', \'YOUR_KEY\')', 'simply-static')}
+                            value={settings.sftp_private_key}
+                            onChange={(pass) => {
+                                updateSetting('sftp_private_key', pass);
                             }}
                         />
 


### PR DESCRIPTION
### 🚀 Changeset Summary

This changeset introduces a new feature to the **SFTP deployment settings** and some UI enhancements for the Simply Static plugin.

#### 🔐 **New Feature:**
- **SFTP Private Key Support**: A new field for entering the **SFTP private key** was added to the **Deployment Settings** page.
  - This feature allows password-less SFTP uploads if the server is configured to accept it.
  - Users can define their private key directly in the settings or via the `wp-config.php` file using `define('SSP_SFTP_KEY', 'YOUR_KEY')`.

#### 📋 **UI Enhancements:**
- **New Text Area Field**: The `TextareaControl` component was introduced for the SFTP private key, enhancing the form's layout and making it easier for users to input long strings like keys.
- **Settings Context Update**: The settings context was updated to include the `sftp_private_key` field, ensuring that the value is managed across the application.

#### 🛠 **Code Changes:**
- **Modified Files**:
  - `index.js` now includes logic to handle the SFTP private key.
  - `SettingsContext` was updated to support the new `sftp_private_key` field.
  - The **DeploymentSettings** page now includes a help tooltip and support for inputting the private key.

### 🛠️ **Impact:**
- **Better Security**: The new SFTP private key field enables users to configure password-less uploads, improving security.
- **Improved User Experience**: The inclusion of the private key field and helpful tooltips provides a smoother and more flexible setup process for advanced users.

These updates enhance the plugin’s deployment capabilities while offering better security options for users.
