### PR TITLE
Making sure per_page parameter is always set when getting export log

### DIFF
--- a/src/class-ss-plugin.php
+++ b/src/class-ss-plugin.php
@@ -274,7 +274,8 @@ class Plugin {
 
 		do_action( 'ss_before_render_export_log', $blog_id );
 
-		$offset = ( intval( $current_page ) - 1 ) * intval( $per_page );
+		$per_page = $per_page ?: 25;
+		$offset   = ( intval( $current_page ) - 1 ) * intval( $per_page );
 
 		$static_pages = apply_filters(
 			'ss_total_pages_log',


### PR DESCRIPTION
Fixing error from the ticket regarding offset error when calling get_export_log