### PR TITLE
Making sure the 'version' from DB is not replaced by the constant

### DIFF
--- a/src/class-ss-options.php
+++ b/src/class-ss-options.php
@@ -118,7 +118,7 @@ class Options {
 	public function get( $name = '' ) {
 		return array_key_exists( $name, $this->options ) ?
 			(
-			defined( 'SIMPLY_STATIC_' . strtoupper( $name ) ) ?
+			'VERSION' !== strtoupper( $name ) && defined( 'SIMPLY_STATIC_' . strtoupper( $name ) ) ?
 				constant( 'SIMPLY_STATIC_' . strtoupper( $name ) ) :
 				apply_filters( 'ss_get_option_' . strtolower( $name ), $this->options[ $name ], $this )
 			)


### PR DESCRIPTION
Closes #275

### Changes

The `version` is now always returned from the database instead of using the constant defined in the plugin.

### Testing

- [x] Remove the column json from the Table if you have it
- [x] Change the version inside of the DB to a lower one than the one set in the constant
- [x] Reload the page
- [ ] Check the version in DB, should be the new one
- [x] Check the table schema, it should contain the json column