### PR TITLE
Adding all CSS files from Elementor when exporting in case of conditionals styles.

### DIFF
--- a/src/integrations/class-elementor-integration.php
+++ b/src/integrations/class-elementor-integration.php
@@ -208,6 +208,7 @@ class Elementor_Integration extends Integration {
 		$lib_urls = $this->get_lib_files();
 		//$file_urls   = array_merge( $file_urls, $bundle_urls );
 		$file_urls = array_merge( $file_urls, $lib_urls );
+		$file_urls = array_merge( $file_urls, $this->get_files_in_url( 'css' ) );
 		$file_urls = array_merge( $file_urls, $this->get_files_in_url( 'js' ) );
 		$file_urls = array_merge( $file_urls, $this->get_files_in_url( 'images' ) );
 		$file_urls = array_merge( $file_urls, $this->get_files_in_url( 'shapes' ) );


### PR DESCRIPTION
This will export all CSS from the free Elementor plugin so that the styles are there in case of conditional styles such as dialogs.