### PR TITLE
Allow sub items in the admin bar SS menu

### DIFF
--- a/assets/admin-bar.js
+++ b/assets/admin-bar.js
@@ -22,7 +22,7 @@ jQuery(document).ready(function ($) {
                 }
 
                 // render html
-                $('#wp-admin-bar-ss-admin-bar .ab-item').html(ss_admin_status_object.translations.label + ' ' + message);
+                $('#wp-admin-bar-ss-admin-bar .ab-item:first').html(ss_admin_status_object.translations.label + ' ' + message);
             }
         });
     }


### PR DESCRIPTION
Current admin bar javascript assumes there is only one item in the simply-static admin bar. If we want to add a sub item, its text gets overwritten with the current state of static generation. This fixes that, allowing the admin menu bar to have sub items.