### PR TITLE
Returning back the filter for fetch urls

### DIFF
--- a/src/tasks/class-ss-fetch-urls-task.php
+++ b/src/tasks/class-ss-fetch-urls-task.php
@@ -44,11 +44,14 @@ class Fetch_Urls_Task extends Task {
 	 * @return boolean|WP_Error true if done, false if not done, WP_Error if error.
 	 */
 	public function perform() {
+		$batch_size = apply_filters( 'simply_static_fetch_urls_batch_size', 50 );
+
 		$static_pages = apply_filters(
 			'ss_static_pages',
 			Page::query()
 			    ->where( 'last_checked_at < ? OR last_checked_at IS NULL', $this->archive_start_time )
-			    ->find(),
+				->limit( $batch_size )
+				->find(),
 			$this->archive_start_time
 		);
 


### PR DESCRIPTION
Closes #297.

This introduces back the filter for batch size as a hotfix.

I'll create a different ticket to apply the trait to that task as it seems that it's not using it at all.

Once that is added and tested, it will use the trait correctly and get all the optimizations done to it.