### PR TITLE
Multisite improvements

### DIFF
--- a/src/admin/build/index-rtl.css
+++ b/src/admin/build/index-rtl.css
@@ -1,1 +1,475 @@
-#wpcontent{padding-right:0}#wpbody-content{padding-bottom:0}#wpfooter{display:none}toplevel_page_simply-static img{width:100%}.settings-error.notice.notice-warning{display:none}.plugin-settings-container{background:#f0f0f1}.plugin-settings-container .components-flex{align-items:flex-start;height:100%}.plugin-settings-container .components-flex-item{margin-right:0;width:100%}.plugin-settings-container .inner-settings>*{max-width:850px;width:100%}.plugin-settings-container a.components-external-link{display:block;text-align:left}.plugin-settings-container .save-settings{bottom:0;box-sizing:border-box;padding:15px 0;position:sticky;text-align:left}.plugin-settings-container .save-settings button:not(:first-child){background:#f0f0f1;margin-right:10px}.plugin-settings-container .save-settings button:disabled{background-color:#ddd;cursor:not-allowed}.plugin-settings-container .migrate-notice.components-notice.is-warning{margin:0 0 10px}.plugin-settings-container .diagnostics-notice{border-right:4px solid var(--wp-components-color-accent,#b32d2e);margin:0 0 20px!important;max-width:840px}.plugin-settings-container .diagnostics-notice .is-secondary{box-shadow:inset 0 0 0 1px #b32d2e!important;color:#b32d2e!important}.plugin-settings-container .diagnostics-notice-generate{max-width:100%!important}.plugin-settings-container .upgrade-network-notice{margin:0 40px 0 0}.plugin-settings-container .ss-align-right{text-align:left}.plugin-settings-container textarea{width:100%}.plugin-settings-container .ss-no-shrink{flex-shrink:0}.plugin-settings-container .ss-integration{align-items:center}.plugin-settings-container .ss-integration .ss-text-notice{color:#6804cc;font-size:10px;margin-right:10px;text-transform:uppercase}.plugin-settings-container .ss-integration .integration-toggle{margin:0}.plugin-settings-container .sidebar{background:#fff;box-sizing:border-box;height:100%;margin:0;max-width:220px;padding:25px}.plugin-settings-container .plugin-nav{box-shadow:none;height:100%}.plugin-settings-container .plugin-nav button:focus,.plugin-settings-container .plugin-nav button:focus-visible,.plugin-settings-container .plugin-nav button:hover{box-shadow:none;color:#6804cc}.plugin-settings-container .plugin-nav .generate-container{margin-top:30px}.plugin-settings-container .plugin-nav .generate-container .generate-type{height:40px;line-height:40px;max-width:200px}.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container{display:flex;gap:5px}.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container button{width:100%}.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container button.components-button>.dashicon{margin:0 auto}.plugin-settings-container .plugin-nav .generate-container button{background:#6804cc;border:1px solid #50059b;color:#fff;line-height:1.5;text-align:center;text-decoration:none}.plugin-settings-container .plugin-nav .generate-container button.ss-generate-cancel-button{background:#b32d2e;border-color:#9b2626}.plugin-settings-container .plugin-nav .generate-container button:disabled{opacity:.5}.plugin-settings-container .plugin-nav .generate-container .cancel-button{color:#6804cc;cursor:pointer;display:block;max-width:200px;text-align:center;text-decoration:underline}.plugin-settings-container .plugin-nav .environment-container button{text-align:center}.plugin-settings-container .plugin-nav .environment-delete-button{color:#b32d2e;margin-top:4px}.plugin-settings-container .plugin-nav .components-button{display:block!important;padding:0;text-align:right;width:100%}.plugin-settings-container .plugin-nav .components-card__body{padding:20px 0}.plugin-settings-container .plugin-nav .components-button.is-primary{box-sizing:border-box;padding:10px 5px;width:100%}.plugin-settings-container .plugin-nav .dashicon.dashicons.dashicons-admin-links{font-size:15px;position:relative;top:2px}.plugin-settings-container .plugin-nav .components-button>.dashicon{margin-left:10px}.plugin-settings-container .plugin-nav .plugin-logo{max-width:150px}.plugin-settings-container .plugin-nav .is-active-item{color:#6804cc}.plugin-settings-container .plugin-nav h4.settings-headline{text-transform:uppercase}.plugin-settings-container .plugin-settings{background:#f0f0f1;box-sizing:border-box;height:auto;padding:25px}.plugin-settings-container .plugin-settings .crawler-descriptions{margin:20px 0}.plugin-settings-container .plugin-settings .crawler-description{margin:5px 0}.plugin-settings-container .plugin-settings .crawler-name{max-width:20%}.plugin-settings-container .plugin-settings .horizontal-token-field .components-flex-item{width:auto}.plugin-settings-container .plugin-settings table{width:100%}.plugin-settings-container .plugin-settings table th{text-align:right;text-transform:uppercase}.plugin-settings-container .plugin-settings table td.diagnostics-icon{width:15%}.plugin-settings-container .plugin-settings table td.diagnostics-test{line-break:anywhere;width:30%}.plugin-settings-container .plugin-settings table td.diagnostics-result{line-break:anywhere;width:55%}.plugin-settings-container .plugin-settings .components-notice{box-sizing:border-box;margin:15px 0 0}.plugin-settings-container .plugin-settings .inline-tooltip{display:inline;margin-right:5px;position:relative;top:-2px}.plugin-settings-container .plugin-settings .dashicons-no.icon-no,.plugin-settings-container .plugin-settings .dashicons-yes.icon-yes{border:1px solid;border-radius:50%;padding:2px}.plugin-settings-container .plugin-settings .dashicons-yes.icon-yes{color:#51aa51}.plugin-settings-container .plugin-settings .dashicons-no.icon-no{color:#ca4242}.plugin-settings-container .plugin-settings .formatted-label{display:block;font-size:11px;font-weight:500;margin-bottom:10px;text-transform:uppercase}.plugin-settings-container .plugin-settings .simplycdn-connect{position:relative;top:-7px}.plugin-settings-container .plugin-settings .react-terminal-line{margin-bottom:10px}.plugin-settings-container .plugin-settings .react-terminal-line .is-error{color:#ca4242}.plugin-settings-container .plugin-settings .react-terminal-line .is-success{color:#51aa51}.plugin-settings-container .plugin-settings .react-terminal-line a{color:#6fa4df}.plugin-settings-container .plugin-settings .ss-theme-style-name .components-base-control__help{margin-bottom:10px}.plugin-settings-container .plugin-settings .ss-theme-style-name .components-input-control__container{width:200px}.plugin-settings-container .plugin-settings .ss-theme-style-name .components-input-control__container .components-input-control__input{text-align:left}.plugin-settings-container .plugin-settings .ss-theme-style-name .components-input-control__container .components-input-control__suffix{background:rgba(0,0,0,.05);padding-right:5px;padding-left:10px}.plugin-settings-container .ss-export-log-search{background:#f0f0f1;border:none;border-radius:1px;display:block;margin-bottom:10px;padding:4px 10px;width:100%}.plugin-settings-container .ss-export-log-search :focus{border-color:#3858e9;box-shadow:none;outline:none}.plugin-settings-container input:disabled,.plugin-settings-container select:disabled,.plugin-settings-container textarea:disabled{background:#eee}.plugin-settings-container .components-card{border-radius:0!important}.plugin-settings-container .simply-static-video-modal-background{background-color:rgba(0,0,0,.5);display:none;height:100%;right:0;position:fixed;top:0;width:100%;z-index:9999}.plugin-settings-container .simply-static-video-button.is-link{box-shadow:none;color:#3858e9;display:inline-block;line-height:1.4;margin-right:5px;text-decoration:none}.plugin-settings-container .ss-get-pro{background:#6804cc!important;border:1px solid #50059b}.components-modal__frame.simply-static-video-modal{border-radius:0}.dashicons.spin{animation:dashicons-spin 2s infinite;animation-timing-function:linear}@keyframes dashicons-spin{0%{transform:rotate(0deg)}to{transform:rotate(-1turn)}}.reset-db-btn{margin-right:10px}a.show-nav{display:none}@media screen and (max-width:640px){div#wpwrap{background:#fff}.toggle-nav{display:none}.plugin-settings-container .components-flex{align-items:center;background:#fff;flex-direction:column}.plugin-logo,p.version-number{display:none}.plugin-nav .generate-container{margin-top:0}.log-table-container{max-width:300px}.plugin-settings-container .plugin-settings{padding:0}.components-flex{gap:0}.auto-fold #wpcontent{padding-right:0}.plugin-settings-container .plugin-nav{box-shadow:none;max-width:205px;min-height:auto;padding:0}.react-terminal{height:180px!important}.react-terminal-wrapper{padding:50px 15px 0}.react-terminal-line{font-size:13px}.plugin-settings-container .plugin-nav .components-card__body{padding:0}a.show-nav{background:#f0f0f1;color:#1e1e1e;display:block;padding:20px;text-align:center;width:100%}span.components-form-toggle{margin:10px 0}a.components-button.is-secondary{display:block;line-height:1.5;margin:0 auto;max-width:180px}input::-moz-placeholder,textarea::-moz-placeholder{font-size:13px!important}input::placeholder,select,textarea::placeholder{font-size:13px!important}.components-text-control__input,.components-text-control__input[type=color],.components-text-control__input[type=date],.components-text-control__input[type=datetime-local],.components-text-control__input[type=datetime],.components-text-control__input[type=email],.components-text-control__input[type=month],.components-text-control__input[type=number],.components-text-control__input[type=password],.components-text-control__input[type=tel],.components-text-control__input[type=text]{font-size:13px}.save-settings{display:block;margin:5px auto 15px;width:180px}.save-settings button.components-button.is-primary{display:block;margin:0 auto;text-align:center;width:60%}.save-settings button.components-button.is-secondary{display:block;margin:10px auto;text-align:center;width:60%}.reset-db-btn{margin:10px 0 0}}
+/*!***************************************************************************************************************************************************************************************************************************************************!*\
+  !*** css ./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[4].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[4].use[2]!./node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[4].use[3]!./src/settings/settings.scss ***!
+  \***************************************************************************************************************************************************************************************************************************************************/
+#wpcontent {
+  padding-right: 0;
+}
+
+#wpbody-content {
+  padding-bottom: 0;
+}
+
+#wpfooter {
+  display: none;
+}
+
+toplevel_page_simply-static img {
+  width: 100%;
+}
+
+.settings-error.notice.notice-warning {
+  display: none;
+}
+
+/* Start plugin settings */
+.plugin-settings-container {
+  background: #f0f0f1;
+}
+.plugin-settings-container .components-flex {
+  align-items: flex-start;
+  height: 100%;
+}
+.plugin-settings-container .components-flex-item {
+  margin-right: 0;
+  width: 100%;
+}
+.plugin-settings-container .inner-settings > * {
+  width: 100%;
+  max-width: 850px;
+}
+.plugin-settings-container a.components-external-link {
+  display: block;
+  text-align: left;
+}
+.plugin-settings-container .save-settings {
+  position: sticky;
+  bottom: 0;
+  padding: 15px 0;
+  text-align: left;
+  box-sizing: border-box;
+}
+.plugin-settings-container .save-settings button:not(:first-child) {
+  margin-right: 10px;
+  background: #f0f0f1;
+}
+.plugin-settings-container .save-settings button:disabled {
+  cursor: not-allowed;
+  background-color: #ddd;
+}
+.plugin-settings-container .migrate-notice.components-notice.is-warning {
+  margin: 0 0 10px 0;
+}
+.plugin-settings-container .diagnostics-notice {
+  margin: 0 0 20px 0 !important;
+  max-width: 840px;
+  border-right: 4px solid var(--wp-components-color-accent, #b32d2e);
+}
+.plugin-settings-container .diagnostics-notice .is-secondary {
+  box-shadow: inset 0 0 0 1px #b32d2e !important;
+  color: #b32d2e !important;
+}
+.plugin-settings-container .diagnostics-notice-generate {
+  max-width: 100% !important;
+}
+.plugin-settings-container .upgrade-network-notice {
+  margin: 0 40px 0 0;
+}
+.plugin-settings-container .ss-align-right {
+  text-align: left;
+}
+.plugin-settings-container textarea {
+  width: 100%;
+}
+.plugin-settings-container .ss-no-shrink {
+  flex-shrink: 0;
+}
+.plugin-settings-container .ss-integration {
+  align-items: center;
+}
+.plugin-settings-container .ss-integration .ss-text-notice {
+  text-transform: uppercase;
+  font-size: 10px;
+  color: rgb(104, 4, 204);
+  margin-right: 10px;
+}
+.plugin-settings-container .ss-integration .integration-toggle {
+  margin: 0;
+}
+.plugin-settings-container .sidebar {
+  padding: 25px;
+  background: white;
+  box-sizing: border-box;
+  height: 100%;
+  max-width: 220px;
+  margin: 0;
+}
+.plugin-settings-container {
+  /* Navigation */
+}
+.plugin-settings-container .plugin-nav {
+  height: 100%;
+  box-shadow: none;
+}
+.plugin-settings-container .plugin-nav button:focus, .plugin-settings-container .plugin-nav button:focus-visible, .plugin-settings-container .plugin-nav button:hover {
+  box-shadow: none;
+  color: rgb(104, 4, 204);
+}
+.plugin-settings-container .plugin-nav .generate-container {
+  margin-top: 30px;
+}
+.plugin-settings-container .plugin-nav .generate-container .generate-type {
+  height: 40px;
+  line-height: 40px;
+  max-width: 200px;
+}
+.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container {
+  display: flex;
+  gap: 5px;
+}
+.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container button {
+  width: 100%;
+}
+.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container button.components-button > .dashicon {
+  margin: 0 auto;
+}
+.plugin-settings-container .plugin-nav .generate-container button {
+  background: #6804cc;
+  border: solid 1px #50059b;
+  color: white;
+  text-decoration: none;
+  text-align: center;
+  line-height: 1.5;
+}
+.plugin-settings-container .plugin-nav .generate-container button.ss-generate-cancel-button {
+  background: #b32d2e;
+  border-color: #9b2626;
+}
+.plugin-settings-container .plugin-nav .generate-container button:disabled {
+  opacity: 0.5;
+}
+.plugin-settings-container .plugin-nav .generate-container .cancel-button {
+  text-align: center;
+  display: block;
+  max-width: 200px;
+  cursor: pointer;
+  color: rgb(104, 4, 204);
+  text-decoration: underline;
+}
+.plugin-settings-container .plugin-nav .environment-container button {
+  text-align: center;
+}
+.plugin-settings-container .plugin-nav .environment-delete-button {
+  margin-top: 4px;
+  color: #b32d2e;
+}
+.plugin-settings-container .plugin-nav .components-button {
+  width: 100%;
+  text-align: right;
+  padding: 0;
+  display: block !important;
+}
+.plugin-settings-container .plugin-nav .components-card__body {
+  padding: 20px 0;
+}
+.plugin-settings-container .plugin-nav .components-button.is-primary {
+  padding: 10px 5px;
+  box-sizing: border-box;
+  width: 100%;
+}
+.plugin-settings-container .plugin-nav .dashicon.dashicons.dashicons-admin-links {
+  font-size: 15px;
+  top: 2px;
+  position: relative;
+}
+.plugin-settings-container .plugin-nav .components-button > .dashicon {
+  margin-left: 10px;
+}
+.plugin-settings-container .plugin-nav .plugin-logo {
+  max-width: 150px;
+}
+.plugin-settings-container .plugin-nav .is-active-item {
+  color: rgb(104, 4, 204);
+}
+.plugin-settings-container .plugin-nav h4.settings-headline {
+  text-transform: uppercase;
+}
+.plugin-settings-container {
+  /* Settings */
+}
+.plugin-settings-container .plugin-settings {
+  padding: 25px;
+  box-sizing: border-box;
+  height: auto;
+  background: #f0f0f1;
+  /* Smart Crawl */
+}
+.plugin-settings-container .plugin-settings .crawler-descriptions {
+  margin: 20px 0;
+}
+.plugin-settings-container .plugin-settings .crawler-description {
+  margin: 5px 0;
+}
+.plugin-settings-container .plugin-settings .crawler-name {
+  max-width: 20%;
+}
+.plugin-settings-container .plugin-settings .horizontal-token-field .components-flex-item {
+  width: auto;
+}
+.plugin-settings-container .plugin-settings {
+  /* Tables */
+}
+.plugin-settings-container .plugin-settings table {
+  width: 100%;
+}
+.plugin-settings-container .plugin-settings table th {
+  text-align: right;
+  text-transform: uppercase;
+}
+.plugin-settings-container .plugin-settings table td.diagnostics-icon {
+  width: 15%;
+}
+.plugin-settings-container .plugin-settings table td.diagnostics-test {
+  width: 30%;
+  line-break: anywhere;
+}
+.plugin-settings-container .plugin-settings table td.diagnostics-result {
+  width: 55%;
+  line-break: anywhere;
+}
+.plugin-settings-container .plugin-settings {
+  /* Notices */
+}
+.plugin-settings-container .plugin-settings .components-notice {
+  margin: 15px 0 0 0;
+  box-sizing: border-box;
+}
+.plugin-settings-container .plugin-settings {
+  /* Tooltips */
+}
+.plugin-settings-container .plugin-settings .inline-tooltip {
+  display: inline;
+  top: -2px;
+  position: relative;
+  margin-right: 5px;
+}
+.plugin-settings-container .plugin-settings .dashicons-yes.icon-yes, .plugin-settings-container .plugin-settings .dashicons-no.icon-no {
+  border: solid 1px;
+  border-radius: 50%;
+  padding: 2px 2px;
+}
+.plugin-settings-container .plugin-settings .dashicons-yes.icon-yes {
+  color: #51aa51;
+}
+.plugin-settings-container .plugin-settings .dashicons-no.icon-no {
+  color: #ca4242;
+}
+.plugin-settings-container .plugin-settings .formatted-label {
+  margin-bottom: 10px;
+  display: block;
+  font-weight: 500;
+  text-transform: uppercase;
+  font-size: 11px;
+}
+.plugin-settings-container .plugin-settings .simplycdn-connect {
+  position: relative;
+  top: -7px;
+}
+.plugin-settings-container .plugin-settings {
+  /* Terminal */
+}
+.plugin-settings-container .plugin-settings .react-terminal-line {
+  margin-bottom: 10px;
+}
+.plugin-settings-container .plugin-settings .react-terminal-line .is-error {
+  color: #ca4242;
+}
+.plugin-settings-container .plugin-settings .react-terminal-line .is-success {
+  color: #51aa51;
+}
+.plugin-settings-container .plugin-settings .react-terminal-line a {
+  color: #6fa4df;
+}
+.plugin-settings-container .plugin-settings .ss-theme-style-name .components-base-control__help {
+  margin-bottom: 10px;
+}
+.plugin-settings-container .plugin-settings .ss-theme-style-name .components-input-control__container {
+  width: 200px;
+}
+.plugin-settings-container .plugin-settings .ss-theme-style-name .components-input-control__container .components-input-control__input {
+  text-align: left;
+}
+.plugin-settings-container .plugin-settings .ss-theme-style-name .components-input-control__container .components-input-control__suffix {
+  padding-left: 10px;
+  background: rgba(0, 0, 0, 0.05);
+  padding-right: 5px;
+}
+.plugin-settings-container .ss-export-log-search {
+  width: 100%;
+  display: block;
+  background: #f0f0f1;
+  border: none;
+  border-radius: 1px;
+  padding: 4px 10px;
+  margin-bottom: 10px;
+}
+.plugin-settings-container .ss-export-log-search :focus {
+  outline: none;
+  box-shadow: none;
+  border-color: #3858e9;
+}
+.plugin-settings-container {
+  /* Style for disabled settings */
+}
+.plugin-settings-container input:disabled, .plugin-settings-container textarea:disabled, .plugin-settings-container select:disabled {
+  background: #eeeeee;
+}
+.plugin-settings-container .components-card {
+  border-radius: 0 !important;
+}
+.plugin-settings-container .simply-static-video-modal-background {
+  display: none;
+  position: fixed;
+  z-index: 9999;
+  right: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+.plugin-settings-container .simply-static-video-button.is-link {
+  box-shadow: none;
+  text-decoration: none;
+  display: inline-block;
+  margin-right: 5px;
+  line-height: 1.4;
+  color: #3858e9;
+}
+.plugin-settings-container .ss-get-pro {
+  background: #6804cc !important;
+  border: solid 1px #50059b;
+}
+
+.components-modal__frame.simply-static-video-modal {
+  border-radius: 0;
+}
+
+.dashicons.spin {
+  animation: dashicons-spin 2s infinite;
+  animation-timing-function: linear;
+}
+
+@keyframes dashicons-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(-360deg);
+  }
+}
+.reset-db-btn {
+  margin-right: 10px;
+}
+
+/* Responsive Design */
+a.show-nav {
+  display: none;
+}
+
+@media screen and (max-width: 640px) {
+  div#wpwrap {
+    background: white;
+  }
+  .toggle-nav {
+    display: none;
+  }
+  .plugin-settings-container .components-flex {
+    flex-direction: column;
+    align-items: center;
+    background: white;
+  }
+  .plugin-logo {
+    display: none;
+  }
+  p.version-number {
+    display: none;
+  }
+  .plugin-nav .generate-container {
+    margin-top: 0;
+  }
+  .log-table-container {
+    max-width: 300px;
+  }
+  .plugin-settings-container .plugin-settings {
+    padding: 0;
+  }
+  .components-flex {
+    gap: 0;
+  }
+  .auto-fold #wpcontent {
+    padding-right: 0;
+  }
+  .plugin-settings-container .plugin-nav {
+    padding: 0;
+    min-height: auto;
+    max-width: 205px;
+    box-shadow: none;
+  }
+  .react-terminal {
+    height: 180px !important;
+  }
+  .react-terminal-wrapper {
+    padding: 50px 15px 0;
+  }
+  .react-terminal-line {
+    font-size: 13px;
+  }
+  .plugin-settings-container .plugin-nav .components-card__body {
+    padding: 0;
+  }
+  a.show-nav {
+    text-align: center;
+    display: block;
+    color: #1e1e1e;
+    width: 100%;
+    background: #f0f0f1;
+    padding: 20px;
+  }
+  span.components-form-toggle {
+    margin: 10px 0 10px 0;
+  }
+  a.components-button.is-secondary {
+    margin: 0px auto;
+    display: block;
+    max-width: 180px;
+    line-height: 1.5;
+  }
+  textarea::-moz-placeholder, input::-moz-placeholder {
+    font-size: 13px !important;
+  }
+  select, textarea::placeholder, input::placeholder {
+    font-size: 13px !important;
+  }
+  .components-text-control__input, .components-text-control__input[type=color], .components-text-control__input[type=date], .components-text-control__input[type=datetime-local], .components-text-control__input[type=datetime], .components-text-control__input[type=email], .components-text-control__input[type=month], .components-text-control__input[type=number], .components-text-control__input[type=password], .components-text-control__input[type=tel], .components-text-control__input[type=text] {
+    font-size: 13px;
+  }
+  .save-settings {
+    margin: 5px auto 15px auto;
+    display: block;
+    width: 180px;
+  }
+  .save-settings button.components-button.is-primary {
+    width: 60%;
+    text-align: center;
+    display: block;
+    margin: 0px auto;
+  }
+  .save-settings button.components-button.is-secondary {
+    width: 60%;
+    text-align: center;
+    display: block;
+    margin: 10px auto;
+  }
+  .reset-db-btn {
+    margin: 10px 0 0 0;
+  }
+}

--- a/src/admin/build/index-rtl.css
+++ b/src/admin/build/index-rtl.css
@@ -106,6 +106,52 @@ toplevel_page_simply-static img {
 .plugin-settings-container {
   /* Navigation */
 }
+.plugin-settings-container .simple-static-sites .generate-container .generate-type,
+.plugin-settings-container .plugin-nav .generate-container .generate-type {
+  height: 40px;
+  line-height: 40px;
+  max-width: 200px;
+}
+.plugin-settings-container .simple-static-sites .generate-container.generating .generate-buttons-container,
+.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container {
+  display: flex;
+  gap: 5px;
+}
+.plugin-settings-container .simple-static-sites .generate-container.generating .generate-buttons-container button,
+.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container button {
+  width: 100%;
+}
+.plugin-settings-container .simple-static-sites .generate-container.generating .generate-buttons-container button.components-button > .dashicon,
+.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container button.components-button > .dashicon {
+  margin: 0 auto;
+}
+.plugin-settings-container .simple-static-sites .generate-container button,
+.plugin-settings-container .plugin-nav .generate-container button {
+  background: #6804cc;
+  border: solid 1px #50059b;
+  color: white;
+  text-decoration: none;
+  text-align: center;
+  line-height: 1.5;
+}
+.plugin-settings-container .simple-static-sites .generate-container button.ss-generate-cancel-button,
+.plugin-settings-container .plugin-nav .generate-container button.ss-generate-cancel-button {
+  background: #b32d2e;
+  border-color: #9b2626;
+}
+.plugin-settings-container .simple-static-sites .generate-container button:disabled,
+.plugin-settings-container .plugin-nav .generate-container button:disabled {
+  opacity: 0.5;
+}
+.plugin-settings-container .simple-static-sites .generate-container .cancel-button,
+.plugin-settings-container .plugin-nav .generate-container .cancel-button {
+  text-align: center;
+  display: block;
+  max-width: 200px;
+  cursor: pointer;
+  color: rgb(104, 4, 204);
+  text-decoration: underline;
+}
 .plugin-settings-container .plugin-nav {
   height: 100%;
   box-shadow: none;
@@ -116,44 +162,6 @@ toplevel_page_simply-static img {
 }
 .plugin-settings-container .plugin-nav .generate-container {
   margin-top: 30px;
-}
-.plugin-settings-container .plugin-nav .generate-container .generate-type {
-  height: 40px;
-  line-height: 40px;
-  max-width: 200px;
-}
-.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container {
-  display: flex;
-  gap: 5px;
-}
-.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container button {
-  width: 100%;
-}
-.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container button.components-button > .dashicon {
-  margin: 0 auto;
-}
-.plugin-settings-container .plugin-nav .generate-container button {
-  background: #6804cc;
-  border: solid 1px #50059b;
-  color: white;
-  text-decoration: none;
-  text-align: center;
-  line-height: 1.5;
-}
-.plugin-settings-container .plugin-nav .generate-container button.ss-generate-cancel-button {
-  background: #b32d2e;
-  border-color: #9b2626;
-}
-.plugin-settings-container .plugin-nav .generate-container button:disabled {
-  opacity: 0.5;
-}
-.plugin-settings-container .plugin-nav .generate-container .cancel-button {
-  text-align: center;
-  display: block;
-  max-width: 200px;
-  cursor: pointer;
-  color: rgb(104, 4, 204);
-  text-decoration: underline;
 }
 .plugin-settings-container .plugin-nav .environment-container button {
   text-align: center;

--- a/src/admin/build/index.asset.php
+++ b/src/admin/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => '619890b5508bac77f456');
+<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => '94371226e343d49d6e47');

--- a/src/admin/build/index.asset.php
+++ b/src/admin/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => '91812ebe80f3079a6855');
+<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => 'e2e1792ee275641a8210');

--- a/src/admin/build/index.asset.php
+++ b/src/admin/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => 'bee531a71f57b92fbe97');
+<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => '339f9710caf807f0ee8c');

--- a/src/admin/build/index.asset.php
+++ b/src/admin/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => '94371226e343d49d6e47');
+<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => '93665dc34380890b0b0e');

--- a/src/admin/build/index.asset.php
+++ b/src/admin/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => 'e2e1792ee275641a8210');
+<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => '73167df91ee2d8b6831e');

--- a/src/admin/build/index.asset.php
+++ b/src/admin/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => '73167df91ee2d8b6831e');
+<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => 'c1689ac0224ebd23515a');

--- a/src/admin/build/index.asset.php
+++ b/src/admin/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => '93665dc34380890b0b0e');
+<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => '91812ebe80f3079a6855');

--- a/src/admin/build/index.asset.php
+++ b/src/admin/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => 'c1689ac0224ebd23515a');
+<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => '30ac3ae612389c53c617');

--- a/src/admin/build/index.asset.php
+++ b/src/admin/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => '30ac3ae612389c53c617');
+<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-element'), 'version' => 'bee531a71f57b92fbe97');

--- a/src/admin/build/index.css
+++ b/src/admin/build/index.css
@@ -106,6 +106,52 @@ toplevel_page_simply-static img {
 .plugin-settings-container {
   /* Navigation */
 }
+.plugin-settings-container .simple-static-sites .generate-container .generate-type,
+.plugin-settings-container .plugin-nav .generate-container .generate-type {
+  height: 40px;
+  line-height: 40px;
+  max-width: 200px;
+}
+.plugin-settings-container .simple-static-sites .generate-container.generating .generate-buttons-container,
+.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container {
+  display: flex;
+  gap: 5px;
+}
+.plugin-settings-container .simple-static-sites .generate-container.generating .generate-buttons-container button,
+.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container button {
+  width: 100%;
+}
+.plugin-settings-container .simple-static-sites .generate-container.generating .generate-buttons-container button.components-button > .dashicon,
+.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container button.components-button > .dashicon {
+  margin: 0 auto;
+}
+.plugin-settings-container .simple-static-sites .generate-container button,
+.plugin-settings-container .plugin-nav .generate-container button {
+  background: #6804cc;
+  border: solid 1px #50059b;
+  color: white;
+  text-decoration: none;
+  text-align: center;
+  line-height: 1.5;
+}
+.plugin-settings-container .simple-static-sites .generate-container button.ss-generate-cancel-button,
+.plugin-settings-container .plugin-nav .generate-container button.ss-generate-cancel-button {
+  background: #b32d2e;
+  border-color: #9b2626;
+}
+.plugin-settings-container .simple-static-sites .generate-container button:disabled,
+.plugin-settings-container .plugin-nav .generate-container button:disabled {
+  opacity: 0.5;
+}
+.plugin-settings-container .simple-static-sites .generate-container .cancel-button,
+.plugin-settings-container .plugin-nav .generate-container .cancel-button {
+  text-align: center;
+  display: block;
+  max-width: 200px;
+  cursor: pointer;
+  color: rgb(104, 4, 204);
+  text-decoration: underline;
+}
 .plugin-settings-container .plugin-nav {
   height: 100%;
   box-shadow: none;
@@ -116,44 +162,6 @@ toplevel_page_simply-static img {
 }
 .plugin-settings-container .plugin-nav .generate-container {
   margin-top: 30px;
-}
-.plugin-settings-container .plugin-nav .generate-container .generate-type {
-  height: 40px;
-  line-height: 40px;
-  max-width: 200px;
-}
-.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container {
-  display: flex;
-  gap: 5px;
-}
-.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container button {
-  width: 100%;
-}
-.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container button.components-button > .dashicon {
-  margin: 0 auto;
-}
-.plugin-settings-container .plugin-nav .generate-container button {
-  background: #6804cc;
-  border: solid 1px #50059b;
-  color: white;
-  text-decoration: none;
-  text-align: center;
-  line-height: 1.5;
-}
-.plugin-settings-container .plugin-nav .generate-container button.ss-generate-cancel-button {
-  background: #b32d2e;
-  border-color: #9b2626;
-}
-.plugin-settings-container .plugin-nav .generate-container button:disabled {
-  opacity: 0.5;
-}
-.plugin-settings-container .plugin-nav .generate-container .cancel-button {
-  text-align: center;
-  display: block;
-  max-width: 200px;
-  cursor: pointer;
-  color: rgb(104, 4, 204);
-  text-decoration: underline;
 }
 .plugin-settings-container .plugin-nav .environment-container button {
   text-align: center;

--- a/src/admin/build/index.css
+++ b/src/admin/build/index.css
@@ -1,1 +1,477 @@
-#wpcontent{padding-left:0}#wpbody-content{padding-bottom:0}#wpfooter{display:none}toplevel_page_simply-static img{width:100%}.settings-error.notice.notice-warning{display:none}.plugin-settings-container{background:#f0f0f1}.plugin-settings-container .components-flex{align-items:flex-start;height:100%}.plugin-settings-container .components-flex-item{margin-left:0;width:100%}.plugin-settings-container .inner-settings>*{max-width:850px;width:100%}.plugin-settings-container a.components-external-link{display:block;text-align:right}.plugin-settings-container .save-settings{bottom:0;box-sizing:border-box;padding:15px 0;position:sticky;text-align:right}.plugin-settings-container .save-settings button:not(:first-child){background:#f0f0f1;margin-left:10px}.plugin-settings-container .save-settings button:disabled{background-color:#ddd;cursor:not-allowed}.plugin-settings-container .migrate-notice.components-notice.is-warning{margin:0 0 10px}.plugin-settings-container .diagnostics-notice{border-left:4px solid var(--wp-components-color-accent,#b32d2e);margin:0 0 20px!important;max-width:840px}.plugin-settings-container .diagnostics-notice .is-secondary{box-shadow:inset 0 0 0 1px #b32d2e!important;color:#b32d2e!important}.plugin-settings-container .diagnostics-notice-generate{max-width:100%!important}.plugin-settings-container .upgrade-network-notice{margin:0 0 0 40px}.plugin-settings-container .ss-align-right{text-align:right}.plugin-settings-container textarea{width:100%}.plugin-settings-container .ss-no-shrink{flex-shrink:0}.plugin-settings-container .ss-integration{align-items:center}.plugin-settings-container .ss-integration .ss-text-notice{color:#6804cc;font-size:10px;margin-left:10px;text-transform:uppercase}.plugin-settings-container .ss-integration .integration-toggle{margin:0}.plugin-settings-container .sidebar{background:#fff;box-sizing:border-box;height:100%;margin:0;max-width:220px;padding:25px}.plugin-settings-container .plugin-nav{box-shadow:none;height:100%}.plugin-settings-container .plugin-nav button:focus,.plugin-settings-container .plugin-nav button:focus-visible,.plugin-settings-container .plugin-nav button:hover{box-shadow:none;color:#6804cc}.plugin-settings-container .plugin-nav .generate-container{margin-top:30px}.plugin-settings-container .plugin-nav .generate-container .generate-type{height:40px;line-height:40px;max-width:200px}.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container{display:flex;gap:5px}.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container button{width:100%}.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container button.components-button>.dashicon{margin:0 auto}.plugin-settings-container .plugin-nav .generate-container button{background:#6804cc;border:1px solid #50059b;color:#fff;line-height:1.5;text-align:center;text-decoration:none}.plugin-settings-container .plugin-nav .generate-container button.ss-generate-cancel-button{background:#b32d2e;border-color:#9b2626}.plugin-settings-container .plugin-nav .generate-container button:disabled{opacity:.5}.plugin-settings-container .plugin-nav .generate-container .cancel-button{color:#6804cc;cursor:pointer;display:block;max-width:200px;text-align:center;text-decoration:underline}.plugin-settings-container .plugin-nav .environment-container button{text-align:center}.plugin-settings-container .plugin-nav .environment-delete-button{color:#b32d2e;margin-top:4px}.plugin-settings-container .plugin-nav .components-button{display:block!important;padding:0;text-align:left;width:100%}.plugin-settings-container .plugin-nav .components-card__body{padding:20px 0}.plugin-settings-container .plugin-nav .components-button.is-primary{box-sizing:border-box;padding:10px 5px;width:100%}.plugin-settings-container .plugin-nav .dashicon.dashicons.dashicons-admin-links{font-size:15px;position:relative;top:2px}.plugin-settings-container .plugin-nav .components-button>.dashicon{margin-right:10px}.plugin-settings-container .plugin-nav .plugin-logo{max-width:150px}.plugin-settings-container .plugin-nav .is-active-item{color:#6804cc}.plugin-settings-container .plugin-nav h4.settings-headline{text-transform:uppercase}.plugin-settings-container .plugin-settings{background:#f0f0f1;box-sizing:border-box;height:auto;padding:25px}.plugin-settings-container .plugin-settings .crawler-descriptions{margin:20px 0}.plugin-settings-container .plugin-settings .crawler-description{margin:5px 0}.plugin-settings-container .plugin-settings .crawler-name{max-width:20%}.plugin-settings-container .plugin-settings .horizontal-token-field .components-flex-item{width:auto}.plugin-settings-container .plugin-settings table{width:100%}.plugin-settings-container .plugin-settings table th{text-align:left;text-transform:uppercase}.plugin-settings-container .plugin-settings table td.diagnostics-icon{width:15%}.plugin-settings-container .plugin-settings table td.diagnostics-test{line-break:anywhere;width:30%}.plugin-settings-container .plugin-settings table td.diagnostics-result{line-break:anywhere;width:55%}.plugin-settings-container .plugin-settings .components-notice{box-sizing:border-box;margin:15px 0 0}.plugin-settings-container .plugin-settings .inline-tooltip{display:inline;margin-left:5px;position:relative;top:-2px}.plugin-settings-container .plugin-settings .dashicons-no.icon-no,.plugin-settings-container .plugin-settings .dashicons-yes.icon-yes{border:1px solid;border-radius:50%;padding:2px}.plugin-settings-container .plugin-settings .dashicons-yes.icon-yes{color:#51aa51}.plugin-settings-container .plugin-settings .dashicons-no.icon-no{color:#ca4242}.plugin-settings-container .plugin-settings .formatted-label{display:block;font-size:11px;font-weight:500;margin-bottom:10px;text-transform:uppercase}.plugin-settings-container .plugin-settings .simplycdn-connect{position:relative;top:-7px}.plugin-settings-container .plugin-settings .react-terminal-line{margin-bottom:10px}.plugin-settings-container .plugin-settings .react-terminal-line .is-error{color:#ca4242}.plugin-settings-container .plugin-settings .react-terminal-line .is-success{color:#51aa51}.plugin-settings-container .plugin-settings .react-terminal-line a{color:#6fa4df}.plugin-settings-container .plugin-settings .ss-theme-style-name .components-base-control__help{margin-bottom:10px}.plugin-settings-container .plugin-settings .ss-theme-style-name .components-input-control__container{width:200px}.plugin-settings-container .plugin-settings .ss-theme-style-name .components-input-control__container .components-input-control__input{text-align:right}.plugin-settings-container .plugin-settings .ss-theme-style-name .components-input-control__container .components-input-control__suffix{background:rgba(0,0,0,.05);padding-left:5px;padding-right:10px}.plugin-settings-container .ss-export-log-search{background:#f0f0f1;border:none;border-radius:1px;display:block;margin-bottom:10px;padding:4px 10px;width:100%}.plugin-settings-container .ss-export-log-search :focus{border-color:#3858e9;box-shadow:none;outline:none}.plugin-settings-container input:disabled,.plugin-settings-container select:disabled,.plugin-settings-container textarea:disabled{background:#eee}.plugin-settings-container .components-card{border-radius:0!important}.plugin-settings-container .simply-static-video-modal-background{background-color:rgba(0,0,0,.5);display:none;height:100%;left:0;position:fixed;top:0;width:100%;z-index:9999}.plugin-settings-container .simply-static-video-button.is-link{box-shadow:none;color:#3858e9;display:inline-block;line-height:1.4;margin-left:5px;text-decoration:none}.plugin-settings-container .ss-get-pro{background:#6804cc!important;border:1px solid #50059b}.components-modal__frame.simply-static-video-modal{border-radius:0}.dashicons.spin{animation:dashicons-spin 2s infinite;animation-timing-function:linear}@keyframes dashicons-spin{0%{transform:rotate(0deg)}to{transform:rotate(1turn)}}.reset-db-btn{margin-left:10px}a.show-nav{display:none}@media screen and (max-width:640px){div#wpwrap{background:#fff}.toggle-nav{display:none}.plugin-settings-container .components-flex{align-items:center;background:#fff;flex-direction:column}.plugin-logo,p.version-number{display:none}.plugin-nav .generate-container{margin-top:0}.log-table-container{max-width:300px}.plugin-settings-container .plugin-settings{padding:0}.components-flex{gap:0}.auto-fold #wpcontent{padding-left:0}.plugin-settings-container .plugin-nav{box-shadow:none;max-width:205px;min-height:auto;padding:0}.react-terminal{height:180px!important}.react-terminal-wrapper{padding:50px 15px 0}.react-terminal-line{font-size:13px}.plugin-settings-container .plugin-nav .components-card__body{padding:0}a.show-nav{background:#f0f0f1;color:#1e1e1e;display:block;padding:20px;text-align:center;width:100%}span.components-form-toggle{margin:10px 0}a.components-button.is-secondary{display:block;line-height:1.5;margin:0 auto;max-width:180px}input::-moz-placeholder,textarea::-moz-placeholder{font-size:13px!important}input::placeholder,select,textarea::placeholder{font-size:13px!important}.components-text-control__input,.components-text-control__input[type=color],.components-text-control__input[type=date],.components-text-control__input[type=datetime-local],.components-text-control__input[type=datetime],.components-text-control__input[type=email],.components-text-control__input[type=month],.components-text-control__input[type=number],.components-text-control__input[type=password],.components-text-control__input[type=tel],.components-text-control__input[type=text]{font-size:13px}.save-settings{display:block;margin:5px auto 15px;width:180px}.save-settings button.components-button.is-primary{display:block;margin:0 auto;text-align:center;width:60%}.save-settings button.components-button.is-secondary{display:block;margin:10px auto;text-align:center;width:60%}.reset-db-btn{margin:10px 0 0}}
+/*!***************************************************************************************************************************************************************************************************************************************************!*\
+  !*** css ./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[4].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[4].use[2]!./node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[4].use[3]!./src/settings/settings.scss ***!
+  \***************************************************************************************************************************************************************************************************************************************************/
+#wpcontent {
+  padding-left: 0;
+}
+
+#wpbody-content {
+  padding-bottom: 0;
+}
+
+#wpfooter {
+  display: none;
+}
+
+toplevel_page_simply-static img {
+  width: 100%;
+}
+
+.settings-error.notice.notice-warning {
+  display: none;
+}
+
+/* Start plugin settings */
+.plugin-settings-container {
+  background: #f0f0f1;
+}
+.plugin-settings-container .components-flex {
+  align-items: flex-start;
+  height: 100%;
+}
+.plugin-settings-container .components-flex-item {
+  margin-left: 0;
+  width: 100%;
+}
+.plugin-settings-container .inner-settings > * {
+  width: 100%;
+  max-width: 850px;
+}
+.plugin-settings-container a.components-external-link {
+  display: block;
+  text-align: right;
+}
+.plugin-settings-container .save-settings {
+  position: sticky;
+  bottom: 0;
+  padding: 15px 0;
+  text-align: right;
+  box-sizing: border-box;
+}
+.plugin-settings-container .save-settings button:not(:first-child) {
+  margin-left: 10px;
+  background: #f0f0f1;
+}
+.plugin-settings-container .save-settings button:disabled {
+  cursor: not-allowed;
+  background-color: #ddd;
+}
+.plugin-settings-container .migrate-notice.components-notice.is-warning {
+  margin: 0 0 10px 0;
+}
+.plugin-settings-container .diagnostics-notice {
+  margin: 0 0 20px 0 !important;
+  max-width: 840px;
+  border-left: 4px solid var(--wp-components-color-accent, #b32d2e);
+}
+.plugin-settings-container .diagnostics-notice .is-secondary {
+  box-shadow: inset 0 0 0 1px #b32d2e !important;
+  color: #b32d2e !important;
+}
+.plugin-settings-container .diagnostics-notice-generate {
+  max-width: 100% !important;
+}
+.plugin-settings-container .upgrade-network-notice {
+  margin: 0 0 0 40px;
+}
+.plugin-settings-container .ss-align-right {
+  text-align: right;
+}
+.plugin-settings-container textarea {
+  width: 100%;
+}
+.plugin-settings-container .ss-no-shrink {
+  flex-shrink: 0;
+}
+.plugin-settings-container .ss-integration {
+  align-items: center;
+}
+.plugin-settings-container .ss-integration .ss-text-notice {
+  text-transform: uppercase;
+  font-size: 10px;
+  color: rgb(104, 4, 204);
+  margin-left: 10px;
+}
+.plugin-settings-container .ss-integration .integration-toggle {
+  margin: 0;
+}
+.plugin-settings-container .sidebar {
+  padding: 25px;
+  background: white;
+  box-sizing: border-box;
+  height: 100%;
+  max-width: 220px;
+  margin: 0;
+}
+.plugin-settings-container {
+  /* Navigation */
+}
+.plugin-settings-container .plugin-nav {
+  height: 100%;
+  box-shadow: none;
+}
+.plugin-settings-container .plugin-nav button:focus, .plugin-settings-container .plugin-nav button:focus-visible, .plugin-settings-container .plugin-nav button:hover {
+  box-shadow: none;
+  color: rgb(104, 4, 204);
+}
+.plugin-settings-container .plugin-nav .generate-container {
+  margin-top: 30px;
+}
+.plugin-settings-container .plugin-nav .generate-container .generate-type {
+  height: 40px;
+  line-height: 40px;
+  max-width: 200px;
+}
+.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container {
+  display: flex;
+  gap: 5px;
+}
+.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container button {
+  width: 100%;
+}
+.plugin-settings-container .plugin-nav .generate-container.generating .generate-buttons-container button.components-button > .dashicon {
+  margin: 0 auto;
+}
+.plugin-settings-container .plugin-nav .generate-container button {
+  background: #6804cc;
+  border: solid 1px #50059b;
+  color: white;
+  text-decoration: none;
+  text-align: center;
+  line-height: 1.5;
+}
+.plugin-settings-container .plugin-nav .generate-container button.ss-generate-cancel-button {
+  background: #b32d2e;
+  border-color: #9b2626;
+}
+.plugin-settings-container .plugin-nav .generate-container button:disabled {
+  opacity: 0.5;
+}
+.plugin-settings-container .plugin-nav .generate-container .cancel-button {
+  text-align: center;
+  display: block;
+  max-width: 200px;
+  cursor: pointer;
+  color: rgb(104, 4, 204);
+  text-decoration: underline;
+}
+.plugin-settings-container .plugin-nav .environment-container button {
+  text-align: center;
+}
+.plugin-settings-container .plugin-nav .environment-delete-button {
+  margin-top: 4px;
+  color: #b32d2e;
+}
+.plugin-settings-container .plugin-nav .components-button {
+  width: 100%;
+  text-align: left;
+  padding: 0;
+  display: block !important;
+}
+.plugin-settings-container .plugin-nav .components-card__body {
+  padding: 20px 0;
+}
+.plugin-settings-container .plugin-nav .components-button.is-primary {
+  padding: 10px 5px;
+  box-sizing: border-box;
+  width: 100%;
+}
+.plugin-settings-container .plugin-nav .dashicon.dashicons.dashicons-admin-links {
+  font-size: 15px;
+  top: 2px;
+  position: relative;
+}
+.plugin-settings-container .plugin-nav .components-button > .dashicon {
+  margin-right: 10px;
+}
+.plugin-settings-container .plugin-nav .plugin-logo {
+  max-width: 150px;
+}
+.plugin-settings-container .plugin-nav .is-active-item {
+  color: rgb(104, 4, 204);
+}
+.plugin-settings-container .plugin-nav h4.settings-headline {
+  text-transform: uppercase;
+}
+.plugin-settings-container {
+  /* Settings */
+}
+.plugin-settings-container .plugin-settings {
+  padding: 25px;
+  box-sizing: border-box;
+  height: auto;
+  background: #f0f0f1;
+  /* Smart Crawl */
+}
+.plugin-settings-container .plugin-settings .crawler-descriptions {
+  margin: 20px 0;
+}
+.plugin-settings-container .plugin-settings .crawler-description {
+  margin: 5px 0;
+}
+.plugin-settings-container .plugin-settings .crawler-name {
+  max-width: 20%;
+}
+.plugin-settings-container .plugin-settings .horizontal-token-field .components-flex-item {
+  width: auto;
+}
+.plugin-settings-container .plugin-settings {
+  /* Tables */
+}
+.plugin-settings-container .plugin-settings table {
+  width: 100%;
+}
+.plugin-settings-container .plugin-settings table th {
+  text-align: left;
+  text-transform: uppercase;
+}
+.plugin-settings-container .plugin-settings table td.diagnostics-icon {
+  width: 15%;
+}
+.plugin-settings-container .plugin-settings table td.diagnostics-test {
+  width: 30%;
+  line-break: anywhere;
+}
+.plugin-settings-container .plugin-settings table td.diagnostics-result {
+  width: 55%;
+  line-break: anywhere;
+}
+.plugin-settings-container .plugin-settings {
+  /* Notices */
+}
+.plugin-settings-container .plugin-settings .components-notice {
+  margin: 15px 0 0 0;
+  box-sizing: border-box;
+}
+.plugin-settings-container .plugin-settings {
+  /* Tooltips */
+}
+.plugin-settings-container .plugin-settings .inline-tooltip {
+  display: inline;
+  top: -2px;
+  position: relative;
+  margin-left: 5px;
+}
+.plugin-settings-container .plugin-settings .dashicons-yes.icon-yes, .plugin-settings-container .plugin-settings .dashicons-no.icon-no {
+  border: solid 1px;
+  border-radius: 50%;
+  padding: 2px 2px;
+}
+.plugin-settings-container .plugin-settings .dashicons-yes.icon-yes {
+  color: #51aa51;
+}
+.plugin-settings-container .plugin-settings .dashicons-no.icon-no {
+  color: #ca4242;
+}
+.plugin-settings-container .plugin-settings .formatted-label {
+  margin-bottom: 10px;
+  display: block;
+  font-weight: 500;
+  text-transform: uppercase;
+  font-size: 11px;
+}
+.plugin-settings-container .plugin-settings .simplycdn-connect {
+  position: relative;
+  top: -7px;
+}
+.plugin-settings-container .plugin-settings {
+  /* Terminal */
+}
+.plugin-settings-container .plugin-settings .react-terminal-line {
+  margin-bottom: 10px;
+}
+.plugin-settings-container .plugin-settings .react-terminal-line .is-error {
+  color: #ca4242;
+}
+.plugin-settings-container .plugin-settings .react-terminal-line .is-success {
+  color: #51aa51;
+}
+.plugin-settings-container .plugin-settings .react-terminal-line a {
+  color: #6fa4df;
+}
+.plugin-settings-container .plugin-settings .ss-theme-style-name .components-base-control__help {
+  margin-bottom: 10px;
+}
+.plugin-settings-container .plugin-settings .ss-theme-style-name .components-input-control__container {
+  width: 200px;
+}
+.plugin-settings-container .plugin-settings .ss-theme-style-name .components-input-control__container .components-input-control__input {
+  text-align: right;
+}
+.plugin-settings-container .plugin-settings .ss-theme-style-name .components-input-control__container .components-input-control__suffix {
+  padding-right: 10px;
+  background: rgba(0, 0, 0, 0.05);
+  padding-left: 5px;
+}
+.plugin-settings-container .ss-export-log-search {
+  width: 100%;
+  display: block;
+  background: #f0f0f1;
+  border: none;
+  border-radius: 1px;
+  padding: 4px 10px;
+  margin-bottom: 10px;
+}
+.plugin-settings-container .ss-export-log-search :focus {
+  outline: none;
+  box-shadow: none;
+  border-color: #3858e9;
+}
+.plugin-settings-container {
+  /* Style for disabled settings */
+}
+.plugin-settings-container input:disabled, .plugin-settings-container textarea:disabled, .plugin-settings-container select:disabled {
+  background: #eeeeee;
+}
+.plugin-settings-container .components-card {
+  border-radius: 0 !important;
+}
+.plugin-settings-container .simply-static-video-modal-background {
+  display: none;
+  position: fixed;
+  z-index: 9999;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+.plugin-settings-container .simply-static-video-button.is-link {
+  box-shadow: none;
+  text-decoration: none;
+  display: inline-block;
+  margin-left: 5px;
+  line-height: 1.4;
+  color: #3858e9;
+}
+.plugin-settings-container .ss-get-pro {
+  background: #6804cc !important;
+  border: solid 1px #50059b;
+}
+
+.components-modal__frame.simply-static-video-modal {
+  border-radius: 0;
+}
+
+.dashicons.spin {
+  animation: dashicons-spin 2s infinite;
+  animation-timing-function: linear;
+}
+
+@keyframes dashicons-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+.reset-db-btn {
+  margin-left: 10px;
+}
+
+/* Responsive Design */
+a.show-nav {
+  display: none;
+}
+
+@media screen and (max-width: 640px) {
+  div#wpwrap {
+    background: white;
+  }
+  .toggle-nav {
+    display: none;
+  }
+  .plugin-settings-container .components-flex {
+    flex-direction: column;
+    align-items: center;
+    background: white;
+  }
+  .plugin-logo {
+    display: none;
+  }
+  p.version-number {
+    display: none;
+  }
+  .plugin-nav .generate-container {
+    margin-top: 0;
+  }
+  .log-table-container {
+    max-width: 300px;
+  }
+  .plugin-settings-container .plugin-settings {
+    padding: 0;
+  }
+  .components-flex {
+    gap: 0;
+  }
+  .auto-fold #wpcontent {
+    padding-left: 0;
+  }
+  .plugin-settings-container .plugin-nav {
+    padding: 0;
+    min-height: auto;
+    max-width: 205px;
+    box-shadow: none;
+  }
+  .react-terminal {
+    height: 180px !important;
+  }
+  .react-terminal-wrapper {
+    padding: 50px 15px 0;
+  }
+  .react-terminal-line {
+    font-size: 13px;
+  }
+  .plugin-settings-container .plugin-nav .components-card__body {
+    padding: 0;
+  }
+  a.show-nav {
+    text-align: center;
+    display: block;
+    color: #1e1e1e;
+    width: 100%;
+    background: #f0f0f1;
+    padding: 20px;
+  }
+  span.components-form-toggle {
+    margin: 10px 0 10px 0;
+  }
+  a.components-button.is-secondary {
+    margin: 0px auto;
+    display: block;
+    max-width: 180px;
+    line-height: 1.5;
+  }
+  textarea::-moz-placeholder, input::-moz-placeholder {
+    font-size: 13px !important;
+  }
+  select, textarea::placeholder, input::placeholder {
+    font-size: 13px !important;
+  }
+  .components-text-control__input, .components-text-control__input[type=color], .components-text-control__input[type=date], .components-text-control__input[type=datetime-local], .components-text-control__input[type=datetime], .components-text-control__input[type=email], .components-text-control__input[type=month], .components-text-control__input[type=number], .components-text-control__input[type=password], .components-text-control__input[type=tel], .components-text-control__input[type=text] {
+    font-size: 13px;
+  }
+  .save-settings {
+    margin: 5px auto 15px auto;
+    display: block;
+    width: 180px;
+  }
+  .save-settings button.components-button.is-primary {
+    width: 60%;
+    text-align: center;
+    display: block;
+    margin: 0px auto;
+  }
+  .save-settings button.components-button.is-secondary {
+    width: 60%;
+    text-align: center;
+    display: block;
+    margin: 10px auto;
+  }
+  .reset-db-btn {
+    margin: 10px 0 0 0;
+  }
+}
+
+/*# sourceMappingURL=index.css.map*/

--- a/src/admin/build/index.js
+++ b/src/admin/build/index.js
@@ -6119,10 +6119,16 @@ function SettingsPage() {
       label: "Builds"
     }, builds);
   }
+  const minHeight = () => {
+    return window.innerHeight - (wpadminbar ? wpadminbar.clientHeight : 0) - 1;
+  };
   return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
     className: "plugin-settings-container"
   }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorProvider, {
-    initialPath: initialPage
+    initialPath: initialPage,
+    style: {
+      minHeight: minHeight() + "px"
+    }
   }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("a", {
     onClick: () => {
       setShowMobileNav(!showMobileNav);

--- a/src/admin/build/index.js
+++ b/src/admin/build/index.js
@@ -6527,7 +6527,8 @@ function Site(props) {
       method: 'POST',
       data: {
         'blog_id': blogId,
-        'type': 'export'
+        'type': 'export',
+        'is_network_admin': options.is_network
       }
     }).then(resp => {
       var json = JSON.parse(resp);
@@ -6543,7 +6544,8 @@ function Site(props) {
       path: '/simplystatic/v1/cancel-export',
       method: 'POST',
       data: {
-        'blog_id': blogId
+        'blog_id': blogId,
+        'is_network_admin': options.is_network
       }
     }).then(resp => {
       setIsPaused(false);
@@ -6556,7 +6558,8 @@ function Site(props) {
       path: '/simplystatic/v1/pause-export',
       method: 'POST',
       data: {
-        'blog_id': blogId
+        'blog_id': blogId,
+        'is_network_admin': options.is_network
       }
     }).then(resp => {
       setIsRunning(false);
@@ -6568,7 +6571,8 @@ function Site(props) {
       path: '/simplystatic/v1/resume-export',
       method: 'POST',
       data: {
-        'blog_id': blogId
+        'blog_id': blogId,
+        'is_network_admin': options.is_network
       }
     }).then(resp => {
       setIsPaused(false);

--- a/src/admin/build/index.js
+++ b/src/admin/build/index.js
@@ -5952,6 +5952,8 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _EnvironmentSidebar__WEBPACK_IMPORTED_MODULE_15__ = __webpack_require__(/*! ./EnvironmentSidebar */ "./src/settings/components/EnvironmentSidebar.jsx");
 /* harmony import */ var _SidebarMultisite__WEBPACK_IMPORTED_MODULE_16__ = __webpack_require__(/*! ./SidebarMultisite */ "./src/settings/components/SidebarMultisite.jsx");
 /* harmony import */ var _GenerateButtons__WEBPACK_IMPORTED_MODULE_17__ = __webpack_require__(/*! ./GenerateButtons */ "./src/settings/components/GenerateButtons.jsx");
+/* harmony import */ var _VersionInfo__WEBPACK_IMPORTED_MODULE_18__ = __webpack_require__(/*! ./VersionInfo */ "./src/settings/components/VersionInfo.jsx");
+
 
 
 
@@ -6149,13 +6151,7 @@ function SettingsPage() {
   }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("img", {
     alt: "Logo",
     src: options.logo
-  })), 'pro' === options.plan && isPro() ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, isStudio() ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", {
-    className: "version-number"
-  }, "Free: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), "Pro: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version_pro), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), "Studio: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version_studio)) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", {
-    className: "version-number"
-  }, "Free: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), "Pro: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version_pro))) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", {
-    className: "version-number"
-  }, "Version: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version)), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+  })), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_VersionInfo__WEBPACK_IMPORTED_MODULE_18__["default"], null), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
     className: `generate-container ${disabledButton ? 'generating' : ''}`
   }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.SelectControl, {
     className: 'generate-type',
@@ -6403,6 +6399,8 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
 /* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_2__);
 /* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _VersionInfo__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./VersionInfo */ "./src/settings/components/VersionInfo.jsx");
+
 
 
 
@@ -6421,11 +6419,7 @@ function SidebarMultisite(props = null) {
   }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("img", {
     alt: "Logo",
     src: options.logo
-  })), 'pro' === options.plan && isPro() ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", {
-    className: "version-number"
-  }, "Free: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), "Pro: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version_pro)) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", {
-    className: "version-number"
-  }, "Version: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version)), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+  })), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_VersionInfo__WEBPACK_IMPORTED_MODULE_4__["default"], null), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
     margin: 5
   }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
     margin: 5
@@ -6594,17 +6588,12 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ });
 /* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
 /* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
-/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
-/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
-/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
-/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2__);
-/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
-/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_3__);
-/* harmony import */ var react_terminal_ui__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! react-terminal-ui */ "./node_modules/react-terminal-ui/build/index.es.js");
-/* harmony import */ var _hooks_useInterval__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ../../hooks/useInterval */ "./src/hooks/useInterval.js");
-/* harmony import */ var _Site__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! ./Site */ "./src/settings/components/Site.jsx");
-
-
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _hooks_useInterval__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../../hooks/useInterval */ "./src/hooks/useInterval.js");
+/* harmony import */ var _Site__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./Site */ "./src/settings/components/Site.jsx");
 
 
 
@@ -6615,11 +6604,11 @@ const {
   __
 } = wp.i18n;
 function Sites(props) {
-  const [sites, setSites] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)([]);
-  const [anyRunning, setAnyRunning] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)(false);
-  const [siteToTriggerCron, setSiteToTriggerCron] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)(0);
+  const [sites, setSites] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)([]);
+  const [anyRunning, setAnyRunning] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [siteToTriggerCron, setSiteToTriggerCron] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(0);
   const triggerCron = blogId => {
-    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default()({
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1___default()({
       path: '/simplystatic/v1/trigger-cron',
       method: 'POST',
       data: {
@@ -6660,7 +6649,7 @@ function Sites(props) {
     return siteIds;
   }
   function refreshSites() {
-    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default()({
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1___default()({
       path: '/simplystatic/v1/sites',
       method: 'GET'
     }).then(resp => {
@@ -6677,11 +6666,11 @@ function Sites(props) {
       setAnyRunning(haveRunningSite);
     });
   }
-  (0,_hooks_useInterval__WEBPACK_IMPORTED_MODULE_5__["default"])(() => {
+  (0,_hooks_useInterval__WEBPACK_IMPORTED_MODULE_3__["default"])(() => {
     refreshSites();
   }, anyRunning ? 2500 : 300000); // Any running, check every 2-3secs. Not running, check every 5 mins.
 
-  (0,_hooks_useInterval__WEBPACK_IMPORTED_MODULE_5__["default"])(() => {
+  (0,_hooks_useInterval__WEBPACK_IMPORTED_MODULE_3__["default"])(() => {
     if (!siteToTriggerCron && sites.length > 0) {
       setSiteToTriggerCron(sites[0].id);
     }
@@ -6697,7 +6686,7 @@ function Sites(props) {
   return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("table", {
     className: 'wp-list-table widefat fixed striped posts simple-static-sites'
   }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("thead", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("tr", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("th", null, __('Name', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("th", null, __('Status', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("th", null, __('Actions', 'simply-static')))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("tbody", null, sites.map(site => {
-    return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_Site__WEBPACK_IMPORTED_MODULE_6__["default"], {
+    return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_Site__WEBPACK_IMPORTED_MODULE_4__["default"], {
       setAnyRunning: setAnyRunning,
       site: site,
       key: site.id
@@ -6705,6 +6694,42 @@ function Sites(props) {
   }))));
 }
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (Sites);
+
+/***/ }),
+
+/***/ "./src/settings/components/VersionInfo.jsx":
+/*!*************************************************!*\
+  !*** ./src/settings/components/VersionInfo.jsx ***!
+  \*************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_2__);
+
+
+
+function VersionInfo() {
+  const {
+    isPro,
+    isStudio
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_1__.SettingsContext);
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, 'pro' === options.plan && isPro() ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, isStudio() ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", {
+    className: "version-number"
+  }, "Free: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), "Pro: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version_pro), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), "Studio: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version_studio)) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", {
+    className: "version-number"
+  }, "Free: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), "Pro: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version_pro))) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", {
+    className: "version-number"
+  }, "Version: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version)));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (VersionInfo);
 
 /***/ }),
 

--- a/src/admin/build/index.js
+++ b/src/admin/build/index.js
@@ -6464,6 +6464,11 @@ function Site(props) {
       setAnyRunning(true);
     }
   }, [isRunning]);
+  (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(() => {
+    setIsPaused(site.paused);
+    setIsRunning(site.running);
+    setCanGenerate(!site.running && !site.paused);
+  }, [site]);
   const startExport = () => {
     setCanGenerate(false);
     setIsPaused(false);
@@ -6520,7 +6525,11 @@ function Site(props) {
       setIsRunning(true);
     });
   };
-  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("tr", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("td", null, site.name), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("td", null, site.url), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("td", null, isRunning ? 'Running' : 'Idle'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("td", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_GenerateButtons__WEBPACK_IMPORTED_MODULE_2__["default"], {
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("tr", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("td", null, site.name, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("a", {
+    href: site.url
+  }, site.url)), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("td", null, isRunning ? 'Running' : isPaused ? 'Paused' : 'Idle'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("td", {
+    className: 'generate-container'
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_GenerateButtons__WEBPACK_IMPORTED_MODULE_2__["default"], {
     site: site,
     canGenerate: canGenerate,
     startExport: startExport,
@@ -6576,7 +6585,6 @@ function Sites(props) {
       path: '/simplystatic/v1/sites',
       method: 'GET'
     }).then(resp => {
-      console.log(resp);
       let sitesObjects = [];
       let haveRunningSite = false;
       resp.data.forEach(function (site) {
@@ -6596,11 +6604,13 @@ function Sites(props) {
   (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(() => {
     refreshSites();
   }, []);
-  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("table", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("thead", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("tr", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("th", null, __('Name', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("th", null, __('URL', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("th", null, __('Status', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("th", null, __('Actions', 'simply-static')))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("tbody", null, sites.map(site => {
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("table", {
+    className: 'wp-list-table widefat fixed striped posts simple-static-sites'
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("thead", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("tr", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("th", null, __('Name', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("th", null, __('Status', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("th", null, __('Actions', 'simply-static')))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("tbody", null, sites.map(site => {
     return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_Site__WEBPACK_IMPORTED_MODULE_6__["default"], {
       setAnyRunning: setAnyRunning,
       site: site,
-      key: site.blog_id
+      key: site.id
     });
   }))));
 }

--- a/src/admin/build/index.js
+++ b/src/admin/build/index.js
@@ -5676,6 +5676,7 @@ const {
 } = wp.i18n;
 function GenerateButtons(props) {
   const {
+    children,
     canGenerate,
     isPaused,
     isDelayed,
@@ -5720,7 +5721,7 @@ function GenerateButtons(props) {
     showToolTip: true
   }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Dashicon, {
     icon: 'no'
-  }))));
+  }))), children);
 }
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (GenerateButtons);
 
@@ -6445,11 +6446,17 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _GenerateButtons__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./GenerateButtons */ "./src/settings/components/GenerateButtons.jsx");
 /* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
 /* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__);
 
 
 
 
 
+
+const {
+  __
+} = wp.i18n;
 function Site(props) {
   const {
     site,
@@ -6538,7 +6545,11 @@ function Site(props) {
     cancelExport: cancelExport,
     pauseExport: pauseExport,
     resumeExport: resumeExport
-  })));
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Button, {
+    onClick: () => window.location = site.settings_url
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Dashicon, {
+    icon: "admin-generic"
+  })))));
 }
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (Site);
 
@@ -6600,7 +6611,8 @@ function Sites(props) {
   }
   (0,_hooks_useInterval__WEBPACK_IMPORTED_MODULE_5__["default"])(() => {
     refreshSites();
-  }, anyRunning ? 2500 : null);
+  }, anyRunning ? 2500 : 300000); // Any running, check every 2-3secs. Not running, check every 5 mins.
+
   (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(() => {
     refreshSites();
   }, []);
@@ -8595,8 +8607,6 @@ function Generate() {
     blogId,
     setBlogId
   } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__.SettingsContext);
-  const [selectedSiteUrl, setSelectedSiteURL] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('');
-  const [selectedSiteActivityUrl, setSelectedSiteActivityUrl] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('');
   return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
     className: "inner-settings"
   }, !options.is_network && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_ActivityLog__WEBPACK_IMPORTED_MODULE_4__["default"], null), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
@@ -8605,40 +8615,11 @@ function Generate() {
     align: "top"
   }, options.is_network && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, {
     isBlock: true
-  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_Sites__WEBPACK_IMPORTED_MODULE_7__["default"], null))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Multisite', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
-    label: __('Choose a site to export', 'simply-static'),
-    value: blogId,
-    options: options.sites.map(function (site) {
-      return {
-        label: `${site.name} (${site.url})`,
-        value: site.blog_id
-      };
-    }),
-    onChange: blog_id => {
-      setBlogId(blog_id);
-
-      // Update admin edit URL:
-      options.sites.some(item => {
-        if (item.blog_id === blog_id) {
-          setSelectedSiteURL(item.settings_url);
-          setSelectedSiteActivityUrl(item.activity_log_url);
-        }
-      });
-    }
-  }), selectedSiteUrl && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
-    isPrimary: true,
-    href: selectedSiteUrl
-  }, "Switch to Site settings"), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
-    style: {
-      marginLeft: "5px"
-    },
-    isSecondary: true,
-    href: selectedSiteActivityUrl
-  }, "Check progress"))))), settings.debugging_mode && options.log_file && !options.is_network && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, {
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_Sites__WEBPACK_IMPORTED_MODULE_7__["default"], null)))), settings.debugging_mode && options.log_file && !options.is_network && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, {
     isBlock: true
-  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Debugging', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_LogButtons__WEBPACK_IMPORTED_MODULE_6__["default"], null))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Debugging', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_LogButtons__WEBPACK_IMPORTED_MODULE_6__["default"], null))))), !options.is_network && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
     margin: 5
-  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Export Log', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_ExportLog__WEBPACK_IMPORTED_MODULE_5__["default"], null))));
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Export Log', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_ExportLog__WEBPACK_IMPORTED_MODULE_5__["default"], null)))));
 }
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (Generate);
 

--- a/src/admin/build/index.js
+++ b/src/admin/build/index.js
@@ -5950,6 +5950,8 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_14__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
 /* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_14___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_14__);
 /* harmony import */ var _EnvironmentSidebar__WEBPACK_IMPORTED_MODULE_15__ = __webpack_require__(/*! ./EnvironmentSidebar */ "./src/settings/components/EnvironmentSidebar.jsx");
+/* harmony import */ var _SidebarMultisite__WEBPACK_IMPORTED_MODULE_16__ = __webpack_require__(/*! ./SidebarMultisite */ "./src/settings/components/SidebarMultisite.jsx");
+
 
 
 
@@ -6138,37 +6140,7 @@ function SettingsPage() {
     icon: "align-center"
   }), " ", __('Toggle menu', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.FlexItem, {
     className: showMobileNav ? 'toggle-nav sidebar' : 'sidebar'
-  }, options.is_network ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Card, {
-    className: "plugin-nav"
-  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
-    className: "plugin-logo"
-  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("img", {
-    alt: "Logo",
-    src: options.logo
-  })), 'pro' === options.plan && isPro() ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", {
-    className: "version-number"
-  }, "Free: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), "Pro: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version_pro)) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", {
-    className: "version-number"
-  }, "Version: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version)), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalSpacer, {
-    margin: 5
-  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalSpacer, {
-    margin: 5
-  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Button, {
-    href: "https://simplystatic.com/changelogs/",
-    target: "_blank"
-  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
-    icon: "editor-ul"
-  }), " ", __('Changelog', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Button, {
-    href: "https://docs.simplystatic.com",
-    target: "_blank"
-  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
-    icon: "admin-links"
-  }), " ", __('Documentation', 'simply-static')), 'free' === options.plan && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Button, {
-    href: "https://simplystatic.com",
-    target: "_blank"
-  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
-    icon: "admin-site-alt3"
-  }), "Simply Static Pro")) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Card, {
+  }, options.is_network ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_SidebarMultisite__WEBPACK_IMPORTED_MODULE_16__["default"], null) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Card, {
     className: "plugin-nav"
   }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
     className: "plugin-logo"
@@ -6431,6 +6403,71 @@ function SettingsPage() {
   }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_IntegrationsSettings__WEBPACK_IMPORTED_MODULE_10__["default"], null)))))));
 }
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (SettingsPage);
+
+/***/ }),
+
+/***/ "./src/settings/components/SidebarMultisite.jsx":
+/*!******************************************************!*\
+  !*** ./src/settings/components/SidebarMultisite.jsx ***!
+  \******************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function SidebarMultisite(props = null) {
+  const {
+    isPro
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__.SettingsContext);
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, {
+    className: "plugin-nav"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "plugin-logo"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("img", {
+    alt: "Logo",
+    src: options.logo
+  })), 'pro' === options.plan && isPro() ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", {
+    className: "version-number"
+  }, "Free: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), "Pro: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version_pro)) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", {
+    className: "version-number"
+  }, "Version: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version)), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    href: "https://simplystatic.com/changelogs/",
+    target: "_blank"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Dashicon, {
+    icon: "editor-ul"
+  }), " ", __('Changelog', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    href: "https://docs.simplystatic.com",
+    target: "_blank"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Dashicon, {
+    icon: "admin-links"
+  }), " ", __('Documentation', 'simply-static')), 'free' === options.plan && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    href: "https://simplystatic.com",
+    target: "_blank"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Dashicon, {
+    icon: "admin-site-alt3"
+  }), "Simply Static Pro"));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (SidebarMultisite);
 
 /***/ }),
 

--- a/src/admin/build/index.js
+++ b/src/admin/build/index.js
@@ -1,7 +1,1405 @@
-(()=>{var e,t,n,a,l={744:e=>{"use strict";var t=function(e){return function(e){return!!e&&"object"==typeof e}(e)&&!function(e){var t=Object.prototype.toString.call(e);return"[object RegExp]"===t||"[object Date]"===t||function(e){return e.$$typeof===n}(e)}(e)},n="function"==typeof Symbol&&Symbol.for?Symbol.for("react.element"):60103;function a(e,t){return!1!==t.clone&&t.isMergeableObject(e)?o((n=e,Array.isArray(n)?[]:{}),e,t):e;var n}function l(e,t,n){return e.concat(t).map((function(e){return a(e,n)}))}function r(e){return Object.keys(e).concat(function(e){return Object.getOwnPropertySymbols?Object.getOwnPropertySymbols(e).filter((function(t){return Object.propertyIsEnumerable.call(e,t)})):[]}(e))}function i(e,t){try{return t in e}catch(e){return!1}}function o(e,n,s){(s=s||{}).arrayMerge=s.arrayMerge||l,s.isMergeableObject=s.isMergeableObject||t,s.cloneUnlessOtherwiseSpecified=a;var c=Array.isArray(n);return c===Array.isArray(e)?c?s.arrayMerge(e,n,s):function(e,t,n){var l={};return n.isMergeableObject(e)&&r(e).forEach((function(t){l[t]=a(e[t],n)})),r(t).forEach((function(r){(function(e,t){return i(e,t)&&!(Object.hasOwnProperty.call(e,t)&&Object.propertyIsEnumerable.call(e,t))})(e,r)||(i(e,r)&&n.isMergeableObject(t[r])?l[r]=function(e,t){if(!t.customMerge)return o;var n=t.customMerge(e);return"function"==typeof n?n:o}(r,n)(e[r],t[r],n):l[r]=a(t[r],n))})),l}(e,n,s):a(n,s)}o.all=function(e,t){if(!Array.isArray(e))throw new Error("first argument should be an array");return e.reduce((function(e,n){return o(e,n,t)}),{})};var s=o;e.exports=s},147:e=>{function t(e,t){e.onload=function(){this.onerror=this.onload=null,t(null,e)},e.onerror=function(){this.onerror=this.onload=null,t(new Error("Failed to load "+this.src),e)}}function n(e,t){e.onreadystatechange=function(){"complete"!=this.readyState&&"loaded"!=this.readyState||(this.onreadystatechange=null,t(null,e))}}e.exports=function(e,a,l){var r=document.head||document.getElementsByTagName("head")[0],i=document.createElement("script");"function"==typeof a&&(l=a,a={}),a=a||{},l=l||function(){},i.type=a.type||"text/javascript",i.charset=a.charset||"utf8",i.async=!("async"in a)||!!a.async,i.src=e,a.attrs&&function(e,t){for(var n in t)e.setAttribute(n,t[n])}(i,a.attrs),a.text&&(i.text=""+a.text),("onload"in i?t:n)(i,l),i.onload||t(i,l),r.appendChild(i)}},811:(e,t,n)=>{"use strict";n.r(t),n.d(t,{default:()=>r});var a=Number.isNaN||function(e){return"number"==typeof e&&e!=e};function l(e,t){if(e.length!==t.length)return!1;for(var n=0;n<e.length;n++)if(!((l=e[n])===(r=t[n])||a(l)&&a(r)))return!1;var l,r;return!0}const r=function(e,t){var n;void 0===t&&(t=l);var a,r=[],i=!1;return function(){for(var l=[],o=0;o<arguments.length;o++)l[o]=arguments[o];return i&&n===this&&t(l,r)||(a=e.apply(this,l),i=!0,n=this,r=l),a}}},694:(e,t,n)=>{"use strict";var a=n(925);function l(){}function r(){}r.resetWarningCache=l,e.exports=function(){function e(e,t,n,l,r,i){if(i!==a){var o=new Error("Calling PropTypes validators directly is not supported by the `prop-types` package. Use PropTypes.checkPropTypes() to call them. Read more at http://fb.me/use-check-prop-types");throw o.name="Invariant Violation",o}}function t(){return e}e.isRequired=e;var n={array:e,bigint:e,bool:e,func:e,number:e,object:e,string:e,symbol:e,any:e,arrayOf:t,element:e,elementType:e,instanceOf:t,node:e,objectOf:t,oneOf:t,oneOfType:t,shape:t,exact:t,checkPropTypes:r,resetWarningCache:l};return n.PropTypes=n,n}},556:(e,t,n)=>{e.exports=n(694)()},925:e=>{"use strict";e.exports="SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED"},757:(e,t,n)=>{"use strict";var a=n(609),l=n(510);function r(e){return e&&"object"==typeof e&&"default"in e?e:{default:e}}var i,o=function(e){if(e&&e.__esModule)return e;var t=Object.create(null);return e&&Object.keys(e).forEach((function(n){if("default"!==n){var a=Object.getOwnPropertyDescriptor(e,n);Object.defineProperty(t,n,a.get?a:{enumerable:!0,get:function(){return e[n]}})}})),t.default=e,Object.freeze(t)}(a),s=r(a),c=r(l);function p(e,t){return e[t]}function u(e=[],t,n=0){return[...e.slice(0,n),t,...e.slice(n)]}function d(e=[],t,n="id"){const a=e.slice(),l=p(t,n);return l?a.splice(a.findIndex((e=>p(e,n)===l)),1):a.splice(a.findIndex((e=>e===t)),1),a}function m(e){return e.map(((e,t)=>{const n=Object.assign(Object.assign({},e),{sortable:e.sortable||!!e.sortFunction||void 0});return e.id||(n.id=t+1),n}))}function h(e,t){return Math.ceil(e/t)}function g(e,t){return Math.min(e,t)}!function(e){e.ASC="asc",e.DESC="desc"}(i||(i={}));const y=()=>null;function f(e,t=[],n=[]){let a={},l=[...n];return t.length&&t.forEach((t=>{if(!t.when||"function"!=typeof t.when)throw new Error('"when" must be defined in the conditional style object and must be function');t.when(e)&&(a=t.style||{},t.classNames&&(l=[...l,...t.classNames]),"function"==typeof t.style&&(a=t.style(e)||{}))})),{conditionalStyle:a,classNames:l.join(" ")}}function b(e,t=[],n="id"){const a=p(e,n);return a?t.some((e=>p(e,n)===a)):t.some((t=>t===e))}function E(e,t){return t?e.findIndex((e=>v(e.id,t))):-1}function v(e,t){return e==t}function w(e,t){const n=!e.toggleOnSelectedRowsChange;switch(t.type){case"SELECT_ALL_ROWS":{const{keyField:n,rows:a,rowCount:l,mergeSelections:r}=t,i=!e.allSelected,o=!e.toggleOnSelectedRowsChange;if(r){const t=i?[...e.selectedRows,...a.filter((t=>!b(t,e.selectedRows,n)))]:e.selectedRows.filter((e=>!b(e,a,n)));return Object.assign(Object.assign({},e),{allSelected:i,selectedCount:t.length,selectedRows:t,toggleOnSelectedRowsChange:o})}return Object.assign(Object.assign({},e),{allSelected:i,selectedCount:i?l:0,selectedRows:i?a:[],toggleOnSelectedRowsChange:o})}case"SELECT_SINGLE_ROW":{const{keyField:a,row:l,isSelected:r,rowCount:i,singleSelect:o}=t;return o?r?Object.assign(Object.assign({},e),{selectedCount:0,allSelected:!1,selectedRows:[],toggleOnSelectedRowsChange:n}):Object.assign(Object.assign({},e),{selectedCount:1,allSelected:!1,selectedRows:[l],toggleOnSelectedRowsChange:n}):r?Object.assign(Object.assign({},e),{selectedCount:e.selectedRows.length>0?e.selectedRows.length-1:0,allSelected:!1,selectedRows:d(e.selectedRows,l,a),toggleOnSelectedRowsChange:n}):Object.assign(Object.assign({},e),{selectedCount:e.selectedRows.length+1,allSelected:e.selectedRows.length+1===i,selectedRows:u(e.selectedRows,l),toggleOnSelectedRowsChange:n})}case"SELECT_MULTIPLE_ROWS":{const{keyField:a,selectedRows:l,totalRows:r,mergeSelections:i}=t;if(i){const t=[...e.selectedRows,...l.filter((t=>!b(t,e.selectedRows,a)))];return Object.assign(Object.assign({},e),{selectedCount:t.length,allSelected:!1,selectedRows:t,toggleOnSelectedRowsChange:n})}return Object.assign(Object.assign({},e),{selectedCount:l.length,allSelected:l.length===r,selectedRows:l,toggleOnSelectedRowsChange:n})}case"CLEAR_SELECTED_ROWS":{const{selectedRowsFlag:n}=t;return Object.assign(Object.assign({},e),{allSelected:!1,selectedCount:0,selectedRows:[],selectedRowsFlag:n})}case"SORT_CHANGE":{const{sortDirection:a,selectedColumn:l,clearSelectedOnSort:r}=t;return Object.assign(Object.assign(Object.assign({},e),{selectedColumn:l,sortDirection:a,currentPage:1}),r&&{allSelected:!1,selectedCount:0,selectedRows:[],toggleOnSelectedRowsChange:n})}case"CHANGE_PAGE":{const{page:a,paginationServer:l,visibleOnly:r,persistSelectedOnPageChange:i}=t,o=l&&i,s=l&&!i||r;return Object.assign(Object.assign(Object.assign(Object.assign({},e),{currentPage:a}),o&&{allSelected:!1}),s&&{allSelected:!1,selectedCount:0,selectedRows:[],toggleOnSelectedRowsChange:n})}case"CHANGE_ROWS_PER_PAGE":{const{rowsPerPage:n,page:a}=t;return Object.assign(Object.assign({},e),{currentPage:a,rowsPerPage:n})}}}const S=l.css`
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ "./node_modules/deepmerge/dist/cjs.js":
+/*!********************************************!*\
+  !*** ./node_modules/deepmerge/dist/cjs.js ***!
+  \********************************************/
+/***/ ((module) => {
+
+"use strict";
+
+
+var isMergeableObject = function isMergeableObject(value) {
+	return isNonNullObject(value)
+		&& !isSpecial(value)
+};
+
+function isNonNullObject(value) {
+	return !!value && typeof value === 'object'
+}
+
+function isSpecial(value) {
+	var stringValue = Object.prototype.toString.call(value);
+
+	return stringValue === '[object RegExp]'
+		|| stringValue === '[object Date]'
+		|| isReactElement(value)
+}
+
+// see https://github.com/facebook/react/blob/b5ac963fb791d1298e7f396236383bc955f916c1/src/isomorphic/classic/element/ReactElement.js#L21-L25
+var canUseSymbol = typeof Symbol === 'function' && Symbol.for;
+var REACT_ELEMENT_TYPE = canUseSymbol ? Symbol.for('react.element') : 0xeac7;
+
+function isReactElement(value) {
+	return value.$$typeof === REACT_ELEMENT_TYPE
+}
+
+function emptyTarget(val) {
+	return Array.isArray(val) ? [] : {}
+}
+
+function cloneUnlessOtherwiseSpecified(value, options) {
+	return (options.clone !== false && options.isMergeableObject(value))
+		? deepmerge(emptyTarget(value), value, options)
+		: value
+}
+
+function defaultArrayMerge(target, source, options) {
+	return target.concat(source).map(function(element) {
+		return cloneUnlessOtherwiseSpecified(element, options)
+	})
+}
+
+function getMergeFunction(key, options) {
+	if (!options.customMerge) {
+		return deepmerge
+	}
+	var customMerge = options.customMerge(key);
+	return typeof customMerge === 'function' ? customMerge : deepmerge
+}
+
+function getEnumerableOwnPropertySymbols(target) {
+	return Object.getOwnPropertySymbols
+		? Object.getOwnPropertySymbols(target).filter(function(symbol) {
+			return Object.propertyIsEnumerable.call(target, symbol)
+		})
+		: []
+}
+
+function getKeys(target) {
+	return Object.keys(target).concat(getEnumerableOwnPropertySymbols(target))
+}
+
+function propertyIsOnObject(object, property) {
+	try {
+		return property in object
+	} catch(_) {
+		return false
+	}
+}
+
+// Protects from prototype poisoning and unexpected merging up the prototype chain.
+function propertyIsUnsafe(target, key) {
+	return propertyIsOnObject(target, key) // Properties are safe to merge if they don't exist in the target yet,
+		&& !(Object.hasOwnProperty.call(target, key) // unsafe if they exist up the prototype chain,
+			&& Object.propertyIsEnumerable.call(target, key)) // and also unsafe if they're nonenumerable.
+}
+
+function mergeObject(target, source, options) {
+	var destination = {};
+	if (options.isMergeableObject(target)) {
+		getKeys(target).forEach(function(key) {
+			destination[key] = cloneUnlessOtherwiseSpecified(target[key], options);
+		});
+	}
+	getKeys(source).forEach(function(key) {
+		if (propertyIsUnsafe(target, key)) {
+			return
+		}
+
+		if (propertyIsOnObject(target, key) && options.isMergeableObject(source[key])) {
+			destination[key] = getMergeFunction(key, options)(target[key], source[key], options);
+		} else {
+			destination[key] = cloneUnlessOtherwiseSpecified(source[key], options);
+		}
+	});
+	return destination
+}
+
+function deepmerge(target, source, options) {
+	options = options || {};
+	options.arrayMerge = options.arrayMerge || defaultArrayMerge;
+	options.isMergeableObject = options.isMergeableObject || isMergeableObject;
+	// cloneUnlessOtherwiseSpecified is added to `options` so that custom arrayMerge()
+	// implementations can use it. The caller may not replace it.
+	options.cloneUnlessOtherwiseSpecified = cloneUnlessOtherwiseSpecified;
+
+	var sourceIsArray = Array.isArray(source);
+	var targetIsArray = Array.isArray(target);
+	var sourceAndTargetTypesMatch = sourceIsArray === targetIsArray;
+
+	if (!sourceAndTargetTypesMatch) {
+		return cloneUnlessOtherwiseSpecified(source, options)
+	} else if (sourceIsArray) {
+		return options.arrayMerge(target, source, options)
+	} else {
+		return mergeObject(target, source, options)
+	}
+}
+
+deepmerge.all = function deepmergeAll(array, options) {
+	if (!Array.isArray(array)) {
+		throw new Error('first argument should be an array')
+	}
+
+	return array.reduce(function(prev, next) {
+		return deepmerge(prev, next, options)
+	}, {})
+};
+
+var deepmerge_1 = deepmerge;
+
+module.exports = deepmerge_1;
+
+
+/***/ }),
+
+/***/ "./node_modules/load-script/index.js":
+/*!*******************************************!*\
+  !*** ./node_modules/load-script/index.js ***!
+  \*******************************************/
+/***/ ((module) => {
+
+
+module.exports = function load (src, opts, cb) {
+  var head = document.head || document.getElementsByTagName('head')[0]
+  var script = document.createElement('script')
+
+  if (typeof opts === 'function') {
+    cb = opts
+    opts = {}
+  }
+
+  opts = opts || {}
+  cb = cb || function() {}
+
+  script.type = opts.type || 'text/javascript'
+  script.charset = opts.charset || 'utf8';
+  script.async = 'async' in opts ? !!opts.async : true
+  script.src = src
+
+  if (opts.attrs) {
+    setAttributes(script, opts.attrs)
+  }
+
+  if (opts.text) {
+    script.text = '' + opts.text
+  }
+
+  var onend = 'onload' in script ? stdOnEnd : ieOnEnd
+  onend(script, cb)
+
+  // some good legacy browsers (firefox) fail the 'in' detection above
+  // so as a fallback we always set onload
+  // old IE will ignore this and new IE will set onload
+  if (!script.onload) {
+    stdOnEnd(script, cb);
+  }
+
+  head.appendChild(script)
+}
+
+function setAttributes(script, attrs) {
+  for (var attr in attrs) {
+    script.setAttribute(attr, attrs[attr]);
+  }
+}
+
+function stdOnEnd (script, cb) {
+  script.onload = function () {
+    this.onerror = this.onload = null
+    cb(null, script)
+  }
+  script.onerror = function () {
+    // this.onload = null here is necessary
+    // because even IE9 works not like others
+    this.onerror = this.onload = null
+    cb(new Error('Failed to load ' + this.src), script)
+  }
+}
+
+function ieOnEnd (script, cb) {
+  script.onreadystatechange = function () {
+    if (this.readyState != 'complete' && this.readyState != 'loaded') return
+    this.onreadystatechange = null
+    cb(null, script) // there is no way to catch loading errors in IE8
+  }
+}
+
+
+/***/ }),
+
+/***/ "./node_modules/memoize-one/dist/memoize-one.esm.js":
+/*!**********************************************************!*\
+  !*** ./node_modules/memoize-one/dist/memoize-one.esm.js ***!
+  \**********************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+var safeIsNaN = Number.isNaN ||
+    function ponyfill(value) {
+        return typeof value === 'number' && value !== value;
+    };
+function isEqual(first, second) {
+    if (first === second) {
+        return true;
+    }
+    if (safeIsNaN(first) && safeIsNaN(second)) {
+        return true;
+    }
+    return false;
+}
+function areInputsEqual(newInputs, lastInputs) {
+    if (newInputs.length !== lastInputs.length) {
+        return false;
+    }
+    for (var i = 0; i < newInputs.length; i++) {
+        if (!isEqual(newInputs[i], lastInputs[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function memoizeOne(resultFn, isEqual) {
+    if (isEqual === void 0) { isEqual = areInputsEqual; }
+    var lastThis;
+    var lastArgs = [];
+    var lastResult;
+    var calledOnce = false;
+    function memoized() {
+        var newArgs = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            newArgs[_i] = arguments[_i];
+        }
+        if (calledOnce && lastThis === this && isEqual(newArgs, lastArgs)) {
+            return lastResult;
+        }
+        lastResult = resultFn.apply(this, newArgs);
+        calledOnce = true;
+        lastThis = this;
+        lastArgs = newArgs;
+        return lastResult;
+    }
+    return memoized;
+}
+
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (memoizeOne);
+
+
+/***/ }),
+
+/***/ "./node_modules/object-assign/index.js":
+/*!*********************************************!*\
+  !*** ./node_modules/object-assign/index.js ***!
+  \*********************************************/
+/***/ ((module) => {
+
+"use strict";
+/*
+object-assign
+(c) Sindre Sorhus
+@license MIT
+*/
+
+
+/* eslint-disable no-unused-vars */
+var getOwnPropertySymbols = Object.getOwnPropertySymbols;
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+var propIsEnumerable = Object.prototype.propertyIsEnumerable;
+
+function toObject(val) {
+	if (val === null || val === undefined) {
+		throw new TypeError('Object.assign cannot be called with null or undefined');
+	}
+
+	return Object(val);
+}
+
+function shouldUseNative() {
+	try {
+		if (!Object.assign) {
+			return false;
+		}
+
+		// Detect buggy property enumeration order in older V8 versions.
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=4118
+		var test1 = new String('abc');  // eslint-disable-line no-new-wrappers
+		test1[5] = 'de';
+		if (Object.getOwnPropertyNames(test1)[0] === '5') {
+			return false;
+		}
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+		var test2 = {};
+		for (var i = 0; i < 10; i++) {
+			test2['_' + String.fromCharCode(i)] = i;
+		}
+		var order2 = Object.getOwnPropertyNames(test2).map(function (n) {
+			return test2[n];
+		});
+		if (order2.join('') !== '0123456789') {
+			return false;
+		}
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+		var test3 = {};
+		'abcdefghijklmnopqrst'.split('').forEach(function (letter) {
+			test3[letter] = letter;
+		});
+		if (Object.keys(Object.assign({}, test3)).join('') !==
+				'abcdefghijklmnopqrst') {
+			return false;
+		}
+
+		return true;
+	} catch (err) {
+		// We don't expect any of the above to throw, but better to be safe.
+		return false;
+	}
+}
+
+module.exports = shouldUseNative() ? Object.assign : function (target, source) {
+	var from;
+	var to = toObject(target);
+	var symbols;
+
+	for (var s = 1; s < arguments.length; s++) {
+		from = Object(arguments[s]);
+
+		for (var key in from) {
+			if (hasOwnProperty.call(from, key)) {
+				to[key] = from[key];
+			}
+		}
+
+		if (getOwnPropertySymbols) {
+			symbols = getOwnPropertySymbols(from);
+			for (var i = 0; i < symbols.length; i++) {
+				if (propIsEnumerable.call(from, symbols[i])) {
+					to[symbols[i]] = from[symbols[i]];
+				}
+			}
+		}
+	}
+
+	return to;
+};
+
+
+/***/ }),
+
+/***/ "./node_modules/prop-types/checkPropTypes.js":
+/*!***************************************************!*\
+  !*** ./node_modules/prop-types/checkPropTypes.js ***!
+  \***************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+"use strict";
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+
+var printWarning = function() {};
+
+if (true) {
+  var ReactPropTypesSecret = __webpack_require__(/*! ./lib/ReactPropTypesSecret */ "./node_modules/prop-types/lib/ReactPropTypesSecret.js");
+  var loggedTypeFailures = {};
+  var has = __webpack_require__(/*! ./lib/has */ "./node_modules/prop-types/lib/has.js");
+
+  printWarning = function(text) {
+    var message = 'Warning: ' + text;
+    if (typeof console !== 'undefined') {
+      console.error(message);
+    }
+    try {
+      // --- Welcome to debugging React ---
+      // This error was thrown as a convenience so that you can use this stack
+      // to find the callsite that caused this warning to fire.
+      throw new Error(message);
+    } catch (x) { /**/ }
+  };
+}
+
+/**
+ * Assert that the values match with the type specs.
+ * Error messages are memorized and will only be shown once.
+ *
+ * @param {object} typeSpecs Map of name to a ReactPropType
+ * @param {object} values Runtime values that need to be type-checked
+ * @param {string} location e.g. "prop", "context", "child context"
+ * @param {string} componentName Name of the component for error messages.
+ * @param {?Function} getStack Returns the component stack.
+ * @private
+ */
+function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
+  if (true) {
+    for (var typeSpecName in typeSpecs) {
+      if (has(typeSpecs, typeSpecName)) {
+        var error;
+        // Prop type validation may throw. In case they do, we don't want to
+        // fail the render phase where it didn't fail before. So we log it.
+        // After these have been cleaned up, we'll let them throw.
+        try {
+          // This is intentionally an invariant that gets caught. It's the same
+          // behavior as without this statement except with a better message.
+          if (typeof typeSpecs[typeSpecName] !== 'function') {
+            var err = Error(
+              (componentName || 'React class') + ': ' + location + ' type `' + typeSpecName + '` is invalid; ' +
+              'it must be a function, usually from the `prop-types` package, but received `' + typeof typeSpecs[typeSpecName] + '`.' +
+              'This often happens because of typos such as `PropTypes.function` instead of `PropTypes.func`.'
+            );
+            err.name = 'Invariant Violation';
+            throw err;
+          }
+          error = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, ReactPropTypesSecret);
+        } catch (ex) {
+          error = ex;
+        }
+        if (error && !(error instanceof Error)) {
+          printWarning(
+            (componentName || 'React class') + ': type specification of ' +
+            location + ' `' + typeSpecName + '` is invalid; the type checker ' +
+            'function must return `null` or an `Error` but returned a ' + typeof error + '. ' +
+            'You may have forgotten to pass an argument to the type checker ' +
+            'creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and ' +
+            'shape all require an argument).'
+          );
+        }
+        if (error instanceof Error && !(error.message in loggedTypeFailures)) {
+          // Only monitor this failure once because there tends to be a lot of the
+          // same error.
+          loggedTypeFailures[error.message] = true;
+
+          var stack = getStack ? getStack() : '';
+
+          printWarning(
+            'Failed ' + location + ' type: ' + error.message + (stack != null ? stack : '')
+          );
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Resets warning cache when testing.
+ *
+ * @private
+ */
+checkPropTypes.resetWarningCache = function() {
+  if (true) {
+    loggedTypeFailures = {};
+  }
+}
+
+module.exports = checkPropTypes;
+
+
+/***/ }),
+
+/***/ "./node_modules/prop-types/factoryWithTypeCheckers.js":
+/*!************************************************************!*\
+  !*** ./node_modules/prop-types/factoryWithTypeCheckers.js ***!
+  \************************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+"use strict";
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+
+var ReactIs = __webpack_require__(/*! react-is */ "./node_modules/prop-types/node_modules/react-is/index.js");
+var assign = __webpack_require__(/*! object-assign */ "./node_modules/object-assign/index.js");
+
+var ReactPropTypesSecret = __webpack_require__(/*! ./lib/ReactPropTypesSecret */ "./node_modules/prop-types/lib/ReactPropTypesSecret.js");
+var has = __webpack_require__(/*! ./lib/has */ "./node_modules/prop-types/lib/has.js");
+var checkPropTypes = __webpack_require__(/*! ./checkPropTypes */ "./node_modules/prop-types/checkPropTypes.js");
+
+var printWarning = function() {};
+
+if (true) {
+  printWarning = function(text) {
+    var message = 'Warning: ' + text;
+    if (typeof console !== 'undefined') {
+      console.error(message);
+    }
+    try {
+      // --- Welcome to debugging React ---
+      // This error was thrown as a convenience so that you can use this stack
+      // to find the callsite that caused this warning to fire.
+      throw new Error(message);
+    } catch (x) {}
+  };
+}
+
+function emptyFunctionThatReturnsNull() {
+  return null;
+}
+
+module.exports = function(isValidElement, throwOnDirectAccess) {
+  /* global Symbol */
+  var ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
+  var FAUX_ITERATOR_SYMBOL = '@@iterator'; // Before Symbol spec.
+
+  /**
+   * Returns the iterator method function contained on the iterable object.
+   *
+   * Be sure to invoke the function with the iterable as context:
+   *
+   *     var iteratorFn = getIteratorFn(myIterable);
+   *     if (iteratorFn) {
+   *       var iterator = iteratorFn.call(myIterable);
+   *       ...
+   *     }
+   *
+   * @param {?object} maybeIterable
+   * @return {?function}
+   */
+  function getIteratorFn(maybeIterable) {
+    var iteratorFn = maybeIterable && (ITERATOR_SYMBOL && maybeIterable[ITERATOR_SYMBOL] || maybeIterable[FAUX_ITERATOR_SYMBOL]);
+    if (typeof iteratorFn === 'function') {
+      return iteratorFn;
+    }
+  }
+
+  /**
+   * Collection of methods that allow declaration and validation of props that are
+   * supplied to React components. Example usage:
+   *
+   *   var Props = require('ReactPropTypes');
+   *   var MyArticle = React.createClass({
+   *     propTypes: {
+   *       // An optional string prop named "description".
+   *       description: Props.string,
+   *
+   *       // A required enum prop named "category".
+   *       category: Props.oneOf(['News','Photos']).isRequired,
+   *
+   *       // A prop named "dialog" that requires an instance of Dialog.
+   *       dialog: Props.instanceOf(Dialog).isRequired
+   *     },
+   *     render: function() { ... }
+   *   });
+   *
+   * A more formal specification of how these methods are used:
+   *
+   *   type := array|bool|func|object|number|string|oneOf([...])|instanceOf(...)
+   *   decl := ReactPropTypes.{type}(.isRequired)?
+   *
+   * Each and every declaration produces a function with the same signature. This
+   * allows the creation of custom validation functions. For example:
+   *
+   *  var MyLink = React.createClass({
+   *    propTypes: {
+   *      // An optional string or URI prop named "href".
+   *      href: function(props, propName, componentName) {
+   *        var propValue = props[propName];
+   *        if (propValue != null && typeof propValue !== 'string' &&
+   *            !(propValue instanceof URI)) {
+   *          return new Error(
+   *            'Expected a string or an URI for ' + propName + ' in ' +
+   *            componentName
+   *          );
+   *        }
+   *      }
+   *    },
+   *    render: function() {...}
+   *  });
+   *
+   * @internal
+   */
+
+  var ANONYMOUS = '<<anonymous>>';
+
+  // Important!
+  // Keep this list in sync with production version in `./factoryWithThrowingShims.js`.
+  var ReactPropTypes = {
+    array: createPrimitiveTypeChecker('array'),
+    bigint: createPrimitiveTypeChecker('bigint'),
+    bool: createPrimitiveTypeChecker('boolean'),
+    func: createPrimitiveTypeChecker('function'),
+    number: createPrimitiveTypeChecker('number'),
+    object: createPrimitiveTypeChecker('object'),
+    string: createPrimitiveTypeChecker('string'),
+    symbol: createPrimitiveTypeChecker('symbol'),
+
+    any: createAnyTypeChecker(),
+    arrayOf: createArrayOfTypeChecker,
+    element: createElementTypeChecker(),
+    elementType: createElementTypeTypeChecker(),
+    instanceOf: createInstanceTypeChecker,
+    node: createNodeChecker(),
+    objectOf: createObjectOfTypeChecker,
+    oneOf: createEnumTypeChecker,
+    oneOfType: createUnionTypeChecker,
+    shape: createShapeTypeChecker,
+    exact: createStrictShapeTypeChecker,
+  };
+
+  /**
+   * inlined Object.is polyfill to avoid requiring consumers ship their own
+   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+   */
+  /*eslint-disable no-self-compare*/
+  function is(x, y) {
+    // SameValue algorithm
+    if (x === y) {
+      // Steps 1-5, 7-10
+      // Steps 6.b-6.e: +0 != -0
+      return x !== 0 || 1 / x === 1 / y;
+    } else {
+      // Step 6.a: NaN == NaN
+      return x !== x && y !== y;
+    }
+  }
+  /*eslint-enable no-self-compare*/
+
+  /**
+   * We use an Error-like object for backward compatibility as people may call
+   * PropTypes directly and inspect their output. However, we don't use real
+   * Errors anymore. We don't inspect their stack anyway, and creating them
+   * is prohibitively expensive if they are created too often, such as what
+   * happens in oneOfType() for any type before the one that matched.
+   */
+  function PropTypeError(message, data) {
+    this.message = message;
+    this.data = data && typeof data === 'object' ? data: {};
+    this.stack = '';
+  }
+  // Make `instanceof Error` still work for returned errors.
+  PropTypeError.prototype = Error.prototype;
+
+  function createChainableTypeChecker(validate) {
+    if (true) {
+      var manualPropTypeCallCache = {};
+      var manualPropTypeWarningCount = 0;
+    }
+    function checkType(isRequired, props, propName, componentName, location, propFullName, secret) {
+      componentName = componentName || ANONYMOUS;
+      propFullName = propFullName || propName;
+
+      if (secret !== ReactPropTypesSecret) {
+        if (throwOnDirectAccess) {
+          // New behavior only for users of `prop-types` package
+          var err = new Error(
+            'Calling PropTypes validators directly is not supported by the `prop-types` package. ' +
+            'Use `PropTypes.checkPropTypes()` to call them. ' +
+            'Read more at http://fb.me/use-check-prop-types'
+          );
+          err.name = 'Invariant Violation';
+          throw err;
+        } else if ( true && typeof console !== 'undefined') {
+          // Old behavior for people using React.PropTypes
+          var cacheKey = componentName + ':' + propName;
+          if (
+            !manualPropTypeCallCache[cacheKey] &&
+            // Avoid spamming the console because they are often not actionable except for lib authors
+            manualPropTypeWarningCount < 3
+          ) {
+            printWarning(
+              'You are manually calling a React.PropTypes validation ' +
+              'function for the `' + propFullName + '` prop on `' + componentName + '`. This is deprecated ' +
+              'and will throw in the standalone `prop-types` package. ' +
+              'You may be seeing this warning due to a third-party PropTypes ' +
+              'library. See https://fb.me/react-warning-dont-call-proptypes ' + 'for details.'
+            );
+            manualPropTypeCallCache[cacheKey] = true;
+            manualPropTypeWarningCount++;
+          }
+        }
+      }
+      if (props[propName] == null) {
+        if (isRequired) {
+          if (props[propName] === null) {
+            return new PropTypeError('The ' + location + ' `' + propFullName + '` is marked as required ' + ('in `' + componentName + '`, but its value is `null`.'));
+          }
+          return new PropTypeError('The ' + location + ' `' + propFullName + '` is marked as required in ' + ('`' + componentName + '`, but its value is `undefined`.'));
+        }
+        return null;
+      } else {
+        return validate(props, propName, componentName, location, propFullName);
+      }
+    }
+
+    var chainedCheckType = checkType.bind(null, false);
+    chainedCheckType.isRequired = checkType.bind(null, true);
+
+    return chainedCheckType;
+  }
+
+  function createPrimitiveTypeChecker(expectedType) {
+    function validate(props, propName, componentName, location, propFullName, secret) {
+      var propValue = props[propName];
+      var propType = getPropType(propValue);
+      if (propType !== expectedType) {
+        // `propValue` being instance of, say, date/regexp, pass the 'object'
+        // check, but we can offer a more precise error message here rather than
+        // 'of type `object`'.
+        var preciseType = getPreciseType(propValue);
+
+        return new PropTypeError(
+          'Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + preciseType + '` supplied to `' + componentName + '`, expected ') + ('`' + expectedType + '`.'),
+          {expectedType: expectedType}
+        );
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createAnyTypeChecker() {
+    return createChainableTypeChecker(emptyFunctionThatReturnsNull);
+  }
+
+  function createArrayOfTypeChecker(typeChecker) {
+    function validate(props, propName, componentName, location, propFullName) {
+      if (typeof typeChecker !== 'function') {
+        return new PropTypeError('Property `' + propFullName + '` of component `' + componentName + '` has invalid PropType notation inside arrayOf.');
+      }
+      var propValue = props[propName];
+      if (!Array.isArray(propValue)) {
+        var propType = getPropType(propValue);
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected an array.'));
+      }
+      for (var i = 0; i < propValue.length; i++) {
+        var error = typeChecker(propValue, i, componentName, location, propFullName + '[' + i + ']', ReactPropTypesSecret);
+        if (error instanceof Error) {
+          return error;
+        }
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createElementTypeChecker() {
+    function validate(props, propName, componentName, location, propFullName) {
+      var propValue = props[propName];
+      if (!isValidElement(propValue)) {
+        var propType = getPropType(propValue);
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected a single ReactElement.'));
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createElementTypeTypeChecker() {
+    function validate(props, propName, componentName, location, propFullName) {
+      var propValue = props[propName];
+      if (!ReactIs.isValidElementType(propValue)) {
+        var propType = getPropType(propValue);
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected a single ReactElement type.'));
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createInstanceTypeChecker(expectedClass) {
+    function validate(props, propName, componentName, location, propFullName) {
+      if (!(props[propName] instanceof expectedClass)) {
+        var expectedClassName = expectedClass.name || ANONYMOUS;
+        var actualClassName = getClassName(props[propName]);
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + actualClassName + '` supplied to `' + componentName + '`, expected ') + ('instance of `' + expectedClassName + '`.'));
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createEnumTypeChecker(expectedValues) {
+    if (!Array.isArray(expectedValues)) {
+      if (true) {
+        if (arguments.length > 1) {
+          printWarning(
+            'Invalid arguments supplied to oneOf, expected an array, got ' + arguments.length + ' arguments. ' +
+            'A common mistake is to write oneOf(x, y, z) instead of oneOf([x, y, z]).'
+          );
+        } else {
+          printWarning('Invalid argument supplied to oneOf, expected an array.');
+        }
+      }
+      return emptyFunctionThatReturnsNull;
+    }
+
+    function validate(props, propName, componentName, location, propFullName) {
+      var propValue = props[propName];
+      for (var i = 0; i < expectedValues.length; i++) {
+        if (is(propValue, expectedValues[i])) {
+          return null;
+        }
+      }
+
+      var valuesString = JSON.stringify(expectedValues, function replacer(key, value) {
+        var type = getPreciseType(value);
+        if (type === 'symbol') {
+          return String(value);
+        }
+        return value;
+      });
+      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of value `' + String(propValue) + '` ' + ('supplied to `' + componentName + '`, expected one of ' + valuesString + '.'));
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createObjectOfTypeChecker(typeChecker) {
+    function validate(props, propName, componentName, location, propFullName) {
+      if (typeof typeChecker !== 'function') {
+        return new PropTypeError('Property `' + propFullName + '` of component `' + componentName + '` has invalid PropType notation inside objectOf.');
+      }
+      var propValue = props[propName];
+      var propType = getPropType(propValue);
+      if (propType !== 'object') {
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected an object.'));
+      }
+      for (var key in propValue) {
+        if (has(propValue, key)) {
+          var error = typeChecker(propValue, key, componentName, location, propFullName + '.' + key, ReactPropTypesSecret);
+          if (error instanceof Error) {
+            return error;
+          }
+        }
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createUnionTypeChecker(arrayOfTypeCheckers) {
+    if (!Array.isArray(arrayOfTypeCheckers)) {
+       true ? printWarning('Invalid argument supplied to oneOfType, expected an instance of array.') : 0;
+      return emptyFunctionThatReturnsNull;
+    }
+
+    for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
+      var checker = arrayOfTypeCheckers[i];
+      if (typeof checker !== 'function') {
+        printWarning(
+          'Invalid argument supplied to oneOfType. Expected an array of check functions, but ' +
+          'received ' + getPostfixForTypeWarning(checker) + ' at index ' + i + '.'
+        );
+        return emptyFunctionThatReturnsNull;
+      }
+    }
+
+    function validate(props, propName, componentName, location, propFullName) {
+      var expectedTypes = [];
+      for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
+        var checker = arrayOfTypeCheckers[i];
+        var checkerResult = checker(props, propName, componentName, location, propFullName, ReactPropTypesSecret);
+        if (checkerResult == null) {
+          return null;
+        }
+        if (checkerResult.data && has(checkerResult.data, 'expectedType')) {
+          expectedTypes.push(checkerResult.data.expectedType);
+        }
+      }
+      var expectedTypesMessage = (expectedTypes.length > 0) ? ', expected one of type [' + expectedTypes.join(', ') + ']': '';
+      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` supplied to ' + ('`' + componentName + '`' + expectedTypesMessage + '.'));
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createNodeChecker() {
+    function validate(props, propName, componentName, location, propFullName) {
+      if (!isNode(props[propName])) {
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` supplied to ' + ('`' + componentName + '`, expected a ReactNode.'));
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function invalidValidatorError(componentName, location, propFullName, key, type) {
+    return new PropTypeError(
+      (componentName || 'React class') + ': ' + location + ' type `' + propFullName + '.' + key + '` is invalid; ' +
+      'it must be a function, usually from the `prop-types` package, but received `' + type + '`.'
+    );
+  }
+
+  function createShapeTypeChecker(shapeTypes) {
+    function validate(props, propName, componentName, location, propFullName) {
+      var propValue = props[propName];
+      var propType = getPropType(propValue);
+      if (propType !== 'object') {
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type `' + propType + '` ' + ('supplied to `' + componentName + '`, expected `object`.'));
+      }
+      for (var key in shapeTypes) {
+        var checker = shapeTypes[key];
+        if (typeof checker !== 'function') {
+          return invalidValidatorError(componentName, location, propFullName, key, getPreciseType(checker));
+        }
+        var error = checker(propValue, key, componentName, location, propFullName + '.' + key, ReactPropTypesSecret);
+        if (error) {
+          return error;
+        }
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createStrictShapeTypeChecker(shapeTypes) {
+    function validate(props, propName, componentName, location, propFullName) {
+      var propValue = props[propName];
+      var propType = getPropType(propValue);
+      if (propType !== 'object') {
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type `' + propType + '` ' + ('supplied to `' + componentName + '`, expected `object`.'));
+      }
+      // We need to check all keys in case some are required but missing from props.
+      var allKeys = assign({}, props[propName], shapeTypes);
+      for (var key in allKeys) {
+        var checker = shapeTypes[key];
+        if (has(shapeTypes, key) && typeof checker !== 'function') {
+          return invalidValidatorError(componentName, location, propFullName, key, getPreciseType(checker));
+        }
+        if (!checker) {
+          return new PropTypeError(
+            'Invalid ' + location + ' `' + propFullName + '` key `' + key + '` supplied to `' + componentName + '`.' +
+            '\nBad object: ' + JSON.stringify(props[propName], null, '  ') +
+            '\nValid keys: ' + JSON.stringify(Object.keys(shapeTypes), null, '  ')
+          );
+        }
+        var error = checker(propValue, key, componentName, location, propFullName + '.' + key, ReactPropTypesSecret);
+        if (error) {
+          return error;
+        }
+      }
+      return null;
+    }
+
+    return createChainableTypeChecker(validate);
+  }
+
+  function isNode(propValue) {
+    switch (typeof propValue) {
+      case 'number':
+      case 'string':
+      case 'undefined':
+        return true;
+      case 'boolean':
+        return !propValue;
+      case 'object':
+        if (Array.isArray(propValue)) {
+          return propValue.every(isNode);
+        }
+        if (propValue === null || isValidElement(propValue)) {
+          return true;
+        }
+
+        var iteratorFn = getIteratorFn(propValue);
+        if (iteratorFn) {
+          var iterator = iteratorFn.call(propValue);
+          var step;
+          if (iteratorFn !== propValue.entries) {
+            while (!(step = iterator.next()).done) {
+              if (!isNode(step.value)) {
+                return false;
+              }
+            }
+          } else {
+            // Iterator will provide entry [k,v] tuples rather than values.
+            while (!(step = iterator.next()).done) {
+              var entry = step.value;
+              if (entry) {
+                if (!isNode(entry[1])) {
+                  return false;
+                }
+              }
+            }
+          }
+        } else {
+          return false;
+        }
+
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  function isSymbol(propType, propValue) {
+    // Native Symbol.
+    if (propType === 'symbol') {
+      return true;
+    }
+
+    // falsy value can't be a Symbol
+    if (!propValue) {
+      return false;
+    }
+
+    // 19.4.3.5 Symbol.prototype[@@toStringTag] === 'Symbol'
+    if (propValue['@@toStringTag'] === 'Symbol') {
+      return true;
+    }
+
+    // Fallback for non-spec compliant Symbols which are polyfilled.
+    if (typeof Symbol === 'function' && propValue instanceof Symbol) {
+      return true;
+    }
+
+    return false;
+  }
+
+  // Equivalent of `typeof` but with special handling for array and regexp.
+  function getPropType(propValue) {
+    var propType = typeof propValue;
+    if (Array.isArray(propValue)) {
+      return 'array';
+    }
+    if (propValue instanceof RegExp) {
+      // Old webkits (at least until Android 4.0) return 'function' rather than
+      // 'object' for typeof a RegExp. We'll normalize this here so that /bla/
+      // passes PropTypes.object.
+      return 'object';
+    }
+    if (isSymbol(propType, propValue)) {
+      return 'symbol';
+    }
+    return propType;
+  }
+
+  // This handles more types than `getPropType`. Only used for error messages.
+  // See `createPrimitiveTypeChecker`.
+  function getPreciseType(propValue) {
+    if (typeof propValue === 'undefined' || propValue === null) {
+      return '' + propValue;
+    }
+    var propType = getPropType(propValue);
+    if (propType === 'object') {
+      if (propValue instanceof Date) {
+        return 'date';
+      } else if (propValue instanceof RegExp) {
+        return 'regexp';
+      }
+    }
+    return propType;
+  }
+
+  // Returns a string that is postfixed to a warning about an invalid type.
+  // For example, "undefined" or "of type array"
+  function getPostfixForTypeWarning(value) {
+    var type = getPreciseType(value);
+    switch (type) {
+      case 'array':
+      case 'object':
+        return 'an ' + type;
+      case 'boolean':
+      case 'date':
+      case 'regexp':
+        return 'a ' + type;
+      default:
+        return type;
+    }
+  }
+
+  // Returns class name of the object, if any.
+  function getClassName(propValue) {
+    if (!propValue.constructor || !propValue.constructor.name) {
+      return ANONYMOUS;
+    }
+    return propValue.constructor.name;
+  }
+
+  ReactPropTypes.checkPropTypes = checkPropTypes;
+  ReactPropTypes.resetWarningCache = checkPropTypes.resetWarningCache;
+  ReactPropTypes.PropTypes = ReactPropTypes;
+
+  return ReactPropTypes;
+};
+
+
+/***/ }),
+
+/***/ "./node_modules/prop-types/index.js":
+/*!******************************************!*\
+  !*** ./node_modules/prop-types/index.js ***!
+  \******************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+if (true) {
+  var ReactIs = __webpack_require__(/*! react-is */ "./node_modules/prop-types/node_modules/react-is/index.js");
+
+  // By explicitly using `prop-types` you are opting into new development behavior.
+  // http://fb.me/prop-types-in-prod
+  var throwOnDirectAccess = true;
+  module.exports = __webpack_require__(/*! ./factoryWithTypeCheckers */ "./node_modules/prop-types/factoryWithTypeCheckers.js")(ReactIs.isElement, throwOnDirectAccess);
+} else // removed by dead control flow
+{}
+
+
+/***/ }),
+
+/***/ "./node_modules/prop-types/lib/ReactPropTypesSecret.js":
+/*!*************************************************************!*\
+  !*** ./node_modules/prop-types/lib/ReactPropTypesSecret.js ***!
+  \*************************************************************/
+/***/ ((module) => {
+
+"use strict";
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+
+var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
+
+module.exports = ReactPropTypesSecret;
+
+
+/***/ }),
+
+/***/ "./node_modules/prop-types/lib/has.js":
+/*!********************************************!*\
+  !*** ./node_modules/prop-types/lib/has.js ***!
+  \********************************************/
+/***/ ((module) => {
+
+module.exports = Function.call.bind(Object.prototype.hasOwnProperty);
+
+
+/***/ }),
+
+/***/ "./node_modules/prop-types/node_modules/react-is/cjs/react-is.development.js":
+/*!***********************************************************************************!*\
+  !*** ./node_modules/prop-types/node_modules/react-is/cjs/react-is.development.js ***!
+  \***********************************************************************************/
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+/** @license React v16.13.1
+ * react-is.development.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+
+
+
+if (true) {
+  (function() {
+'use strict';
+
+// The Symbol used to tag the ReactElement-like types. If there is no native Symbol
+// nor polyfill, then a plain number is used for performance.
+var hasSymbol = typeof Symbol === 'function' && Symbol.for;
+var REACT_ELEMENT_TYPE = hasSymbol ? Symbol.for('react.element') : 0xeac7;
+var REACT_PORTAL_TYPE = hasSymbol ? Symbol.for('react.portal') : 0xeaca;
+var REACT_FRAGMENT_TYPE = hasSymbol ? Symbol.for('react.fragment') : 0xeacb;
+var REACT_STRICT_MODE_TYPE = hasSymbol ? Symbol.for('react.strict_mode') : 0xeacc;
+var REACT_PROFILER_TYPE = hasSymbol ? Symbol.for('react.profiler') : 0xead2;
+var REACT_PROVIDER_TYPE = hasSymbol ? Symbol.for('react.provider') : 0xeacd;
+var REACT_CONTEXT_TYPE = hasSymbol ? Symbol.for('react.context') : 0xeace; // TODO: We don't use AsyncMode or ConcurrentMode anymore. They were temporary
+// (unstable) APIs that have been removed. Can we remove the symbols?
+
+var REACT_ASYNC_MODE_TYPE = hasSymbol ? Symbol.for('react.async_mode') : 0xeacf;
+var REACT_CONCURRENT_MODE_TYPE = hasSymbol ? Symbol.for('react.concurrent_mode') : 0xeacf;
+var REACT_FORWARD_REF_TYPE = hasSymbol ? Symbol.for('react.forward_ref') : 0xead0;
+var REACT_SUSPENSE_TYPE = hasSymbol ? Symbol.for('react.suspense') : 0xead1;
+var REACT_SUSPENSE_LIST_TYPE = hasSymbol ? Symbol.for('react.suspense_list') : 0xead8;
+var REACT_MEMO_TYPE = hasSymbol ? Symbol.for('react.memo') : 0xead3;
+var REACT_LAZY_TYPE = hasSymbol ? Symbol.for('react.lazy') : 0xead4;
+var REACT_BLOCK_TYPE = hasSymbol ? Symbol.for('react.block') : 0xead9;
+var REACT_FUNDAMENTAL_TYPE = hasSymbol ? Symbol.for('react.fundamental') : 0xead5;
+var REACT_RESPONDER_TYPE = hasSymbol ? Symbol.for('react.responder') : 0xead6;
+var REACT_SCOPE_TYPE = hasSymbol ? Symbol.for('react.scope') : 0xead7;
+
+function isValidElementType(type) {
+  return typeof type === 'string' || typeof type === 'function' || // Note: its typeof might be other than 'symbol' or 'number' if it's a polyfill.
+  type === REACT_FRAGMENT_TYPE || type === REACT_CONCURRENT_MODE_TYPE || type === REACT_PROFILER_TYPE || type === REACT_STRICT_MODE_TYPE || type === REACT_SUSPENSE_TYPE || type === REACT_SUSPENSE_LIST_TYPE || typeof type === 'object' && type !== null && (type.$$typeof === REACT_LAZY_TYPE || type.$$typeof === REACT_MEMO_TYPE || type.$$typeof === REACT_PROVIDER_TYPE || type.$$typeof === REACT_CONTEXT_TYPE || type.$$typeof === REACT_FORWARD_REF_TYPE || type.$$typeof === REACT_FUNDAMENTAL_TYPE || type.$$typeof === REACT_RESPONDER_TYPE || type.$$typeof === REACT_SCOPE_TYPE || type.$$typeof === REACT_BLOCK_TYPE);
+}
+
+function typeOf(object) {
+  if (typeof object === 'object' && object !== null) {
+    var $$typeof = object.$$typeof;
+
+    switch ($$typeof) {
+      case REACT_ELEMENT_TYPE:
+        var type = object.type;
+
+        switch (type) {
+          case REACT_ASYNC_MODE_TYPE:
+          case REACT_CONCURRENT_MODE_TYPE:
+          case REACT_FRAGMENT_TYPE:
+          case REACT_PROFILER_TYPE:
+          case REACT_STRICT_MODE_TYPE:
+          case REACT_SUSPENSE_TYPE:
+            return type;
+
+          default:
+            var $$typeofType = type && type.$$typeof;
+
+            switch ($$typeofType) {
+              case REACT_CONTEXT_TYPE:
+              case REACT_FORWARD_REF_TYPE:
+              case REACT_LAZY_TYPE:
+              case REACT_MEMO_TYPE:
+              case REACT_PROVIDER_TYPE:
+                return $$typeofType;
+
+              default:
+                return $$typeof;
+            }
+
+        }
+
+      case REACT_PORTAL_TYPE:
+        return $$typeof;
+    }
+  }
+
+  return undefined;
+} // AsyncMode is deprecated along with isAsyncMode
+
+var AsyncMode = REACT_ASYNC_MODE_TYPE;
+var ConcurrentMode = REACT_CONCURRENT_MODE_TYPE;
+var ContextConsumer = REACT_CONTEXT_TYPE;
+var ContextProvider = REACT_PROVIDER_TYPE;
+var Element = REACT_ELEMENT_TYPE;
+var ForwardRef = REACT_FORWARD_REF_TYPE;
+var Fragment = REACT_FRAGMENT_TYPE;
+var Lazy = REACT_LAZY_TYPE;
+var Memo = REACT_MEMO_TYPE;
+var Portal = REACT_PORTAL_TYPE;
+var Profiler = REACT_PROFILER_TYPE;
+var StrictMode = REACT_STRICT_MODE_TYPE;
+var Suspense = REACT_SUSPENSE_TYPE;
+var hasWarnedAboutDeprecatedIsAsyncMode = false; // AsyncMode should be deprecated
+
+function isAsyncMode(object) {
+  {
+    if (!hasWarnedAboutDeprecatedIsAsyncMode) {
+      hasWarnedAboutDeprecatedIsAsyncMode = true; // Using console['warn'] to evade Babel and ESLint
+
+      console['warn']('The ReactIs.isAsyncMode() alias has been deprecated, ' + 'and will be removed in React 17+. Update your code to use ' + 'ReactIs.isConcurrentMode() instead. It has the exact same API.');
+    }
+  }
+
+  return isConcurrentMode(object) || typeOf(object) === REACT_ASYNC_MODE_TYPE;
+}
+function isConcurrentMode(object) {
+  return typeOf(object) === REACT_CONCURRENT_MODE_TYPE;
+}
+function isContextConsumer(object) {
+  return typeOf(object) === REACT_CONTEXT_TYPE;
+}
+function isContextProvider(object) {
+  return typeOf(object) === REACT_PROVIDER_TYPE;
+}
+function isElement(object) {
+  return typeof object === 'object' && object !== null && object.$$typeof === REACT_ELEMENT_TYPE;
+}
+function isForwardRef(object) {
+  return typeOf(object) === REACT_FORWARD_REF_TYPE;
+}
+function isFragment(object) {
+  return typeOf(object) === REACT_FRAGMENT_TYPE;
+}
+function isLazy(object) {
+  return typeOf(object) === REACT_LAZY_TYPE;
+}
+function isMemo(object) {
+  return typeOf(object) === REACT_MEMO_TYPE;
+}
+function isPortal(object) {
+  return typeOf(object) === REACT_PORTAL_TYPE;
+}
+function isProfiler(object) {
+  return typeOf(object) === REACT_PROFILER_TYPE;
+}
+function isStrictMode(object) {
+  return typeOf(object) === REACT_STRICT_MODE_TYPE;
+}
+function isSuspense(object) {
+  return typeOf(object) === REACT_SUSPENSE_TYPE;
+}
+
+exports.AsyncMode = AsyncMode;
+exports.ConcurrentMode = ConcurrentMode;
+exports.ContextConsumer = ContextConsumer;
+exports.ContextProvider = ContextProvider;
+exports.Element = Element;
+exports.ForwardRef = ForwardRef;
+exports.Fragment = Fragment;
+exports.Lazy = Lazy;
+exports.Memo = Memo;
+exports.Portal = Portal;
+exports.Profiler = Profiler;
+exports.StrictMode = StrictMode;
+exports.Suspense = Suspense;
+exports.isAsyncMode = isAsyncMode;
+exports.isConcurrentMode = isConcurrentMode;
+exports.isContextConsumer = isContextConsumer;
+exports.isContextProvider = isContextProvider;
+exports.isElement = isElement;
+exports.isForwardRef = isForwardRef;
+exports.isFragment = isFragment;
+exports.isLazy = isLazy;
+exports.isMemo = isMemo;
+exports.isPortal = isPortal;
+exports.isProfiler = isProfiler;
+exports.isStrictMode = isStrictMode;
+exports.isSuspense = isSuspense;
+exports.isValidElementType = isValidElementType;
+exports.typeOf = typeOf;
+  })();
+}
+
+
+/***/ }),
+
+/***/ "./node_modules/prop-types/node_modules/react-is/index.js":
+/*!****************************************************************!*\
+  !*** ./node_modules/prop-types/node_modules/react-is/index.js ***!
+  \****************************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+"use strict";
+
+
+if (false) // removed by dead control flow
+{} else {
+  module.exports = __webpack_require__(/*! ./cjs/react-is.development.js */ "./node_modules/prop-types/node_modules/react-is/cjs/react-is.development.js");
+}
+
+
+/***/ }),
+
+/***/ "./node_modules/react-data-table-component/dist/index.cjs.js":
+/*!*******************************************************************!*\
+  !*** ./node_modules/react-data-table-component/dist/index.cjs.js ***!
+  \*******************************************************************/
+/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+
+"use strict";
+Object.defineProperty(exports, "__esModule", ({value:!0}));var e=__webpack_require__(/*! react */ "react"),t=__webpack_require__(/*! styled-components */ "./node_modules/styled-components/dist/styled-components.browser.esm.js");function n(e){return e&&"object"==typeof e&&"default"in e?e:{default:e}}function o(e){if(e&&e.__esModule)return e;var t=Object.create(null);return e&&Object.keys(e).forEach((function(n){if("default"!==n){var o=Object.getOwnPropertyDescriptor(e,n);Object.defineProperty(t,n,o.get?o:{enumerable:!0,get:function(){return e[n]}})}})),t.default=e,Object.freeze(t)}var a,l=o(e),r=n(e),i=n(t);function s(e,t){return e[t]}function d(e=[],t,n=0){return[...e.slice(0,n),t,...e.slice(n)]}function c(e=[],t,n="id"){const o=e.slice(),a=s(t,n);return a?o.splice(o.findIndex((e=>s(e,n)===a)),1):o.splice(o.findIndex((e=>e===t)),1),o}function g(e){return e.map(((e,t)=>{const n=Object.assign(Object.assign({},e),{sortable:e.sortable||!!e.sortFunction||void 0});return e.id||(n.id=t+1),n}))}function u(e,t){return Math.ceil(e/t)}function p(e,t){return Math.min(e,t)}!function(e){e.ASC="asc",e.DESC="desc"}(a||(a={}));const b=()=>null;function m(e,t=[],n=[]){let o={},a=[...n];return t.length&&t.forEach((t=>{if(!t.when||"function"!=typeof t.when)throw new Error('"when" must be defined in the conditional style object and must be function');t.when(e)&&(o=t.style||{},t.classNames&&(a=[...a,...t.classNames]),"function"==typeof t.style&&(o=t.style(e)||{}))})),{conditionalStyle:o,classNames:a.join(" ")}}function f(e,t=[],n="id"){const o=s(e,n);return o?t.some((e=>s(e,n)===o)):t.some((t=>t===e))}function h(e,t){return t?e.findIndex((e=>w(e.id,t))):-1}function w(e,t){return e==t}function x(e,t){const n=!e.toggleOnSelectedRowsChange;switch(t.type){case"SELECT_ALL_ROWS":{const{keyField:n,rows:o,rowCount:a,mergeSelections:l}=t,r=!e.allSelected,i=!e.toggleOnSelectedRowsChange;if(l){const t=r?[...e.selectedRows,...o.filter((t=>!f(t,e.selectedRows,n)))]:e.selectedRows.filter((e=>!f(e,o,n)));return Object.assign(Object.assign({},e),{allSelected:r,selectedCount:t.length,selectedRows:t,toggleOnSelectedRowsChange:i})}return Object.assign(Object.assign({},e),{allSelected:r,selectedCount:r?a:0,selectedRows:r?o:[],toggleOnSelectedRowsChange:i})}case"SELECT_SINGLE_ROW":{const{keyField:o,row:a,isSelected:l,rowCount:r,singleSelect:i}=t;return i?l?Object.assign(Object.assign({},e),{selectedCount:0,allSelected:!1,selectedRows:[],toggleOnSelectedRowsChange:n}):Object.assign(Object.assign({},e),{selectedCount:1,allSelected:!1,selectedRows:[a],toggleOnSelectedRowsChange:n}):l?Object.assign(Object.assign({},e),{selectedCount:e.selectedRows.length>0?e.selectedRows.length-1:0,allSelected:!1,selectedRows:c(e.selectedRows,a,o),toggleOnSelectedRowsChange:n}):Object.assign(Object.assign({},e),{selectedCount:e.selectedRows.length+1,allSelected:e.selectedRows.length+1===r,selectedRows:d(e.selectedRows,a),toggleOnSelectedRowsChange:n})}case"SELECT_MULTIPLE_ROWS":{const{keyField:o,selectedRows:a,totalRows:l,mergeSelections:r}=t;if(r){const t=[...e.selectedRows,...a.filter((t=>!f(t,e.selectedRows,o)))];return Object.assign(Object.assign({},e),{selectedCount:t.length,allSelected:!1,selectedRows:t,toggleOnSelectedRowsChange:n})}return Object.assign(Object.assign({},e),{selectedCount:a.length,allSelected:a.length===l,selectedRows:a,toggleOnSelectedRowsChange:n})}case"CLEAR_SELECTED_ROWS":{const{selectedRowsFlag:n}=t;return Object.assign(Object.assign({},e),{allSelected:!1,selectedCount:0,selectedRows:[],selectedRowsFlag:n})}case"SORT_CHANGE":{const{sortDirection:o,selectedColumn:a,clearSelectedOnSort:l}=t;return Object.assign(Object.assign(Object.assign({},e),{selectedColumn:a,sortDirection:o,currentPage:1}),l&&{allSelected:!1,selectedCount:0,selectedRows:[],toggleOnSelectedRowsChange:n})}case"CHANGE_PAGE":{const{page:o,paginationServer:a,visibleOnly:l,persistSelectedOnPageChange:r}=t,i=a&&r,s=a&&!r||l;return Object.assign(Object.assign(Object.assign(Object.assign({},e),{currentPage:o}),i&&{allSelected:!1}),s&&{allSelected:!1,selectedCount:0,selectedRows:[],toggleOnSelectedRowsChange:n})}case"CHANGE_ROWS_PER_PAGE":{const{rowsPerPage:n,page:o}=t;return Object.assign(Object.assign({},e),{currentPage:o,rowsPerPage:n})}}}const C=t.css`
 	pointer-events: none;
 	opacity: 0.4;
-`,C=c.default.div`
+`,y=i.default.div`
 	position: relative;
 	box-sizing: border-box;
 	display: flex;
@@ -9,37 +1407,41 @@
 	width: 100%;
 	height: 100%;
 	max-width: 100%;
-	${({disabled:e})=>e&&S};
+	${({disabled:e})=>e&&C};
 	${({theme:e})=>e.table.style};
-`,_=l.css`
+`,v=t.css`
 	position: sticky;
 	position: -webkit-sticky; /* Safari */
 	top: 0;
 	z-index: 1;
-`,x=c.default.div`
+`,R=i.default.div`
 	display: flex;
 	width: 100%;
-	${({$fixedHeader:e})=>e&&_};
+	${({$fixedHeader:e})=>e&&v};
 	${({theme:e})=>e.head.style};
-`,P=c.default.div`
+`,S=i.default.div`
 	display: flex;
 	align-items: stretch;
 	width: 100%;
 	${({theme:e})=>e.headRow.style};
 	${({$dense:e,theme:t})=>e&&t.headRow.denseStyle};
-`,k=(e,...t)=>l.css`
+`,E=(e,...n)=>t.css`
 		@media screen and (max-width: ${599}px) {
-			${l.css(e,...t)}
+			${t.css(e,...n)}
 		}
-	`,R=(e,...t)=>l.css`
+	`,O=(e,...n)=>t.css`
 		@media screen and (max-width: ${959}px) {
-			${l.css(e,...t)}
+			${t.css(e,...n)}
 		}
-	`,O=(e,...t)=>l.css`
+	`,$=(e,...n)=>t.css`
 		@media screen and (max-width: ${1280}px) {
-			${l.css(e,...t)}
+			${t.css(e,...n)}
 		}
-	`,T=c.default.div`
+	`,P=e=>(n,...o)=>t.css`
+			@media screen and (max-width: ${e}px) {
+				${t.css(n,...o)}
+			}
+		`,k=i.default.div`
 	position: relative;
 	display: flex;
 	align-items: center;
@@ -47,13 +1449,13 @@
 	line-height: normal;
 	${({theme:e,$headCell:t})=>e[t?"headCells":"cells"].style};
 	${({$noPadding:e})=>e&&"padding: 0"};
-`,I=c.default(T)`
+`,D=i.default(k)`
 	flex-grow: ${({button:e,grow:t})=>0===t||e?0:t||1};
 	flex-shrink: 0;
 	flex-basis: 0;
 	max-width: ${({maxWidth:e})=>e||"100%"};
 	min-width: ${({minWidth:e})=>e||"100px"};
-	${({width:e})=>e&&l.css`
+	${({width:e})=>e&&t.css`
 			min-width: ${e};
 			max-width: ${e};
 		`};
@@ -62,40 +1464,36 @@
 	${({compact:e,button:t})=>(e||t)&&"padding: 0"};
 
 	/* handle hiding cells */
-	${({hide:e})=>e&&"sm"===e&&k`
+	${({hide:e})=>e&&"sm"===e&&E`
     display: none;
   `};
-	${({hide:e})=>e&&"md"===e&&R`
+	${({hide:e})=>e&&"md"===e&&O`
     display: none;
   `};
-	${({hide:e})=>e&&"lg"===e&&O`
+	${({hide:e})=>e&&"lg"===e&&$`
     display: none;
   `};
-	${({hide:e})=>e&&Number.isInteger(e)&&(e=>(t,...n)=>l.css`
-			@media screen and (max-width: ${e}px) {
-				${l.css(t,...n)}
-			}
-		`)(e)`
+	${({hide:e})=>e&&Number.isInteger(e)&&P(e)`
     display: none;
   `};
-`,A=l.css`
+`,H=t.css`
 	div:first-child {
 		white-space: ${({$wrapCell:e})=>e?"normal":"nowrap"};
 		overflow: ${({$allowOverflow:e})=>e?"visible":"hidden"};
 		text-overflow: ellipsis;
 	}
-`,D=c.default(I).attrs((e=>({style:e.style})))`
-	${({$renderAsCell:e})=>!e&&A};
+`,j=i.default(D).attrs((e=>({style:e.style})))`
+	${({$renderAsCell:e})=>!e&&H};
 	${({theme:e,$isDragging:t})=>t&&e.cells.draggingStyle};
 	${({$cellStyle:e})=>e};
-`;var N=o.memo((function({id:e,column:t,row:n,rowIndex:a,dataTag:l,isDragging:r,onDragStart:i,onDragOver:s,onDragEnd:c,onDragEnter:p,onDragLeave:u}){const{conditionalStyle:d,classNames:m}=f(n,t.conditionalCellStyles,["rdt_TableCell"]);return o.createElement(D,{id:e,"data-column-id":t.id,role:"cell",className:m,"data-tag":l,$cellStyle:t.style,$renderAsCell:!!t.cell,$allowOverflow:t.allowOverflow,button:t.button,center:t.center,compact:t.compact,grow:t.grow,hide:t.hide,maxWidth:t.maxWidth,minWidth:t.minWidth,right:t.right,width:t.width,$wrapCell:t.wrap,style:d,$isDragging:r,onDragStart:i,onDragOver:s,onDragEnd:c,onDragEnter:p,onDragLeave:u},!t.cell&&o.createElement("div",{"data-tag":l},function(e,t,n,a){return t?n&&"function"==typeof n?n(e,a):t(e,a):null}(n,t.selector,t.format,a)),t.cell&&t.cell(n,a,t,e))}));const F="input";var $=o.memo((function({name:e,component:t=F,componentOptions:n={style:{}},indeterminate:a=!1,checked:l=!1,disabled:r=!1,onClick:i=y}){const s=t,c=s!==F?n.style:(e=>Object.assign(Object.assign({fontSize:"18px"},!e&&{cursor:"pointer"}),{padding:0,marginTop:"1px",verticalAlign:"middle",position:"relative"}))(r),p=o.useMemo((()=>function(e,...t){let n;return Object.keys(e).map((t=>e[t])).forEach(((a,l)=>{const r=e;"function"==typeof a&&(n=Object.assign(Object.assign({},r),{[Object.keys(e)[l]]:a(...t)}))})),n||e}(n,a)),[n,a]);return o.createElement(s,Object.assign({type:"checkbox",ref:e=>{e&&(e.indeterminate=a)},style:c,onClick:r?y:i,name:e,"aria-label":e,checked:l,disabled:r},p,{onChange:y}))}));const L=c.default(T)`
+`;var F=l.memo((function({id:e,column:t,row:n,rowIndex:o,dataTag:a,isDragging:r,onDragStart:i,onDragOver:s,onDragEnd:d,onDragEnter:c,onDragLeave:g}){const{conditionalStyle:u,classNames:p}=m(n,t.conditionalCellStyles,["rdt_TableCell"]);return l.createElement(j,{id:e,"data-column-id":t.id,role:"cell",className:p,"data-tag":a,$cellStyle:t.style,$renderAsCell:!!t.cell,$allowOverflow:t.allowOverflow,button:t.button,center:t.center,compact:t.compact,grow:t.grow,hide:t.hide,maxWidth:t.maxWidth,minWidth:t.minWidth,right:t.right,width:t.width,$wrapCell:t.wrap,style:u,$isDragging:r,onDragStart:i,onDragOver:s,onDragEnd:d,onDragEnter:c,onDragLeave:g},!t.cell&&l.createElement("div",{"data-tag":a},function(e,t,n,o){return t?n&&"function"==typeof n?n(e,o):t(e,o):null}(n,t.selector,t.format,o)),t.cell&&t.cell(n,o,t,e))}));const T="input";var I=l.memo((function({name:e,component:t=T,componentOptions:n={style:{}},indeterminate:o=!1,checked:a=!1,disabled:r=!1,onClick:i=b}){const s=t,d=s!==T?n.style:(e=>Object.assign(Object.assign({fontSize:"18px"},!e&&{cursor:"pointer"}),{padding:0,marginTop:"1px",verticalAlign:"middle",position:"relative"}))(r),c=l.useMemo((()=>function(e,...t){let n;return Object.keys(e).map((t=>e[t])).forEach(((o,a)=>{const l=e;"function"==typeof o&&(n=Object.assign(Object.assign({},l),{[Object.keys(e)[a]]:o(...t)}))})),n||e}(n,o)),[n,o]);return l.createElement(s,Object.assign({type:"checkbox",ref:e=>{e&&(e.indeterminate=o)},style:d,onClick:r?b:i,name:e,"aria-label":e,checked:a,disabled:r},c,{onChange:b}))}));const M=i.default(k)`
 	flex: 0 0 48px;
 	min-width: 48px;
 	justify-content: center;
 	align-items: center;
 	user-select: none;
 	white-space: nowrap;
-`;function j({name:e,keyField:t,row:n,rowCount:a,selected:l,selectableRowsComponent:r,selectableRowsComponentProps:i,selectableRowsSingle:s,selectableRowDisabled:c,onSelectedRow:p}){const u=!(!c||!c(n));return o.createElement(L,{onClick:e=>e.stopPropagation(),className:"rdt_TableCell",$noPadding:!0},o.createElement($,{name:e,component:r,componentOptions:i,checked:l,"aria-checked":l,onClick:()=>{p({type:"SELECT_SINGLE_ROW",row:n,isSelected:l,keyField:t,rowCount:a,singleSelect:s})},disabled:u}))}const H=c.default.button`
+`;function A({name:e,keyField:t,row:n,rowCount:o,selected:a,selectableRowsComponent:r,selectableRowsComponentProps:i,selectableRowsSingle:s,selectableRowDisabled:d,onSelectedRow:c}){const g=!(!d||!d(n));return l.createElement(M,{onClick:e=>e.stopPropagation(),className:"rdt_TableCell",$noPadding:!0},l.createElement(I,{name:e,component:r,componentOptions:i,checked:a,"aria-checked":a,onClick:()=>{c({type:"SELECT_SINGLE_ROW",row:n,isSelected:a,keyField:t,rowCount:o,singleSelect:s})},disabled:g}))}const L=i.default.button`
 	display: inline-flex;
 	align-items: center;
 	user-select: none;
@@ -103,25 +1501,25 @@
 	border: none;
 	background-color: transparent;
 	${({theme:e})=>e.expanderButton.style};
-`;function M({disabled:e=!1,expanded:t=!1,expandableIcon:n,id:a,row:l,onToggled:r}){const i=t?n.expanded:n.collapsed;return o.createElement(H,{"aria-disabled":e,onClick:()=>r&&r(l),"data-testid":`expander-button-${a}`,disabled:e,"aria-label":t?"Collapse Row":"Expand Row",role:"button",type:"button"},i)}const B=c.default(T)`
+`;function _({disabled:e=!1,expanded:t=!1,expandableIcon:n,id:o,row:a,onToggled:r}){const i=t?n.expanded:n.collapsed;return l.createElement(L,{"aria-disabled":e,onClick:()=>r&&r(a),"data-testid":`expander-button-${o}`,disabled:e,"aria-label":t?"Collapse Row":"Expand Row",role:"button",type:"button"},i)}const z=i.default(k)`
 	white-space: nowrap;
 	font-weight: 400;
 	min-width: 48px;
 	${({theme:e})=>e.expanderCell.style};
-`;function z({row:e,expanded:t=!1,expandableIcon:n,id:a,onToggled:l,disabled:r=!1}){return o.createElement(B,{onClick:e=>e.stopPropagation(),$noPadding:!0},o.createElement(M,{id:a,row:e,expanded:t,expandableIcon:n,disabled:r,onToggled:l}))}const U=c.default.div`
+`;function N({row:e,expanded:t=!1,expandableIcon:n,id:o,onToggled:a,disabled:r=!1}){return l.createElement(z,{onClick:e=>e.stopPropagation(),$noPadding:!0},l.createElement(_,{id:o,row:e,expanded:t,expandableIcon:n,disabled:r,onToggled:a}))}const W=i.default.div`
 	width: 100%;
 	box-sizing: border-box;
 	${({theme:e})=>e.expanderRow.style};
 	${({$extendedRowStyle:e})=>e};
-`;var W=o.memo((function({data:e,ExpanderComponent:t,expanderComponentProps:n,extendedRowStyle:a,extendedClassNames:l}){const r=["rdt_ExpanderRow",...l.split(" ").filter((e=>"rdt_TableRow"!==e))].join(" ");return o.createElement(U,{className:r,$extendedRowStyle:a},o.createElement(t,Object.assign({data:e},n)))}));const G="allowRowEvents";var V,q,J;t.OP=void 0,(V=t.OP||(t.OP={})).LTR="ltr",V.RTL="rtl",V.AUTO="auto",t.C1=void 0,(q=t.C1||(t.C1={})).LEFT="left",q.RIGHT="right",q.CENTER="center",t.$U=void 0,(J=t.$U||(t.$U={})).SM="sm",J.MD="md",J.LG="lg";const Y=l.css`
+`;var B=l.memo((function({data:e,ExpanderComponent:t,expanderComponentProps:n,extendedRowStyle:o,extendedClassNames:a}){const r=["rdt_ExpanderRow",...a.split(" ").filter((e=>"rdt_TableRow"!==e))].join(" ");return l.createElement(W,{className:r,$extendedRowStyle:o},l.createElement(t,Object.assign({data:e},n)))}));const G="allowRowEvents";var V,U,q;exports.Direction=void 0,(V=exports.Direction||(exports.Direction={})).LTR="ltr",V.RTL="rtl",V.AUTO="auto",exports.Alignment=void 0,(U=exports.Alignment||(exports.Alignment={})).LEFT="left",U.RIGHT="right",U.CENTER="center",exports.Media=void 0,(q=exports.Media||(exports.Media={})).SM="sm",q.MD="md",q.LG="lg";const Y=t.css`
 	&:hover {
 		${({$highlightOnHover:e,theme:t})=>e&&t.rows.highlightOnHoverStyle};
 	}
-`,K=l.css`
+`,K=t.css`
 	&:hover {
 		cursor: pointer;
 	}
-`,Z=c.default.div.attrs((e=>({style:e.style})))`
+`,J=i.default.div.attrs((e=>({style:e.style})))`
 	display: flex;
 	align-items: stretch;
 	align-content: stretch;
@@ -134,17 +1532,17 @@
 	${({$pointerOnHover:e})=>e&&K};
 	${({$selected:e,theme:t})=>e&&t.rows.selectedHighlightStyle};
 	${({$conditionalStyle:e})=>e};
-`;function Q({columns:e=[],conditionalRowStyles:t=[],defaultExpanded:n=!1,defaultExpanderDisabled:a=!1,dense:l=!1,expandableIcon:r,expandableRows:i=!1,expandableRowsComponent:s,expandableRowsComponentProps:c,expandableRowsHideExpander:u,expandOnRowClicked:d=!1,expandOnRowDoubleClicked:m=!1,highlightOnHover:h=!1,id:g,expandableInheritConditionalStyles:b,keyField:E,onRowClicked:w=y,onRowDoubleClicked:S=y,onRowMouseEnter:C=y,onRowMouseLeave:_=y,onRowExpandToggled:x=y,onSelectedRow:P=y,pointerOnHover:k=!1,row:R,rowCount:O,rowIndex:T,selectableRowDisabled:I=null,selectableRows:A=!1,selectableRowsComponent:D,selectableRowsComponentProps:F,selectableRowsHighlight:$=!1,selectableRowsSingle:L=!1,selected:H,striped:M=!1,draggingColumnId:B,onDragStart:U,onDragOver:V,onDragEnd:q,onDragEnter:J,onDragLeave:Y}){const[K,Q]=o.useState(n);o.useEffect((()=>{Q(n)}),[n]);const X=o.useCallback((()=>{Q(!K),x(!K,R)}),[K,x,R]),ee=k||i&&(d||m),te=o.useCallback((e=>{e.target.getAttribute("data-tag")===G&&(w(R,e),!a&&i&&d&&X())}),[a,d,i,X,w,R]),ne=o.useCallback((e=>{e.target.getAttribute("data-tag")===G&&(S(R,e),!a&&i&&m&&X())}),[a,m,i,X,S,R]),ae=o.useCallback((e=>{C(R,e)}),[C,R]),le=o.useCallback((e=>{_(R,e)}),[_,R]),re=p(R,E),{conditionalStyle:ie,classNames:oe}=f(R,t,["rdt_TableRow"]),se=$&&H,ce=b?ie:{},pe=M&&T%2==0;return o.createElement(o.Fragment,null,o.createElement(Z,{id:`row-${g}`,role:"row",$striped:pe,$highlightOnHover:h,$pointerOnHover:!a&&ee,$dense:l,onClick:te,onDoubleClick:ne,onMouseEnter:ae,onMouseLeave:le,className:oe,$selected:se,$conditionalStyle:ie},A&&o.createElement(j,{name:`select-row-${re}`,keyField:E,row:R,rowCount:O,selected:H,selectableRowsComponent:D,selectableRowsComponentProps:F,selectableRowDisabled:I,selectableRowsSingle:L,onSelectedRow:P}),i&&!u&&o.createElement(z,{id:re,expandableIcon:r,expanded:K,row:R,onToggled:X,disabled:a}),e.map((e=>e.omit?null:o.createElement(N,{id:`cell-${e.id}-${re}`,key:`cell-${e.id}-${re}`,dataTag:e.ignoreRowClick||e.button?null:G,column:e,row:R,rowIndex:T,isDragging:v(B,e.id),onDragStart:U,onDragOver:V,onDragEnd:q,onDragEnter:J,onDragLeave:Y})))),i&&K&&o.createElement(W,{key:`expander-${re}`,data:R,extendedRowStyle:ce,extendedClassNames:oe,ExpanderComponent:s,expanderComponentProps:c}))}const X=c.default.span`
+`;function Q({columns:e=[],conditionalRowStyles:t=[],defaultExpanded:n=!1,defaultExpanderDisabled:o=!1,dense:a=!1,expandableIcon:r,expandableRows:i=!1,expandableRowsComponent:d,expandableRowsComponentProps:c,expandableRowsHideExpander:g,expandOnRowClicked:u=!1,expandOnRowDoubleClicked:p=!1,highlightOnHover:f=!1,id:h,expandableInheritConditionalStyles:x,keyField:C,onRowClicked:y=b,onRowDoubleClicked:v=b,onRowMouseEnter:R=b,onRowMouseLeave:S=b,onRowExpandToggled:E=b,onSelectedRow:O=b,pointerOnHover:$=!1,row:P,rowCount:k,rowIndex:D,selectableRowDisabled:H=null,selectableRows:j=!1,selectableRowsComponent:T,selectableRowsComponentProps:I,selectableRowsHighlight:M=!1,selectableRowsSingle:L=!1,selected:_,striped:z=!1,draggingColumnId:W,onDragStart:V,onDragOver:U,onDragEnd:q,onDragEnter:Y,onDragLeave:K}){const[Q,X]=l.useState(n);l.useEffect((()=>{X(n)}),[n]);const Z=l.useCallback((()=>{X(!Q),E(!Q,P)}),[Q,E,P]),ee=$||i&&(u||p),te=l.useCallback((e=>{e.target.getAttribute("data-tag")===G&&(y(P,e),!o&&i&&u&&Z())}),[o,u,i,Z,y,P]),ne=l.useCallback((e=>{e.target.getAttribute("data-tag")===G&&(v(P,e),!o&&i&&p&&Z())}),[o,p,i,Z,v,P]),oe=l.useCallback((e=>{R(P,e)}),[R,P]),ae=l.useCallback((e=>{S(P,e)}),[S,P]),le=s(P,C),{conditionalStyle:re,classNames:ie}=m(P,t,["rdt_TableRow"]),se=M&&_,de=x?re:{},ce=z&&D%2==0;return l.createElement(l.Fragment,null,l.createElement(J,{id:`row-${h}`,role:"row",$striped:ce,$highlightOnHover:f,$pointerOnHover:!o&&ee,$dense:a,onClick:te,onDoubleClick:ne,onMouseEnter:oe,onMouseLeave:ae,className:ie,$selected:se,$conditionalStyle:re},j&&l.createElement(A,{name:`select-row-${le}`,keyField:C,row:P,rowCount:k,selected:_,selectableRowsComponent:T,selectableRowsComponentProps:I,selectableRowDisabled:H,selectableRowsSingle:L,onSelectedRow:O}),i&&!g&&l.createElement(N,{id:le,expandableIcon:r,expanded:Q,row:P,onToggled:Z,disabled:o}),e.map((e=>e.omit?null:l.createElement(F,{id:`cell-${e.id}-${le}`,key:`cell-${e.id}-${le}`,dataTag:e.ignoreRowClick||e.button?null:G,column:e,row:P,rowIndex:D,isDragging:w(W,e.id),onDragStart:V,onDragOver:U,onDragEnd:q,onDragEnter:Y,onDragLeave:K})))),i&&Q&&l.createElement(B,{key:`expander-${le}`,data:P,extendedRowStyle:de,extendedClassNames:ie,ExpanderComponent:d,expanderComponentProps:c}))}const X=i.default.span`
 	padding: 2px;
 	color: inherit;
 	flex-grow: 0;
 	flex-shrink: 0;
 	${({$sortActive:e})=>e?"opacity: 1":"opacity: 0"};
 	${({$sortDirection:e})=>"desc"===e&&"transform: rotate(180deg)"};
-`,ee=({sortActive:e,sortDirection:t})=>s.default.createElement(X,{$sortActive:e,$sortDirection:t},"▲"),te=c.default(I)`
+`,Z=({sortActive:e,sortDirection:t})=>r.default.createElement(X,{$sortActive:e,$sortDirection:t},"▲"),ee=i.default(D)`
 	${({button:e})=>e&&"text-align: center"};
 	${({theme:e,$isDragging:t})=>t&&e.headCells.draggingStyle};
-`,ne=l.css`
+`,te=t.css`
 	cursor: pointer;
 	span.__rdt_custom_sort_icon__ {
 		i,
@@ -167,7 +1565,7 @@
 		}
 	}
 
-	${({$sortActive:e})=>!e&&l.css`
+	${({$sortActive:e})=>!e&&t.css`
 			&:hover,
 			&:focus {
 				opacity: 0.7;
@@ -178,7 +1576,7 @@
 				}
 			}
 		`};
-`,ae=c.default.div`
+`,ne=i.default.div`
 	display: inline-flex;
 	align-items: center;
 	justify-content: inherit;
@@ -187,19 +1585,19 @@
 	outline: none;
 	user-select: none;
 	overflow: hidden;
-	${({disabled:e})=>!e&&ne};
-`,le=c.default.div`
+	${({disabled:e})=>!e&&te};
+`,oe=i.default.div`
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
-`;var re=o.memo((function({column:e,disabled:t,draggingColumnId:n,selectedColumn:a={},sortDirection:l,sortIcon:r,sortServer:s,pagination:c,paginationServer:p,persistSelectedOnSort:u,selectableRowsVisibleOnly:d,onSort:m,onDragStart:h,onDragOver:g,onDragEnd:y,onDragEnter:f,onDragLeave:b}){o.useEffect((()=>{"string"==typeof e.selector&&console.error(`Warning: ${e.selector} is a string based column selector which has been deprecated as of v7 and will be removed in v8. Instead, use a selector function e.g. row => row[field]...`)}),[]);const[E,w]=o.useState(!1),S=o.useRef(null);if(o.useEffect((()=>{S.current&&w(S.current.scrollWidth>S.current.clientWidth)}),[E]),e.omit)return null;const C=()=>{if(!e.sortable&&!e.selector)return;let t=l;v(a.id,e.id)&&(t=l===i.ASC?i.DESC:i.ASC),m({type:"SORT_CHANGE",sortDirection:t,selectedColumn:e,clearSelectedOnSort:c&&p&&!u||s||d})},_=e=>o.createElement(ee,{sortActive:e,sortDirection:l}),x=()=>o.createElement("span",{className:[l,"__rdt_custom_sort_icon__"].join(" ")},r),P=!(!e.sortable||!v(a.id,e.id)),k=!e.sortable||t,R=e.sortable&&!r&&!e.right,O=e.sortable&&!r&&e.right,T=e.sortable&&r&&!e.right,I=e.sortable&&r&&e.right;return o.createElement(te,{"data-column-id":e.id,className:"rdt_TableCol",$headCell:!0,allowOverflow:e.allowOverflow,button:e.button,compact:e.compact,grow:e.grow,hide:e.hide,maxWidth:e.maxWidth,minWidth:e.minWidth,right:e.right,center:e.center,width:e.width,draggable:e.reorder,$isDragging:v(e.id,n),onDragStart:h,onDragOver:g,onDragEnd:y,onDragEnter:f,onDragLeave:b},e.name&&o.createElement(ae,{"data-column-id":e.id,"data-sort-id":e.id,role:"columnheader",tabIndex:0,className:"rdt_TableCol_Sortable",onClick:k?void 0:C,onKeyPress:k?void 0:e=>{"Enter"===e.key&&C()},$sortActive:!k&&P,disabled:k},!k&&I&&x(),!k&&O&&_(P),"string"==typeof e.name?o.createElement(le,{title:E?e.name:void 0,ref:S,"data-column-id":e.id},e.name):e.name,!k&&T&&x(),!k&&R&&_(P)))}));const ie=c.default(T)`
+`;var ae=l.memo((function({column:e,disabled:t,draggingColumnId:n,selectedColumn:o={},sortDirection:r,sortIcon:i,sortServer:s,pagination:d,paginationServer:c,persistSelectedOnSort:g,selectableRowsVisibleOnly:u,onSort:p,onDragStart:b,onDragOver:m,onDragEnd:f,onDragEnter:h,onDragLeave:x}){l.useEffect((()=>{"string"==typeof e.selector&&console.error(`Warning: ${e.selector} is a string based column selector which has been deprecated as of v7 and will be removed in v8. Instead, use a selector function e.g. row => row[field]...`)}),[]);const[C,y]=l.useState(!1),v=l.useRef(null);if(l.useEffect((()=>{v.current&&y(v.current.scrollWidth>v.current.clientWidth)}),[C]),e.omit)return null;const R=()=>{if(!e.sortable&&!e.selector)return;let t=r;w(o.id,e.id)&&(t=r===a.ASC?a.DESC:a.ASC),p({type:"SORT_CHANGE",sortDirection:t,selectedColumn:e,clearSelectedOnSort:d&&c&&!g||s||u})},S=e=>l.createElement(Z,{sortActive:e,sortDirection:r}),E=()=>l.createElement("span",{className:[r,"__rdt_custom_sort_icon__"].join(" ")},i),O=!(!e.sortable||!w(o.id,e.id)),$=!e.sortable||t,P=e.sortable&&!i&&!e.right,k=e.sortable&&!i&&e.right,D=e.sortable&&i&&!e.right,H=e.sortable&&i&&e.right;return l.createElement(ee,{"data-column-id":e.id,className:"rdt_TableCol",$headCell:!0,allowOverflow:e.allowOverflow,button:e.button,compact:e.compact,grow:e.grow,hide:e.hide,maxWidth:e.maxWidth,minWidth:e.minWidth,right:e.right,center:e.center,width:e.width,draggable:e.reorder,$isDragging:w(e.id,n),onDragStart:b,onDragOver:m,onDragEnd:f,onDragEnter:h,onDragLeave:x},e.name&&l.createElement(ne,{"data-column-id":e.id,"data-sort-id":e.id,role:"columnheader",tabIndex:0,className:"rdt_TableCol_Sortable",onClick:$?void 0:R,onKeyPress:$?void 0:e=>{"Enter"===e.key&&R()},$sortActive:!$&&O,disabled:$},!$&&H&&E(),!$&&k&&S(O),"string"==typeof e.name?l.createElement(oe,{title:C?e.name:void 0,ref:v,"data-column-id":e.id},e.name):e.name,!$&&D&&E(),!$&&P&&S(O)))}));const le=i.default(k)`
 	flex: 0 0 48px;
 	justify-content: center;
 	align-items: center;
 	user-select: none;
 	white-space: nowrap;
 	font-size: unset;
-`;function oe({headCell:e=!0,rowData:t,keyField:n,allSelected:a,mergeSelections:l,selectedRows:r,selectableRowsComponent:i,selectableRowsComponentProps:s,selectableRowDisabled:c,onSelectAllRows:p}){const u=r.length>0&&!a,d=c?t.filter((e=>!c(e))):t,m=0===d.length,h=Math.min(t.length,d.length);return o.createElement(ie,{className:"rdt_TableCol",$headCell:e,$noPadding:!0},o.createElement($,{name:"select-all-rows",component:i,componentOptions:s,onClick:()=>{p({type:"SELECT_ALL_ROWS",rows:d,rowCount:h,mergeSelections:l,keyField:n})},checked:a,indeterminate:u,disabled:m}))}function se(e=t.OP.AUTO){const n="object"==typeof window,[a,l]=o.useState(!1);return o.useEffect((()=>{if(n)if("auto"!==e)l("rtl"===e);else{const e=!(!window.document||!window.document.createElement),t=document.getElementsByTagName("BODY")[0],n=document.getElementsByTagName("HTML")[0],a="rtl"===t.dir||"rtl"===n.dir;l(e&&a)}}),[e,n]),a}const ce=c.default.div`
+`;function re({headCell:e=!0,rowData:t,keyField:n,allSelected:o,mergeSelections:a,selectedRows:r,selectableRowsComponent:i,selectableRowsComponentProps:s,selectableRowDisabled:d,onSelectAllRows:c}){const g=r.length>0&&!o,u=d?t.filter((e=>!d(e))):t,p=0===u.length,b=Math.min(t.length,u.length);return l.createElement(le,{className:"rdt_TableCol",$headCell:e,$noPadding:!0},l.createElement(I,{name:"select-all-rows",component:i,componentOptions:s,onClick:()=>{c({type:"SELECT_ALL_ROWS",rows:u,rowCount:b,mergeSelections:a,keyField:n})},checked:o,indeterminate:g,disabled:p}))}function ie(e=exports.Direction.AUTO){const t="object"==typeof window,[n,o]=l.useState(!1);return l.useEffect((()=>{if(t)if("auto"!==e)o("rtl"===e);else{const e=!(!window.document||!window.document.createElement),t=document.getElementsByTagName("BODY")[0],n=document.getElementsByTagName("HTML")[0],a="rtl"===t.dir||"rtl"===n.dir;o(e&&a)}}),[e,t]),n}const se=i.default.div`
 	display: flex;
 	align-items: center;
 	flex: 1 0 auto;
@@ -207,12 +1605,12 @@
 	color: ${({theme:e})=>e.contextMenu.fontColor};
 	font-size: ${({theme:e})=>e.contextMenu.fontSize};
 	font-weight: 400;
-`,pe=c.default.div`
+`,de=i.default.div`
 	display: flex;
 	align-items: center;
 	justify-content: flex-end;
 	flex-wrap: wrap;
-`,ue=c.default.div`
+`,ce=i.default.div`
 	position: absolute;
 	top: 0;
 	left: 0;
@@ -226,7 +1624,7 @@
 	${({$rtl:e})=>e&&"direction: rtl"};
 	${({theme:e})=>e.contextMenu.style};
 	${({theme:e,$visible:t})=>t&&e.contextMenu.activeStyle};
-`;function de({contextMessage:e,contextActions:t,contextComponent:n,selectedCount:a,direction:l}){const r=se(l),i=a>0;return n?o.createElement(ue,{$visible:i},o.cloneElement(n,{selectedCount:a})):o.createElement(ue,{$visible:i,$rtl:r},o.createElement(ce,null,((e,t,n)=>{if(0===t)return null;const a=1===t?e.singular:e.plural;return n?`${t} ${e.message||""} ${a}`:`${t} ${a} ${e.message||""}`})(e,a,r)),o.createElement(pe,null,t))}const me=c.default.div`
+`;function ge({contextMessage:e,contextActions:t,contextComponent:n,selectedCount:o,direction:a}){const r=ie(a),i=o>0;return n?l.createElement(ce,{$visible:i},l.cloneElement(n,{selectedCount:o})):l.createElement(ce,{$visible:i,$rtl:r},l.createElement(se,null,((e,t,n)=>{if(0===t)return null;const o=1===t?e.singular:e.plural;return n?`${t} ${e.message||""} ${o}`:`${t} ${o} ${e.message||""}`})(e,o,r)),l.createElement(de,null,t))}const ue=i.default.div`
 	position: relative;
 	box-sizing: border-box;
 	overflow: hidden;
@@ -237,12 +1635,12 @@
 	width: 100%;
 	flex-wrap: wrap;
 	${({theme:e})=>e.header.style}
-`,he=c.default.div`
+`,pe=i.default.div`
 	flex: 1 0 auto;
 	color: ${({theme:e})=>e.header.fontColor};
 	font-size: ${({theme:e})=>e.header.fontSize};
 	font-weight: 400;
-`,ge=c.default.div`
+`,be=i.default.div`
 	flex: 1 0 auto;
 	display: flex;
 	align-items: center;
@@ -251,7 +1649,7 @@
 	> * {
 		margin-left: 5px;
 	}
-`,ye=({title:e,actions:t=null,contextMessage:n,contextActions:a,contextComponent:l,selectedCount:r,direction:i,showMenu:s=!0})=>o.createElement(me,{className:"rdt_TableHeader",role:"heading","aria-level":1},o.createElement(he,null,e),t&&o.createElement(ge,null,t),s&&o.createElement(de,{contextMessage:n,contextActions:a,contextComponent:l,direction:i,selectedCount:r}));function fe(e,t){var n={};for(var a in e)Object.prototype.hasOwnProperty.call(e,a)&&t.indexOf(a)<0&&(n[a]=e[a]);if(null!=e&&"function"==typeof Object.getOwnPropertySymbols){var l=0;for(a=Object.getOwnPropertySymbols(e);l<a.length;l++)t.indexOf(a[l])<0&&Object.prototype.propertyIsEnumerable.call(e,a[l])&&(n[a[l]]=e[a[l]])}return n}"function"==typeof SuppressedError&&SuppressedError;const be={left:"flex-start",right:"flex-end",center:"center"},Ee=c.default.header`
+`,me=({title:e,actions:t=null,contextMessage:n,contextActions:o,contextComponent:a,selectedCount:r,direction:i,showMenu:s=!0})=>l.createElement(ue,{className:"rdt_TableHeader",role:"heading","aria-level":1},l.createElement(pe,null,e),t&&l.createElement(be,null,t),s&&l.createElement(ge,{contextMessage:n,contextActions:o,contextComponent:a,direction:i,selectedCount:r}));function fe(e,t){var n={};for(var o in e)Object.prototype.hasOwnProperty.call(e,o)&&t.indexOf(o)<0&&(n[o]=e[o]);if(null!=e&&"function"==typeof Object.getOwnPropertySymbols){var a=0;for(o=Object.getOwnPropertySymbols(e);a<o.length;a++)t.indexOf(o[a])<0&&Object.prototype.propertyIsEnumerable.call(e,o[a])&&(n[o[a]]=e[o[a]])}return n}"function"==typeof SuppressedError&&SuppressedError;const he={left:"flex-start",right:"flex-end",center:"center"},we=i.default.header`
 	position: relative;
 	display: flex;
 	flex: 1 1 auto;
@@ -259,49 +1657,49 @@
 	align-items: center;
 	padding: 4px 16px 4px 24px;
 	width: 100%;
-	justify-content: ${({align:e})=>be[e]};
+	justify-content: ${({align:e})=>he[e]};
 	flex-wrap: ${({$wrapContent:e})=>e?"wrap":"nowrap"};
 	${({theme:e})=>e.subHeader.style}
-`,ve=e=>{var{align:t="right",wrapContent:n=!0}=e,a=fe(e,["align","wrapContent"]);return o.createElement(Ee,Object.assign({align:t,$wrapContent:n},a))},we=c.default.div`
+`,xe=e=>{var{align:t="right",wrapContent:n=!0}=e,o=fe(e,["align","wrapContent"]);return l.createElement(we,Object.assign({align:t,$wrapContent:n},o))},Ce=i.default.div`
 	display: flex;
 	flex-direction: column;
-`,Se=c.default.div`
+`,ye=i.default.div`
 	position: relative;
 	width: 100%;
 	border-radius: inherit;
-	${({$responsive:e,$fixedHeader:t})=>e&&l.css`
+	${({$responsive:e,$fixedHeader:n})=>e&&t.css`
 			overflow-x: auto;
 
 			// hidden prevents vertical scrolling in firefox when fixedHeader is disabled
-			overflow-y: ${t?"auto":"hidden"};
+			overflow-y: ${n?"auto":"hidden"};
 			min-height: 0;
 		`};
 
-	${({$fixedHeader:e=!1,$fixedHeaderScrollHeight:t="100vh"})=>e&&l.css`
-			max-height: ${t};
+	${({$fixedHeader:e=!1,$fixedHeaderScrollHeight:n="100vh"})=>e&&t.css`
+			max-height: ${n};
 			-webkit-overflow-scrolling: touch;
 		`};
 
 	${({theme:e})=>e.responsiveWrapper.style};
-`,Ce=c.default.div`
+`,ve=i.default.div`
 	position: relative;
 	box-sizing: border-box;
 	width: 100%;
 	height: 100%;
 	${e=>e.theme.progress.style};
-`,_e=c.default.div`
+`,Re=i.default.div`
 	position: relative;
 	width: 100%;
 	${({theme:e})=>e.tableWrapper.style};
-`,xe=c.default(T)`
+`,Se=i.default(k)`
 	white-space: nowrap;
 	${({theme:e})=>e.expanderCell.style};
-`,Pe=c.default.div`
+`,Ee=i.default.div`
 	box-sizing: border-box;
 	width: 100%;
 	height: 100%;
 	${({theme:e})=>e.noData.style};
-`,ke=()=>s.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24"},s.default.createElement("path",{d:"M7 10l5 5 5-5z"}),s.default.createElement("path",{d:"M0 0h24v24H0z",fill:"none"})),Re=c.default.select`
+`,Oe=()=>r.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24"},r.default.createElement("path",{d:"M7 10l5 5 5-5z"}),r.default.createElement("path",{d:"M0 0h24v24H0z",fill:"none"})),$e=i.default.select`
 	cursor: pointer;
 	height: 24px;
 	max-width: 100%;
@@ -328,7 +1726,7 @@
 	option {
 		color: initial;
 	}
-`,Oe=c.default.div`
+`,Pe=i.default.div`
 	position: relative;
 	flex-shrink: 0;
 	font-size: inherit;
@@ -347,7 +1745,7 @@
 		user-select: none;
 		pointer-events: none;
 	}
-`,Te=e=>{var{defaultValue:t,onChange:n}=e,a=fe(e,["defaultValue","onChange"]);return o.createElement(Oe,null,o.createElement(Re,Object.assign({onChange:n,defaultValue:t},a)),o.createElement(ke,null))},Ie={columns:[],data:[],title:"",keyField:"id",selectableRows:!1,selectableRowsHighlight:!1,selectableRowsNoSelectAll:!1,selectableRowSelected:null,selectableRowDisabled:null,selectableRowsComponent:"input",selectableRowsComponentProps:{},selectableRowsVisibleOnly:!1,selectableRowsSingle:!1,clearSelectedRows:!1,expandableRows:!1,expandableRowDisabled:null,expandableRowExpanded:null,expandOnRowClicked:!1,expandableRowsHideExpander:!1,expandOnRowDoubleClicked:!1,expandableInheritConditionalStyles:!1,expandableRowsComponent:function(){return s.default.createElement("div",null,"To add an expander pass in a component instance via ",s.default.createElement("strong",null,"expandableRowsComponent"),". You can then access props.data from this component.")},expandableIcon:{collapsed:s.default.createElement((()=>s.default.createElement("svg",{fill:"currentColor",height:"24",viewBox:"0 0 24 24",width:"24",xmlns:"http://www.w3.org/2000/svg"},s.default.createElement("path",{d:"M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"}),s.default.createElement("path",{d:"M0-.25h24v24H0z",fill:"none"}))),null),expanded:s.default.createElement((()=>s.default.createElement("svg",{fill:"currentColor",height:"24",viewBox:"0 0 24 24",width:"24",xmlns:"http://www.w3.org/2000/svg"},s.default.createElement("path",{d:"M7.41 7.84L12 12.42l4.59-4.58L18 9.25l-6 6-6-6z"}),s.default.createElement("path",{d:"M0-.75h24v24H0z",fill:"none"}))),null)},expandableRowsComponentProps:{},progressPending:!1,progressComponent:s.default.createElement("div",{style:{fontSize:"24px",fontWeight:700,padding:"24px"}},"Loading..."),persistTableHead:!1,sortIcon:null,sortFunction:null,sortServer:!1,striped:!1,highlightOnHover:!1,pointerOnHover:!1,noContextMenu:!1,contextMessage:{singular:"item",plural:"items",message:"selected"},actions:null,contextActions:null,contextComponent:null,defaultSortFieldId:null,defaultSortAsc:!0,responsive:!0,noDataComponent:s.default.createElement("div",{style:{padding:"24px"}},"There are no records to display"),disabled:!1,noTableHead:!1,noHeader:!1,subHeader:!1,subHeaderAlign:t.C1.RIGHT,subHeaderWrap:!0,subHeaderComponent:null,fixedHeader:!1,fixedHeaderScrollHeight:"100vh",pagination:!1,paginationServer:!1,paginationServerOptions:{persistSelectedOnSort:!1,persistSelectedOnPageChange:!1},paginationDefaultPage:1,paginationResetDefaultPage:!1,paginationTotalRows:0,paginationPerPage:10,paginationRowsPerPageOptions:[10,15,20,25,30],paginationComponent:null,paginationComponentOptions:{},paginationIconFirstPage:s.default.createElement((()=>s.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24","aria-hidden":"true",role:"presentation"},s.default.createElement("path",{d:"M18.41 16.59L13.82 12l4.59-4.59L17 6l-6 6 6 6zM6 6h2v12H6z"}),s.default.createElement("path",{fill:"none",d:"M24 24H0V0h24v24z"}))),null),paginationIconLastPage:s.default.createElement((()=>s.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24","aria-hidden":"true",role:"presentation"},s.default.createElement("path",{d:"M5.59 7.41L10.18 12l-4.59 4.59L7 18l6-6-6-6zM16 6h2v12h-2z"}),s.default.createElement("path",{fill:"none",d:"M0 0h24v24H0V0z"}))),null),paginationIconNext:s.default.createElement((()=>s.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24","aria-hidden":"true",role:"presentation"},s.default.createElement("path",{d:"M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"}),s.default.createElement("path",{d:"M0 0h24v24H0z",fill:"none"}))),null),paginationIconPrevious:s.default.createElement((()=>s.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24","aria-hidden":"true",role:"presentation"},s.default.createElement("path",{d:"M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"}),s.default.createElement("path",{d:"M0 0h24v24H0z",fill:"none"}))),null),dense:!1,conditionalRowStyles:[],theme:"default",customStyles:{},direction:t.OP.AUTO,onChangePage:y,onChangeRowsPerPage:y,onRowClicked:y,onRowDoubleClicked:y,onRowMouseEnter:y,onRowMouseLeave:y,onRowExpandToggled:y,onSelectedRowsChange:y,onSort:y,onColumnOrderChange:y},Ae={rowsPerPageText:"Rows per page:",rangeSeparatorText:"of",noRowsPerPage:!1,selectAllRowsItem:!1,selectAllRowsItemText:"All"},De=c.default.nav`
+`,ke=e=>{var{defaultValue:t,onChange:n}=e,o=fe(e,["defaultValue","onChange"]);return l.createElement(Pe,null,l.createElement($e,Object.assign({onChange:n,defaultValue:t},o)),l.createElement(Oe,null))},De={columns:[],data:[],title:"",keyField:"id",selectableRows:!1,selectableRowsHighlight:!1,selectableRowsNoSelectAll:!1,selectableRowSelected:null,selectableRowDisabled:null,selectableRowsComponent:"input",selectableRowsComponentProps:{},selectableRowsVisibleOnly:!1,selectableRowsSingle:!1,clearSelectedRows:!1,expandableRows:!1,expandableRowDisabled:null,expandableRowExpanded:null,expandOnRowClicked:!1,expandableRowsHideExpander:!1,expandOnRowDoubleClicked:!1,expandableInheritConditionalStyles:!1,expandableRowsComponent:function(){return r.default.createElement("div",null,"To add an expander pass in a component instance via ",r.default.createElement("strong",null,"expandableRowsComponent"),". You can then access props.data from this component.")},expandableIcon:{collapsed:r.default.createElement((()=>r.default.createElement("svg",{fill:"currentColor",height:"24",viewBox:"0 0 24 24",width:"24",xmlns:"http://www.w3.org/2000/svg"},r.default.createElement("path",{d:"M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"}),r.default.createElement("path",{d:"M0-.25h24v24H0z",fill:"none"}))),null),expanded:r.default.createElement((()=>r.default.createElement("svg",{fill:"currentColor",height:"24",viewBox:"0 0 24 24",width:"24",xmlns:"http://www.w3.org/2000/svg"},r.default.createElement("path",{d:"M7.41 7.84L12 12.42l4.59-4.58L18 9.25l-6 6-6-6z"}),r.default.createElement("path",{d:"M0-.75h24v24H0z",fill:"none"}))),null)},expandableRowsComponentProps:{},progressPending:!1,progressComponent:r.default.createElement("div",{style:{fontSize:"24px",fontWeight:700,padding:"24px"}},"Loading..."),persistTableHead:!1,sortIcon:null,sortFunction:null,sortServer:!1,striped:!1,highlightOnHover:!1,pointerOnHover:!1,noContextMenu:!1,contextMessage:{singular:"item",plural:"items",message:"selected"},actions:null,contextActions:null,contextComponent:null,defaultSortFieldId:null,defaultSortAsc:!0,responsive:!0,noDataComponent:r.default.createElement("div",{style:{padding:"24px"}},"There are no records to display"),disabled:!1,noTableHead:!1,noHeader:!1,subHeader:!1,subHeaderAlign:exports.Alignment.RIGHT,subHeaderWrap:!0,subHeaderComponent:null,fixedHeader:!1,fixedHeaderScrollHeight:"100vh",pagination:!1,paginationServer:!1,paginationServerOptions:{persistSelectedOnSort:!1,persistSelectedOnPageChange:!1},paginationDefaultPage:1,paginationResetDefaultPage:!1,paginationTotalRows:0,paginationPerPage:10,paginationRowsPerPageOptions:[10,15,20,25,30],paginationComponent:null,paginationComponentOptions:{},paginationIconFirstPage:r.default.createElement((()=>r.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24","aria-hidden":"true",role:"presentation"},r.default.createElement("path",{d:"M18.41 16.59L13.82 12l4.59-4.59L17 6l-6 6 6 6zM6 6h2v12H6z"}),r.default.createElement("path",{fill:"none",d:"M24 24H0V0h24v24z"}))),null),paginationIconLastPage:r.default.createElement((()=>r.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24","aria-hidden":"true",role:"presentation"},r.default.createElement("path",{d:"M5.59 7.41L10.18 12l-4.59 4.59L7 18l6-6-6-6zM16 6h2v12h-2z"}),r.default.createElement("path",{fill:"none",d:"M0 0h24v24H0V0z"}))),null),paginationIconNext:r.default.createElement((()=>r.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24","aria-hidden":"true",role:"presentation"},r.default.createElement("path",{d:"M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"}),r.default.createElement("path",{d:"M0 0h24v24H0z",fill:"none"}))),null),paginationIconPrevious:r.default.createElement((()=>r.default.createElement("svg",{xmlns:"http://www.w3.org/2000/svg",width:"24",height:"24",viewBox:"0 0 24 24","aria-hidden":"true",role:"presentation"},r.default.createElement("path",{d:"M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"}),r.default.createElement("path",{d:"M0 0h24v24H0z",fill:"none"}))),null),dense:!1,conditionalRowStyles:[],theme:"default",customStyles:{},direction:exports.Direction.AUTO,onChangePage:b,onChangeRowsPerPage:b,onRowClicked:b,onRowDoubleClicked:b,onRowMouseEnter:b,onRowMouseLeave:b,onRowExpandToggled:b,onSelectedRowsChange:b,onSort:b,onColumnOrderChange:b},He={rowsPerPageText:"Rows per page:",rangeSeparatorText:"of",noRowsPerPage:!1,selectAllRowsItem:!1,selectAllRowsItemText:"All"},je=i.default.nav`
 	display: flex;
 	flex: 1 1 auto;
 	justify-content: flex-end;
@@ -357,27 +1755,8296 @@
 	padding-left: 8px;
 	width: 100%;
 	${({theme:e})=>e.pagination.style};
-`,Ne=c.default.button`
+`,Fe=i.default.button`
 	position: relative;
 	display: block;
 	user-select: none;
 	border: none;
 	${({theme:e})=>e.pagination.pageButtonsStyle};
 	${({$isRTL:e})=>e&&"transform: scale(-1, -1)"};
-`,Fe=c.default.div`
+`,Te=i.default.div`
 	display: flex;
 	align-items: center;
 	border-radius: 4px;
 	white-space: nowrap;
-	${k`
+	${E`
     width: 100%;
     justify-content: space-around;
   `};
-`,$e=c.default.span`
+`,Ie=i.default.span`
 	flex-shrink: 1;
 	user-select: none;
-`,Le=c.default($e)`
+`,Me=i.default(Ie)`
 	margin: 0 24px;
-`,je=c.default($e)`
+`,Ae=i.default(Ie)`
 	margin: 0 4px;
-`;var He=o.memo((function({rowsPerPage:e,rowCount:t,currentPage:n,direction:a=Ie.direction,paginationRowsPerPageOptions:l=Ie.paginationRowsPerPageOptions,paginationIconLastPage:r=Ie.paginationIconLastPage,paginationIconFirstPage:i=Ie.paginationIconFirstPage,paginationIconNext:s=Ie.paginationIconNext,paginationIconPrevious:c=Ie.paginationIconPrevious,paginationComponentOptions:p=Ie.paginationComponentOptions,onChangeRowsPerPage:u=Ie.onChangeRowsPerPage,onChangePage:d=Ie.onChangePage}){const m=(()=>{const e="object"==typeof window;function t(){return{width:e?window.innerWidth:void 0,height:e?window.innerHeight:void 0}}const[n,a]=o.useState(t);return o.useEffect((()=>{if(!e)return()=>null;function n(){a(t())}return window.addEventListener("resize",n),()=>window.removeEventListener("resize",n)}),[]),n})(),g=se(a),y=m.width&&m.width>599,f=h(t,e),b=n*e,E=b-e+1,v=1===n,w=n===f,S=Object.assign(Object.assign({},Ae),p),C=n===f?`${E}-${t} ${S.rangeSeparatorText} ${t}`:`${E}-${b} ${S.rangeSeparatorText} ${t}`,_=o.useCallback((()=>d(n-1)),[n,d]),x=o.useCallback((()=>d(n+1)),[n,d]),P=o.useCallback((()=>d(1)),[d]),k=o.useCallback((()=>d(h(t,e))),[d,t,e]),R=o.useCallback((e=>u(Number(e.target.value),n)),[n,u]),O=l.map((e=>o.createElement("option",{key:e,value:e},e)));S.selectAllRowsItem&&O.push(o.createElement("option",{key:-1,value:t},S.selectAllRowsItemText));const T=o.createElement(Te,{onChange:R,defaultValue:e,"aria-label":S.rowsPerPageText},O);return o.createElement(De,{className:"rdt_Pagination"},!S.noRowsPerPage&&y&&o.createElement(o.Fragment,null,o.createElement(je,null,S.rowsPerPageText),T),y&&o.createElement(Le,null,C),o.createElement(Fe,null,o.createElement(Ne,{id:"pagination-first-page",type:"button","aria-label":"First Page","aria-disabled":v,onClick:P,disabled:v,$isRTL:g},i),o.createElement(Ne,{id:"pagination-previous-page",type:"button","aria-label":"Previous Page","aria-disabled":v,onClick:_,disabled:v,$isRTL:g},c),!S.noRowsPerPage&&!y&&T,o.createElement(Ne,{id:"pagination-next-page",type:"button","aria-label":"Next Page","aria-disabled":w,onClick:x,disabled:w,$isRTL:g},s),o.createElement(Ne,{id:"pagination-last-page",type:"button","aria-label":"Last Page","aria-disabled":w,onClick:k,disabled:w,$isRTL:g},r)))}));const Me=(e,t)=>{const n=o.useRef(!0);o.useEffect((()=>{n.current?n.current=!1:e()}),t)};var Be=function(e){return function(e){return!!e&&"object"==typeof e}(e)&&!function(e){var t=Object.prototype.toString.call(e);return"[object RegExp]"===t||"[object Date]"===t||function(e){return e.$$typeof===ze}(e)}(e)},ze="function"==typeof Symbol&&Symbol.for?Symbol.for("react.element"):60103;function Ue(e,t){return!1!==t.clone&&t.isMergeableObject(e)?qe((n=e,Array.isArray(n)?[]:{}),e,t):e;var n}function We(e,t,n){return e.concat(t).map((function(e){return Ue(e,n)}))}function Ge(e){return Object.keys(e).concat(function(e){return Object.getOwnPropertySymbols?Object.getOwnPropertySymbols(e).filter((function(t){return Object.propertyIsEnumerable.call(e,t)})):[]}(e))}function Ve(e,t){try{return t in e}catch(e){return!1}}function qe(e,t,n){(n=n||{}).arrayMerge=n.arrayMerge||We,n.isMergeableObject=n.isMergeableObject||Be,n.cloneUnlessOtherwiseSpecified=Ue;var a=Array.isArray(t);return a===Array.isArray(e)?a?n.arrayMerge(e,t,n):function(e,t,n){var a={};return n.isMergeableObject(e)&&Ge(e).forEach((function(t){a[t]=Ue(e[t],n)})),Ge(t).forEach((function(l){(function(e,t){return Ve(e,t)&&!(Object.hasOwnProperty.call(e,t)&&Object.propertyIsEnumerable.call(e,t))})(e,l)||(Ve(e,l)&&n.isMergeableObject(t[l])?a[l]=function(e,t){if(!t.customMerge)return qe;var n=t.customMerge(e);return"function"==typeof n?n:qe}(l,n)(e[l],t[l],n):a[l]=Ue(t[l],n))})),a}(e,t,n):Ue(t,n)}qe.all=function(e,t){if(!Array.isArray(e))throw new Error("first argument should be an array");return e.reduce((function(e,n){return qe(e,n,t)}),{})};var Je=function(e){return e&&e.__esModule&&Object.prototype.hasOwnProperty.call(e,"default")?e.default:e}(qe);const Ye={text:{primary:"rgba(0, 0, 0, 0.87)",secondary:"rgba(0, 0, 0, 0.54)",disabled:"rgba(0, 0, 0, 0.38)"},background:{default:"#FFFFFF"},context:{background:"#e3f2fd",text:"rgba(0, 0, 0, 0.87)"},divider:{default:"rgba(0,0,0,.12)"},button:{default:"rgba(0,0,0,.54)",focus:"rgba(0,0,0,.12)",hover:"rgba(0,0,0,.12)",disabled:"rgba(0, 0, 0, .18)"},selected:{default:"#e3f2fd",text:"rgba(0, 0, 0, 0.87)"},highlightOnHover:{default:"#EEEEEE",text:"rgba(0, 0, 0, 0.87)"},striped:{default:"#FAFAFA",text:"rgba(0, 0, 0, 0.87)"}},Ke={default:Ye,light:Ye,dark:{text:{primary:"#FFFFFF",secondary:"rgba(255, 255, 255, 0.7)",disabled:"rgba(0,0,0,.12)"},background:{default:"#424242"},context:{background:"#E91E63",text:"#FFFFFF"},divider:{default:"rgba(81, 81, 81, 1)"},button:{default:"#FFFFFF",focus:"rgba(255, 255, 255, .54)",hover:"rgba(255, 255, 255, .12)",disabled:"rgba(255, 255, 255, .18)"},selected:{default:"rgba(0, 0, 0, .7)",text:"#FFFFFF"},highlightOnHover:{default:"rgba(0, 0, 0, .7)",text:"#FFFFFF"},striped:{default:"rgba(0, 0, 0, .87)",text:"#FFFFFF"}}};function Ze(e,t,n,a){const[l,r]=o.useState((()=>m(e))),[s,c]=o.useState(""),p=o.useRef("");Me((()=>{r(m(e))}),[e]);const u=o.useCallback((e=>{var t,n,a;const{attributes:r}=e.target,i=null===(t=r.getNamedItem("data-column-id"))||void 0===t?void 0:t.value;i&&(p.current=(null===(a=null===(n=l[E(l,i)])||void 0===n?void 0:n.id)||void 0===a?void 0:a.toString())||"",c(p.current))}),[l]),d=o.useCallback((e=>{var n;const{attributes:a}=e.target,i=null===(n=a.getNamedItem("data-column-id"))||void 0===n?void 0:n.value;if(i&&p.current&&i!==p.current){const e=E(l,p.current),n=E(l,i),a=[...l];a[e]=l[n],a[n]=l[e],r(a),t(a)}}),[t,l]),h=o.useCallback((e=>{e.preventDefault()}),[]),g=o.useCallback((e=>{e.preventDefault()}),[]),y=o.useCallback((e=>{e.preventDefault(),p.current="",c("")}),[]),f=function(e=!1){return e?i.ASC:i.DESC}(a),b=o.useMemo((()=>l[E(l,null==n?void 0:n.toString())]||{}),[n,l]);return{tableColumns:l,draggingColumnId:s,handleDragStart:u,handleDragEnter:d,handleDragOver:h,handleDragLeave:g,handleDragEnd:y,defaultSortDirection:f,defaultSortColumn:b}}var Qe=o.memo((function(e){const{data:t=Ie.data,columns:n=Ie.columns,title:a=Ie.title,actions:r=Ie.actions,keyField:s=Ie.keyField,striped:c=Ie.striped,highlightOnHover:u=Ie.highlightOnHover,pointerOnHover:d=Ie.pointerOnHover,dense:m=Ie.dense,selectableRows:y=Ie.selectableRows,selectableRowsSingle:f=Ie.selectableRowsSingle,selectableRowsHighlight:E=Ie.selectableRowsHighlight,selectableRowsNoSelectAll:v=Ie.selectableRowsNoSelectAll,selectableRowsVisibleOnly:S=Ie.selectableRowsVisibleOnly,selectableRowSelected:_=Ie.selectableRowSelected,selectableRowDisabled:k=Ie.selectableRowDisabled,selectableRowsComponent:R=Ie.selectableRowsComponent,selectableRowsComponentProps:O=Ie.selectableRowsComponentProps,onRowExpandToggled:I=Ie.onRowExpandToggled,onSelectedRowsChange:A=Ie.onSelectedRowsChange,expandableIcon:D=Ie.expandableIcon,onChangeRowsPerPage:N=Ie.onChangeRowsPerPage,onChangePage:F=Ie.onChangePage,paginationServer:$=Ie.paginationServer,paginationServerOptions:L=Ie.paginationServerOptions,paginationTotalRows:j=Ie.paginationTotalRows,paginationDefaultPage:H=Ie.paginationDefaultPage,paginationResetDefaultPage:M=Ie.paginationResetDefaultPage,paginationPerPage:B=Ie.paginationPerPage,paginationRowsPerPageOptions:z=Ie.paginationRowsPerPageOptions,paginationIconLastPage:U=Ie.paginationIconLastPage,paginationIconFirstPage:W=Ie.paginationIconFirstPage,paginationIconNext:G=Ie.paginationIconNext,paginationIconPrevious:V=Ie.paginationIconPrevious,paginationComponent:q=Ie.paginationComponent,paginationComponentOptions:J=Ie.paginationComponentOptions,responsive:Y=Ie.responsive,progressPending:K=Ie.progressPending,progressComponent:Z=Ie.progressComponent,persistTableHead:X=Ie.persistTableHead,noDataComponent:ee=Ie.noDataComponent,disabled:te=Ie.disabled,noTableHead:ne=Ie.noTableHead,noHeader:ae=Ie.noHeader,fixedHeader:le=Ie.fixedHeader,fixedHeaderScrollHeight:ie=Ie.fixedHeaderScrollHeight,pagination:se=Ie.pagination,subHeader:ce=Ie.subHeader,subHeaderAlign:pe=Ie.subHeaderAlign,subHeaderWrap:ue=Ie.subHeaderWrap,subHeaderComponent:de=Ie.subHeaderComponent,noContextMenu:me=Ie.noContextMenu,contextMessage:he=Ie.contextMessage,contextActions:ge=Ie.contextActions,contextComponent:fe=Ie.contextComponent,expandableRows:be=Ie.expandableRows,onRowClicked:Ee=Ie.onRowClicked,onRowDoubleClicked:ke=Ie.onRowDoubleClicked,onRowMouseEnter:Re=Ie.onRowMouseEnter,onRowMouseLeave:Oe=Ie.onRowMouseLeave,sortIcon:Te=Ie.sortIcon,onSort:Ae=Ie.onSort,sortFunction:De=Ie.sortFunction,sortServer:Ne=Ie.sortServer,expandableRowsComponent:Fe=Ie.expandableRowsComponent,expandableRowsComponentProps:$e=Ie.expandableRowsComponentProps,expandableRowDisabled:Le=Ie.expandableRowDisabled,expandableRowsHideExpander:je=Ie.expandableRowsHideExpander,expandOnRowClicked:Be=Ie.expandOnRowClicked,expandOnRowDoubleClicked:ze=Ie.expandOnRowDoubleClicked,expandableRowExpanded:Ue=Ie.expandableRowExpanded,expandableInheritConditionalStyles:We=Ie.expandableInheritConditionalStyles,defaultSortFieldId:Ge=Ie.defaultSortFieldId,defaultSortAsc:Ve=Ie.defaultSortAsc,clearSelectedRows:qe=Ie.clearSelectedRows,conditionalRowStyles:Ye=Ie.conditionalRowStyles,theme:Qe=Ie.theme,customStyles:Xe=Ie.customStyles,direction:et=Ie.direction,onColumnOrderChange:tt=Ie.onColumnOrderChange,className:nt}=e,{tableColumns:at,draggingColumnId:lt,handleDragStart:rt,handleDragEnter:it,handleDragOver:ot,handleDragLeave:st,handleDragEnd:ct,defaultSortDirection:pt,defaultSortColumn:ut}=Ze(n,tt,Ge,Ve),[{rowsPerPage:dt,currentPage:mt,selectedRows:ht,allSelected:gt,selectedCount:yt,selectedColumn:ft,sortDirection:bt,toggleOnSelectedRowsChange:Et},vt]=o.useReducer(w,{allSelected:!1,selectedCount:0,selectedRows:[],selectedColumn:ut,toggleOnSelectedRowsChange:!1,sortDirection:pt,currentPage:H,rowsPerPage:B,selectedRowsFlag:!1,contextMessage:Ie.contextMessage}),{persistSelectedOnSort:wt=!1,persistSelectedOnPageChange:St=!1}=L,Ct=!(!$||!St&&!wt),_t=se&&!K&&t.length>0,xt=q||He,Pt=o.useMemo((()=>((e={},t="default",n="default")=>{return Je({table:{style:{color:(a=Ke[Ke[t]?t:n]).text.primary,backgroundColor:a.background.default}},tableWrapper:{style:{display:"table"}},responsiveWrapper:{style:{}},header:{style:{fontSize:"22px",color:a.text.primary,backgroundColor:a.background.default,minHeight:"56px",paddingLeft:"16px",paddingRight:"8px"}},subHeader:{style:{backgroundColor:a.background.default,minHeight:"52px"}},head:{style:{color:a.text.primary,fontSize:"12px",fontWeight:500}},headRow:{style:{backgroundColor:a.background.default,minHeight:"52px",borderBottomWidth:"1px",borderBottomColor:a.divider.default,borderBottomStyle:"solid"},denseStyle:{minHeight:"32px"}},headCells:{style:{paddingLeft:"16px",paddingRight:"16px"},draggingStyle:{cursor:"move"}},contextMenu:{style:{backgroundColor:a.context.background,fontSize:"18px",fontWeight:400,color:a.context.text,paddingLeft:"16px",paddingRight:"8px",transform:"translate3d(0, -100%, 0)",transitionDuration:"125ms",transitionTimingFunction:"cubic-bezier(0, 0, 0.2, 1)",willChange:"transform"},activeStyle:{transform:"translate3d(0, 0, 0)"}},cells:{style:{paddingLeft:"16px",paddingRight:"16px",wordBreak:"break-word"},draggingStyle:{}},rows:{style:{fontSize:"13px",fontWeight:400,color:a.text.primary,backgroundColor:a.background.default,minHeight:"48px","&:not(:last-of-type)":{borderBottomStyle:"solid",borderBottomWidth:"1px",borderBottomColor:a.divider.default}},denseStyle:{minHeight:"32px"},selectedHighlightStyle:{"&:nth-of-type(n)":{color:a.selected.text,backgroundColor:a.selected.default,borderBottomColor:a.background.default}},highlightOnHoverStyle:{color:a.highlightOnHover.text,backgroundColor:a.highlightOnHover.default,transitionDuration:"0.15s",transitionProperty:"background-color",borderBottomColor:a.background.default,outlineStyle:"solid",outlineWidth:"1px",outlineColor:a.background.default},stripedStyle:{color:a.striped.text,backgroundColor:a.striped.default}},expanderRow:{style:{color:a.text.primary,backgroundColor:a.background.default}},expanderCell:{style:{flex:"0 0 48px"}},expanderButton:{style:{color:a.button.default,fill:a.button.default,backgroundColor:"transparent",borderRadius:"2px",transition:"0.25s",height:"100%",width:"100%","&:hover:enabled":{cursor:"pointer"},"&:disabled":{color:a.button.disabled},"&:hover:not(:disabled)":{cursor:"pointer",backgroundColor:a.button.hover},"&:focus":{outline:"none",backgroundColor:a.button.focus},svg:{margin:"auto"}}},pagination:{style:{color:a.text.secondary,fontSize:"13px",minHeight:"56px",backgroundColor:a.background.default,borderTopStyle:"solid",borderTopWidth:"1px",borderTopColor:a.divider.default},pageButtonsStyle:{borderRadius:"50%",height:"40px",width:"40px",padding:"8px",margin:"px",cursor:"pointer",transition:"0.4s",color:a.button.default,fill:a.button.default,backgroundColor:"transparent","&:disabled":{cursor:"unset",color:a.button.disabled,fill:a.button.disabled},"&:hover:not(:disabled)":{backgroundColor:a.button.hover},"&:focus":{outline:"none",backgroundColor:a.button.focus}}},noData:{style:{display:"flex",alignItems:"center",justifyContent:"center",color:a.text.primary,backgroundColor:a.background.default}},progress:{style:{display:"flex",alignItems:"center",justifyContent:"center",color:a.text.primary,backgroundColor:a.background.default}}},e);var a})(Xe,Qe)),[Xe,Qe]),kt=o.useMemo((()=>Object.assign({},"auto"!==et&&{dir:et})),[et]),Rt=o.useMemo((()=>{if(Ne)return t;if((null==ft?void 0:ft.sortFunction)&&"function"==typeof ft.sortFunction){const e=ft.sortFunction,n=bt===i.ASC?e:(t,n)=>-1*e(t,n);return[...t].sort(n)}return function(e,t,n,a){return t?a&&"function"==typeof a?a(e.slice(0),t,n):e.slice(0).sort(((e,a)=>{const l=t(e),r=t(a);if("asc"===n){if(l<r)return-1;if(l>r)return 1}if("desc"===n){if(l>r)return-1;if(l<r)return 1}return 0})):e}(t,null==ft?void 0:ft.selector,bt,De)}),[Ne,ft,bt,t,De]),Ot=o.useMemo((()=>{if(se&&!$){const e=mt*dt,t=e-dt;return Rt.slice(t,e)}return Rt}),[mt,se,$,dt,Rt]),Tt=o.useCallback((e=>{vt(e)}),[]),It=o.useCallback((e=>{vt(e)}),[]),At=o.useCallback((e=>{vt(e)}),[]),Dt=o.useCallback(((e,t)=>Ee(e,t)),[Ee]),Nt=o.useCallback(((e,t)=>ke(e,t)),[ke]),Ft=o.useCallback(((e,t)=>Re(e,t)),[Re]),$t=o.useCallback(((e,t)=>Oe(e,t)),[Oe]),Lt=o.useCallback((e=>vt({type:"CHANGE_PAGE",page:e,paginationServer:$,visibleOnly:S,persistSelectedOnPageChange:St})),[$,St,S]),jt=o.useCallback((e=>{const t=h(j||Ot.length,e),n=g(mt,t);$||Lt(n),vt({type:"CHANGE_ROWS_PER_PAGE",page:n,rowsPerPage:e})}),[mt,Lt,$,j,Ot.length]);if(se&&!$&&Rt.length>0&&0===Ot.length){const e=h(Rt.length,dt),t=g(mt,e);Lt(t)}Me((()=>{A({allSelected:gt,selectedCount:yt,selectedRows:ht.slice(0)})}),[Et]),Me((()=>{Ae(ft,bt,Rt.slice(0))}),[ft,bt]),Me((()=>{F(mt,j||Rt.length)}),[mt]),Me((()=>{N(dt,mt)}),[dt]),Me((()=>{Lt(H)}),[H,M]),Me((()=>{if(se&&$&&j>0){const e=h(j,dt),t=g(mt,e);mt!==t&&Lt(t)}}),[j]),o.useEffect((()=>{vt({type:"CLEAR_SELECTED_ROWS",selectedRowsFlag:qe})}),[f,qe]),o.useEffect((()=>{if(!_)return;const e=Rt.filter((e=>_(e))),t=f?e.slice(0,1):e;vt({type:"SELECT_MULTIPLE_ROWS",keyField:s,selectedRows:t,totalRows:Rt.length,mergeSelections:Ct})}),[t,_]);const Ht=S?Ot:Rt,Mt=St||f||v;return o.createElement(l.ThemeProvider,{theme:Pt},!ae&&(!!a||!!r)&&o.createElement(ye,{title:a,actions:r,showMenu:!me,selectedCount:yt,direction:et,contextActions:ge,contextComponent:fe,contextMessage:he}),ce&&o.createElement(ve,{align:pe,wrapContent:ue},de),o.createElement(Se,Object.assign({$responsive:Y,$fixedHeader:le,$fixedHeaderScrollHeight:ie,className:nt},kt),o.createElement(_e,null,K&&!X&&o.createElement(Ce,null,Z),o.createElement(C,{disabled:te,className:"rdt_Table",role:"table"},!ne&&(!!X||Rt.length>0&&!K)&&o.createElement(x,{className:"rdt_TableHead",role:"rowgroup",$fixedHeader:le},o.createElement(P,{className:"rdt_TableHeadRow",role:"row",$dense:m},y&&(Mt?o.createElement(T,{style:{flex:"0 0 48px"}}):o.createElement(oe,{allSelected:gt,selectedRows:ht,selectableRowsComponent:R,selectableRowsComponentProps:O,selectableRowDisabled:k,rowData:Ht,keyField:s,mergeSelections:Ct,onSelectAllRows:It})),be&&!je&&o.createElement(xe,null),at.map((e=>o.createElement(re,{key:e.id,column:e,selectedColumn:ft,disabled:K||0===Rt.length,pagination:se,paginationServer:$,persistSelectedOnSort:wt,selectableRowsVisibleOnly:S,sortDirection:bt,sortIcon:Te,sortServer:Ne,onSort:Tt,onDragStart:rt,onDragOver:ot,onDragEnd:ct,onDragEnter:it,onDragLeave:st,draggingColumnId:lt}))))),!Rt.length&&!K&&o.createElement(Pe,null,ee),K&&X&&o.createElement(Ce,null,Z),!K&&Rt.length>0&&o.createElement(we,{className:"rdt_TableBody",role:"rowgroup"},Ot.map(((e,t)=>{const n=p(e,s),a=function(e=""){return"number"!=typeof e&&(!e||0===e.length)}(n)?t:n,l=b(e,ht,s),r=!!(be&&Ue&&Ue(e)),i=!!(be&&Le&&Le(e));return o.createElement(Q,{id:a,key:a,keyField:s,"data-row-id":a,columns:at,row:e,rowCount:Rt.length,rowIndex:t,selectableRows:y,expandableRows:be,expandableIcon:D,highlightOnHover:u,pointerOnHover:d,dense:m,expandOnRowClicked:Be,expandOnRowDoubleClicked:ze,expandableRowsComponent:Fe,expandableRowsComponentProps:$e,expandableRowsHideExpander:je,defaultExpanderDisabled:i,defaultExpanded:r,expandableInheritConditionalStyles:We,conditionalRowStyles:Ye,selected:l,selectableRowsHighlight:E,selectableRowsComponent:R,selectableRowsComponentProps:O,selectableRowDisabled:k,selectableRowsSingle:f,striped:c,onRowExpandToggled:I,onRowClicked:Dt,onRowDoubleClicked:Nt,onRowMouseEnter:Ft,onRowMouseLeave:$t,onSelectedRow:At,draggingColumnId:lt,onDragStart:rt,onDragOver:ot,onDragEnd:ct,onDragEnter:it,onDragLeave:st})})))))),_t&&o.createElement("div",null,o.createElement(xt,{onChangePage:Lt,onChangeRowsPerPage:jt,rowCount:j||Rt.length,currentPage:mt,rowsPerPage:dt,direction:et,paginationRowsPerPageOptions:z,paginationIconLastPage:U,paginationIconFirstPage:W,paginationIconNext:G,paginationIconPrevious:V,paginationComponentOptions:J})))}));t.Ay=Qe},115:e=>{var t="undefined"!=typeof Element,n="function"==typeof Map,a="function"==typeof Set,l="function"==typeof ArrayBuffer&&!!ArrayBuffer.isView;function r(e,i){if(e===i)return!0;if(e&&i&&"object"==typeof e&&"object"==typeof i){if(e.constructor!==i.constructor)return!1;var o,s,c,p;if(Array.isArray(e)){if((o=e.length)!=i.length)return!1;for(s=o;0!=s--;)if(!r(e[s],i[s]))return!1;return!0}if(n&&e instanceof Map&&i instanceof Map){if(e.size!==i.size)return!1;for(p=e.entries();!(s=p.next()).done;)if(!i.has(s.value[0]))return!1;for(p=e.entries();!(s=p.next()).done;)if(!r(s.value[1],i.get(s.value[0])))return!1;return!0}if(a&&e instanceof Set&&i instanceof Set){if(e.size!==i.size)return!1;for(p=e.entries();!(s=p.next()).done;)if(!i.has(s.value[0]))return!1;return!0}if(l&&ArrayBuffer.isView(e)&&ArrayBuffer.isView(i)){if((o=e.length)!=i.length)return!1;for(s=o;0!=s--;)if(e[s]!==i[s])return!1;return!0}if(e.constructor===RegExp)return e.source===i.source&&e.flags===i.flags;if(e.valueOf!==Object.prototype.valueOf&&"function"==typeof e.valueOf&&"function"==typeof i.valueOf)return e.valueOf()===i.valueOf();if(e.toString!==Object.prototype.toString&&"function"==typeof e.toString&&"function"==typeof i.toString)return e.toString()===i.toString();if((o=(c=Object.keys(e)).length)!==Object.keys(i).length)return!1;for(s=o;0!=s--;)if(!Object.prototype.hasOwnProperty.call(i,c[s]))return!1;if(t&&e instanceof Element)return!1;for(s=o;0!=s--;)if(("_owner"!==c[s]&&"__v"!==c[s]&&"__o"!==c[s]||!e.$$typeof)&&!r(e[c[s]],i[c[s]]))return!1;return!0}return e!=e&&i!=i}e.exports=function(e,t){try{return r(e,t)}catch(e){if((e.message||"").match(/stack|recursion/i))return console.warn("react-fast-compare cannot handle circular refs"),!1;throw e}}},21:(e,t,n)=>{var a,l=Object.create,r=Object.defineProperty,i=Object.getOwnPropertyDescriptor,o=Object.getOwnPropertyNames,s=Object.getPrototypeOf,c=Object.prototype.hasOwnProperty,p=(e,t,n,a)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let l of o(t))c.call(e,l)||l===n||r(e,l,{get:()=>t[l],enumerable:!(a=i(t,l))||a.enumerable});return e},u=(e,t,n)=>(n=null!=e?l(s(e)):{},p(!t&&e&&e.__esModule?n:r(n,"default",{value:e,enumerable:!0}),e)),d=(e,t,n)=>(((e,t,n)=>{t in e?r(e,t,{enumerable:!0,configurable:!0,writable:!0,value:n}):e[t]=n})(e,"symbol"!=typeof t?t+"":t,n),n),m={};((e,t)=>{for(var n in t)r(e,n,{get:t[n],enumerable:!0})})(m,{default:()=>b}),e.exports=(a=m,p(r({},"__esModule",{value:!0}),a));var h=u(n(609)),g=u(n(115)),y=n(604),f=n(635);class b extends h.Component{constructor(){super(...arguments),d(this,"mounted",!1),d(this,"isReady",!1),d(this,"isPlaying",!1),d(this,"isLoading",!0),d(this,"loadOnReady",null),d(this,"startOnPlay",!0),d(this,"seekOnPlay",null),d(this,"onDurationCalled",!1),d(this,"handlePlayerMount",(e=>{this.player||(this.player=e,this.player.load(this.props.url)),this.progress()})),d(this,"getInternalPlayer",(e=>this.player?this.player[e]:null)),d(this,"progress",(()=>{if(this.props.url&&this.player&&this.isReady){const e=this.getCurrentTime()||0,t=this.getSecondsLoaded(),n=this.getDuration();if(n){const a={playedSeconds:e,played:e/n};null!==t&&(a.loadedSeconds=t,a.loaded=t/n),a.playedSeconds===this.prevPlayed&&a.loadedSeconds===this.prevLoaded||this.props.onProgress(a),this.prevPlayed=a.playedSeconds,this.prevLoaded=a.loadedSeconds}}this.progressTimeout=setTimeout(this.progress,this.props.progressFrequency||this.props.progressInterval)})),d(this,"handleReady",(()=>{if(!this.mounted)return;this.isReady=!0,this.isLoading=!1;const{onReady:e,playing:t,volume:n,muted:a}=this.props;e(),a||null===n||this.player.setVolume(n),this.loadOnReady?(this.player.load(this.loadOnReady,!0),this.loadOnReady=null):t&&this.player.play(),this.handleDurationCheck()})),d(this,"handlePlay",(()=>{this.isPlaying=!0,this.isLoading=!1;const{onStart:e,onPlay:t,playbackRate:n}=this.props;this.startOnPlay&&(this.player.setPlaybackRate&&1!==n&&this.player.setPlaybackRate(n),e(),this.startOnPlay=!1),t(),this.seekOnPlay&&(this.seekTo(this.seekOnPlay),this.seekOnPlay=null),this.handleDurationCheck()})),d(this,"handlePause",(e=>{this.isPlaying=!1,this.isLoading||this.props.onPause(e)})),d(this,"handleEnded",(()=>{const{activePlayer:e,loop:t,onEnded:n}=this.props;e.loopOnEnded&&t&&this.seekTo(0),t||(this.isPlaying=!1,n())})),d(this,"handleError",((...e)=>{this.isLoading=!1,this.props.onError(...e)})),d(this,"handleDurationCheck",(()=>{clearTimeout(this.durationCheckTimeout);const e=this.getDuration();e?this.onDurationCalled||(this.props.onDuration(e),this.onDurationCalled=!0):this.durationCheckTimeout=setTimeout(this.handleDurationCheck,100)})),d(this,"handleLoaded",(()=>{this.isLoading=!1}))}componentDidMount(){this.mounted=!0}componentWillUnmount(){clearTimeout(this.progressTimeout),clearTimeout(this.durationCheckTimeout),this.isReady&&this.props.stopOnUnmount&&(this.player.stop(),this.player.disablePIP&&this.player.disablePIP()),this.mounted=!1}componentDidUpdate(e){if(!this.player)return;const{url:t,playing:n,volume:a,muted:l,playbackRate:r,pip:i,loop:o,activePlayer:s,disableDeferredLoading:c}=this.props;if(!(0,g.default)(e.url,t)){if(this.isLoading&&!s.forceLoad&&!c&&!(0,f.isMediaStream)(t))return console.warn(`ReactPlayer: the attempt to load ${t} is being deferred until the player has loaded`),void(this.loadOnReady=t);this.isLoading=!0,this.startOnPlay=!0,this.onDurationCalled=!1,this.player.load(t,this.isReady)}e.playing||!n||this.isPlaying||this.player.play(),e.playing&&!n&&this.isPlaying&&this.player.pause(),!e.pip&&i&&this.player.enablePIP&&this.player.enablePIP(),e.pip&&!i&&this.player.disablePIP&&this.player.disablePIP(),e.volume!==a&&null!==a&&this.player.setVolume(a),e.muted!==l&&(l?this.player.mute():(this.player.unmute(),null!==a&&setTimeout((()=>this.player.setVolume(a))))),e.playbackRate!==r&&this.player.setPlaybackRate&&this.player.setPlaybackRate(r),e.loop!==o&&this.player.setLoop&&this.player.setLoop(o)}getDuration(){return this.isReady?this.player.getDuration():null}getCurrentTime(){return this.isReady?this.player.getCurrentTime():null}getSecondsLoaded(){return this.isReady?this.player.getSecondsLoaded():null}seekTo(e,t,n){if(this.isReady){if(t?"fraction"===t:e>0&&e<1){const t=this.player.getDuration();return t?void this.player.seekTo(t*e,n):void console.warn("ReactPlayer: could not seek using fraction – duration not yet available")}this.player.seekTo(e,n)}else 0!==e&&(this.seekOnPlay=e,setTimeout((()=>{this.seekOnPlay=null}),5e3))}render(){const e=this.props.activePlayer;return e?h.default.createElement(e,{...this.props,onMount:this.handlePlayerMount,onReady:this.handleReady,onPlay:this.handlePlay,onPause:this.handlePause,onEnded:this.handleEnded,onLoaded:this.handleLoaded,onError:this.handleError}):null}}d(b,"displayName","Player"),d(b,"propTypes",y.propTypes),d(b,"defaultProps",y.defaultProps)},580:(e,t,n)=>{var a,l=Object.create,r=Object.defineProperty,i=Object.getOwnPropertyDescriptor,o=Object.getOwnPropertyNames,s=Object.getPrototypeOf,c=Object.prototype.hasOwnProperty,p=(e,t,n,a)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let l of o(t))c.call(e,l)||l===n||r(e,l,{get:()=>t[l],enumerable:!(a=i(t,l))||a.enumerable});return e},u=(e,t,n)=>(n=null!=e?l(s(e)):{},p(!t&&e&&e.__esModule?n:r(n,"default",{value:e,enumerable:!0}),e)),d=(e,t,n)=>(((e,t,n)=>{t in e?r(e,t,{enumerable:!0,configurable:!0,writable:!0,value:n}):e[t]=n})(e,"symbol"!=typeof t?t+"":t,n),n),m={};((e,t)=>{for(var n in t)r(e,n,{get:t[n],enumerable:!0})})(m,{createReactPlayer:()=>k}),e.exports=(a=m,p(r({},"__esModule",{value:!0}),a));var h=u(n(609)),g=u(n(744)),y=u(n(811)),f=u(n(115)),b=n(604),E=n(635),v=u(n(21));const w=(0,E.lazy)((()=>n.e(353).then(n.t.bind(n,734,23)))),S="undefined"!=typeof window&&window.document&&"undefined"!=typeof document,C=void 0!==n.g&&n.g.window&&n.g.window.document,_=Object.keys(b.propTypes),x=S||C?h.Suspense:()=>null,P=[],k=(e,t)=>{var n;return n=class extends h.Component{constructor(){super(...arguments),d(this,"state",{showPreview:!!this.props.light}),d(this,"references",{wrapper:e=>{this.wrapper=e},player:e=>{this.player=e}}),d(this,"handleClickPreview",(e=>{this.setState({showPreview:!1}),this.props.onClickPreview(e)})),d(this,"showPreview",(()=>{this.setState({showPreview:!0})})),d(this,"getDuration",(()=>this.player?this.player.getDuration():null)),d(this,"getCurrentTime",(()=>this.player?this.player.getCurrentTime():null)),d(this,"getSecondsLoaded",(()=>this.player?this.player.getSecondsLoaded():null)),d(this,"getInternalPlayer",((e="player")=>this.player?this.player.getInternalPlayer(e):null)),d(this,"seekTo",((e,t,n)=>{if(!this.player)return null;this.player.seekTo(e,t,n)})),d(this,"handleReady",(()=>{this.props.onReady(this)})),d(this,"getActivePlayer",(0,y.default)((n=>{for(const t of[...P,...e])if(t.canPlay(n))return t;return t||null}))),d(this,"getConfig",(0,y.default)(((e,t)=>{const{config:n}=this.props;return g.default.all([b.defaultProps.config,b.defaultProps.config[t]||{},n,n[t]||{}])}))),d(this,"getAttributes",(0,y.default)((e=>(0,E.omit)(this.props,_)))),d(this,"renderActivePlayer",(e=>{if(!e)return null;const t=this.getActivePlayer(e);if(!t)return null;const n=this.getConfig(e,t.key);return h.default.createElement(v.default,{...this.props,key:t.key,ref:this.references.player,config:n,activePlayer:t.lazyPlayer||t,onReady:this.handleReady})}))}shouldComponentUpdate(e,t){return!(0,f.default)(this.props,e)||!(0,f.default)(this.state,t)}componentDidUpdate(e){const{light:t}=this.props;!e.light&&t&&this.setState({showPreview:!0}),e.light&&!t&&this.setState({showPreview:!1})}renderPreview(e){if(!e)return null;const{light:t,playIcon:n,previewTabIndex:a,oEmbedUrl:l,previewAriaLabel:r}=this.props;return h.default.createElement(w,{url:e,light:t,playIcon:n,previewTabIndex:a,previewAriaLabel:r,oEmbedUrl:l,onClick:this.handleClickPreview})}render(){const{url:e,style:t,width:n,height:a,fallback:l,wrapper:r}=this.props,{showPreview:i}=this.state,o=this.getAttributes(e),s="string"==typeof r?this.references.wrapper:void 0;return h.default.createElement(r,{ref:s,style:{...t,width:n,height:a},...o},h.default.createElement(x,{fallback:l},i?this.renderPreview(e):this.renderActivePlayer(e)))}},d(n,"displayName","ReactPlayer"),d(n,"propTypes",b.propTypes),d(n,"defaultProps",b.defaultProps),d(n,"addCustomPlayer",(e=>{P.push(e)})),d(n,"removeCustomPlayers",(()=>{P.length=0})),d(n,"canPlay",(t=>{for(const n of[...P,...e])if(n.canPlay(t))return!0;return!1})),d(n,"canEnablePIP",(t=>{for(const n of[...P,...e])if(n.canEnablePIP&&n.canEnablePIP(t))return!0;return!1})),n}},554:(e,t,n)=>{var a,l=Object.create,r=Object.defineProperty,i=Object.getOwnPropertyDescriptor,o=Object.getOwnPropertyNames,s=Object.getPrototypeOf,c=Object.prototype.hasOwnProperty,p=(e,t,n,a)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let l of o(t))c.call(e,l)||l===n||r(e,l,{get:()=>t[l],enumerable:!(a=i(t,l))||a.enumerable});return e},u={};((e,t)=>{for(var n in t)r(e,n,{get:t[n],enumerable:!0})})(u,{default:()=>g}),e.exports=(a=u,p(r({},"__esModule",{value:!0}),a));var d=((e,t,n)=>(n=null!=e?l(s(e)):{},p(e&&e.__esModule?n:r(n,"default",{value:e,enumerable:!0}),e)))(n(15)),m=n(580);const h=d.default[d.default.length-1];var g=(0,m.createReactPlayer)(d.default,h)},327:(e,t,n)=>{var a,l=Object.defineProperty,r=Object.getOwnPropertyDescriptor,i=Object.getOwnPropertyNames,o=Object.prototype.hasOwnProperty,s={};((e,t)=>{for(var n in t)l(e,n,{get:t[n],enumerable:!0})})(s,{AUDIO_EXTENSIONS:()=>_,DASH_EXTENSIONS:()=>k,FLV_EXTENSIONS:()=>R,HLS_EXTENSIONS:()=>P,MATCH_URL_DAILYMOTION:()=>v,MATCH_URL_FACEBOOK:()=>h,MATCH_URL_FACEBOOK_WATCH:()=>g,MATCH_URL_KALTURA:()=>C,MATCH_URL_MIXCLOUD:()=>w,MATCH_URL_MUX:()=>m,MATCH_URL_SOUNDCLOUD:()=>u,MATCH_URL_STREAMABLE:()=>y,MATCH_URL_TWITCH_CHANNEL:()=>E,MATCH_URL_TWITCH_VIDEO:()=>b,MATCH_URL_VIDYARD:()=>S,MATCH_URL_VIMEO:()=>d,MATCH_URL_WISTIA:()=>f,MATCH_URL_YOUTUBE:()=>p,VIDEO_EXTENSIONS:()=>x,canPlay:()=>T}),e.exports=(a=s,((e,t,n,a)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let n of i(t))o.call(e,n)||undefined===n||l(e,n,{get:()=>t[n],enumerable:!(a=r(t,n))||a.enumerable});return e})(l({},"__esModule",{value:!0}),a));var c=n(635);const p=/(?:youtu\.be\/|youtube(?:-nocookie|education)?\.com\/(?:embed\/|v\/|watch\/|watch\?v=|watch\?.+&v=|shorts\/|live\/))((\w|-){11})|youtube\.com\/playlist\?list=|youtube\.com\/user\//,u=/(?:soundcloud\.com|snd\.sc)\/[^.]+$/,d=/vimeo\.com\/(?!progressive_redirect).+/,m=/stream\.mux\.com\/(?!\w+\.m3u8)(\w+)/,h=/^https?:\/\/(www\.)?facebook\.com.*\/(video(s)?|watch|story)(\.php?|\/).+$/,g=/^https?:\/\/fb\.watch\/.+$/,y=/streamable\.com\/([a-z0-9]+)$/,f=/(?:wistia\.(?:com|net)|wi\.st)\/(?:medias|embed)\/(?:iframe\/)?([^?]+)/,b=/(?:www\.|go\.)?twitch\.tv\/videos\/(\d+)($|\?)/,E=/(?:www\.|go\.)?twitch\.tv\/([a-zA-Z0-9_]+)($|\?)/,v=/^(?:(?:https?):)?(?:\/\/)?(?:www\.)?(?:(?:dailymotion\.com(?:\/embed)?\/video)|dai\.ly)\/([a-zA-Z0-9]+)(?:_[\w_-]+)?(?:[\w.#_-]+)?/,w=/mixcloud\.com\/([^/]+\/[^/]+)/,S=/vidyard.com\/(?:watch\/)?([a-zA-Z0-9-_]+)/,C=/^https?:\/\/[a-zA-Z]+\.kaltura.(com|org)\/p\/([0-9]+)\/sp\/([0-9]+)00\/embedIframeJs\/uiconf_id\/([0-9]+)\/partner_id\/([0-9]+)(.*)entry_id.([a-zA-Z0-9-_].*)$/,_=/\.(m4a|m4b|mp4a|mpga|mp2|mp2a|mp3|m2a|m3a|wav|weba|aac|oga|spx)($|\?)/i,x=/\.(mp4|og[gv]|webm|mov|m4v)(#t=[,\d+]+)?($|\?)/i,P=/\.(m3u8)($|\?)/i,k=/\.(mpd)($|\?)/i,R=/\.(flv)($|\?)/i,O=e=>{if(e instanceof Array){for(const t of e){if("string"==typeof t&&O(t))return!0;if(O(t.src))return!0}return!1}return!(!(0,c.isMediaStream)(e)&&!(0,c.isBlobUrl)(e))||_.test(e)||x.test(e)||P.test(e)||k.test(e)||R.test(e)},T={youtube:e=>e instanceof Array?e.every((e=>p.test(e))):p.test(e),soundcloud:e=>u.test(e)&&!_.test(e),vimeo:e=>d.test(e)&&!x.test(e)&&!P.test(e),mux:e=>m.test(e),facebook:e=>h.test(e)||g.test(e),streamable:e=>y.test(e),wistia:e=>f.test(e),twitch:e=>b.test(e)||E.test(e),dailymotion:e=>v.test(e),mixcloud:e=>w.test(e),vidyard:e=>S.test(e),kaltura:e=>C.test(e),file:O}},15:(e,t,n)=>{Object.create;var a,l=Object.defineProperty,r=Object.getOwnPropertyDescriptor,i=Object.getOwnPropertyNames,o=(Object.getPrototypeOf,Object.prototype.hasOwnProperty),s={};((e,t)=>{for(var n in t)l(e,n,{get:t[n],enumerable:!0})})(s,{default:()=>u}),e.exports=(a=s,((e,t,n,a)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let s of i(t))o.call(e,s)||s===n||l(e,s,{get:()=>t[s],enumerable:!(a=r(t,s))||a.enumerable});return e})(l({},"__esModule",{value:!0}),a));var c=n(635),p=n(327),u=[{key:"youtube",name:"YouTube",canPlay:p.canPlay.youtube,lazyPlayer:(0,c.lazy)((()=>n.e(446).then(n.t.bind(n,910,23))))},{key:"soundcloud",name:"SoundCloud",canPlay:p.canPlay.soundcloud,lazyPlayer:(0,c.lazy)((()=>n.e(979).then(n.t.bind(n,127,23))))},{key:"vimeo",name:"Vimeo",canPlay:p.canPlay.vimeo,lazyPlayer:(0,c.lazy)((()=>n.e(173).then(n.t.bind(n,423,23))))},{key:"mux",name:"Mux",canPlay:p.canPlay.mux,lazyPlayer:(0,c.lazy)((()=>n.e(723).then(n.t.bind(n,553,23))))},{key:"facebook",name:"Facebook",canPlay:p.canPlay.facebook,lazyPlayer:(0,c.lazy)((()=>n.e(887).then(n.t.bind(n,343,23))))},{key:"streamable",name:"Streamable",canPlay:p.canPlay.streamable,lazyPlayer:(0,c.lazy)((()=>n.e(627).then(n.t.bind(n,643,23))))},{key:"wistia",name:"Wistia",canPlay:p.canPlay.wistia,lazyPlayer:(0,c.lazy)((()=>n.e(340).then(n.t.bind(n,330,23))))},{key:"twitch",name:"Twitch",canPlay:p.canPlay.twitch,lazyPlayer:(0,c.lazy)((()=>n.e(42).then(n.t.bind(n,400,23))))},{key:"dailymotion",name:"DailyMotion",canPlay:p.canPlay.dailymotion,lazyPlayer:(0,c.lazy)((()=>n.e(328).then(n.t.bind(n,348,23))))},{key:"mixcloud",name:"Mixcloud",canPlay:p.canPlay.mixcloud,lazyPlayer:(0,c.lazy)((()=>n.e(570).then(n.t.bind(n,276,23))))},{key:"vidyard",name:"Vidyard",canPlay:p.canPlay.vidyard,lazyPlayer:(0,c.lazy)((()=>n.e(392).then(n.t.bind(n,552,23))))},{key:"kaltura",name:"Kaltura",canPlay:p.canPlay.kaltura,lazyPlayer:(0,c.lazy)((()=>n.e(463).then(n.t.bind(n,945,23))))},{key:"file",name:"FilePlayer",canPlay:p.canPlay.file,canEnablePIP:e=>p.canPlay.file(e)&&(document.pictureInPictureEnabled||(0,c.supportsWebKitPresentationMode)())&&!p.AUDIO_EXTENSIONS.test(e),lazyPlayer:(0,c.lazy)((()=>n.e(458).then(n.t.bind(n,688,23))))}]},604:(e,t,n)=>{var a,l=Object.create,r=Object.defineProperty,i=Object.getOwnPropertyDescriptor,o=Object.getOwnPropertyNames,s=Object.getPrototypeOf,c=Object.prototype.hasOwnProperty,p=(e,t,n,a)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let l of o(t))c.call(e,l)||l===n||r(e,l,{get:()=>t[l],enumerable:!(a=i(t,l))||a.enumerable});return e},u={};((e,t)=>{for(var n in t)r(e,n,{get:t[n],enumerable:!0})})(u,{defaultProps:()=>_,propTypes:()=>S}),e.exports=(a=u,p(r({},"__esModule",{value:!0}),a));var d=((e,t,n)=>(n=null!=e?l(s(e)):{},p(e&&e.__esModule?n:r(n,"default",{value:e,enumerable:!0}),e)))(n(556));const{string:m,bool:h,number:g,array:y,oneOfType:f,shape:b,object:E,func:v,node:w}=d.default,S={url:f([m,y,E]),playing:h,loop:h,controls:h,volume:g,muted:h,playbackRate:g,width:f([m,g]),height:f([m,g]),style:E,progressInterval:g,playsinline:h,pip:h,stopOnUnmount:h,light:f([h,m,E]),playIcon:w,previewTabIndex:g,previewAriaLabel:m,fallback:w,oEmbedUrl:m,wrapper:f([m,v,b({render:v.isRequired})]),config:b({soundcloud:b({options:E}),youtube:b({playerVars:E,embedOptions:E,onUnstarted:v}),facebook:b({appId:m,version:m,playerId:m,attributes:E}),dailymotion:b({params:E}),vimeo:b({playerOptions:E,title:m}),mux:b({attributes:E,version:m}),file:b({attributes:E,tracks:y,forceVideo:h,forceAudio:h,forceHLS:h,forceSafariHLS:h,forceDisableHls:h,forceDASH:h,forceFLV:h,hlsOptions:E,hlsVersion:m,dashVersion:m,flvVersion:m}),wistia:b({options:E,playerId:m,customControls:y}),mixcloud:b({options:E}),twitch:b({options:E,playerId:m}),vidyard:b({options:E})}),onReady:v,onStart:v,onPlay:v,onPause:v,onBuffer:v,onBufferEnd:v,onEnded:v,onError:v,onDuration:v,onSeek:v,onPlaybackRateChange:v,onPlaybackQualityChange:v,onProgress:v,onClickPreview:v,onEnablePIP:v,onDisablePIP:v},C=()=>{},_={playing:!1,loop:!1,controls:!1,volume:null,muted:!1,playbackRate:1,width:"640px",height:"360px",style:{},progressInterval:1e3,playsinline:!1,pip:!1,stopOnUnmount:!0,light:!1,fallback:null,wrapper:"div",previewTabIndex:0,previewAriaLabel:"",oEmbedUrl:"https://noembed.com/embed?url={url}",config:{soundcloud:{options:{visual:!0,buying:!1,liking:!1,download:!1,sharing:!1,show_comments:!1,show_playcount:!1}},youtube:{playerVars:{playsinline:1,showinfo:0,rel:0,iv_load_policy:3,modestbranding:1},embedOptions:{},onUnstarted:C},facebook:{appId:"1309697205772819",version:"v3.3",playerId:null,attributes:{}},dailymotion:{params:{api:1,"endscreen-enable":!1}},vimeo:{playerOptions:{autopause:!1,byline:!1,portrait:!1,title:!1},title:null},mux:{attributes:{},version:"2"},file:{attributes:{},tracks:[],forceVideo:!1,forceAudio:!1,forceHLS:!1,forceDASH:!1,forceFLV:!1,hlsOptions:{},hlsVersion:"1.1.4",dashVersion:"3.1.3",flvVersion:"1.5.0",forceDisableHls:!1},wistia:{options:{},playerId:null,customControls:null},mixcloud:{options:{hide_cover:1}},twitch:{options:{},playerId:null},vidyard:{options:{}}},onReady:C,onStart:C,onPlay:C,onPause:C,onBuffer:C,onBufferEnd:C,onEnded:C,onError:C,onDuration:C,onSeek:C,onPlaybackRateChange:C,onPlaybackQualityChange:C,onProgress:C,onClickPreview:C,onEnablePIP:C,onDisablePIP:C}},635:(e,t,n)=>{var a,l=Object.create,r=Object.defineProperty,i=Object.getOwnPropertyDescriptor,o=Object.getOwnPropertyNames,s=Object.getPrototypeOf,c=Object.prototype.hasOwnProperty,p=(e,t,n,a)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let l of o(t))c.call(e,l)||l===n||r(e,l,{get:()=>t[l],enumerable:!(a=i(t,l))||a.enumerable});return e},u=(e,t,n)=>(n=null!=e?l(s(e)):{},p(!t&&e&&e.__esModule?n:r(n,"default",{value:e,enumerable:!0}),e)),d={};((e,t)=>{for(var n in t)r(e,n,{get:t[n],enumerable:!0})})(d,{callPlayer:()=>I,getConfig:()=>O,getSDK:()=>R,isBlobUrl:()=>D,isMediaStream:()=>A,lazy:()=>y,omit:()=>T,parseEndTime:()=>C,parseStartTime:()=>S,queryString:()=>x,randomString:()=>_,supportsWebKitPresentationMode:()=>N}),e.exports=(a=d,p(r({},"__esModule",{value:!0}),a));var m=u(n(609)),h=u(n(147)),g=u(n(744));const y=e=>m.default.lazy((async()=>{const t=await e();return"function"==typeof t.default?t:t.default})),f=/[?&#](?:start|t)=([0-9hms]+)/,b=/[?&#]end=([0-9hms]+)/,E=/(\d+)(h|m|s)/g,v=/^\d+$/;function w(e,t){if(e instanceof Array)return;const n=e.match(t);if(n){const e=n[1];if(e.match(E))return function(e){let t=0,n=E.exec(e);for(;null!==n;){const[,a,l]=n;"h"===l&&(t+=60*parseInt(a,10)*60),"m"===l&&(t+=60*parseInt(a,10)),"s"===l&&(t+=parseInt(a,10)),n=E.exec(e)}return t}(e);if(v.test(e))return parseInt(e)}}function S(e){return w(e,f)}function C(e){return w(e,b)}function _(){return Math.random().toString(36).substr(2,5)}function x(e){return Object.keys(e).map((t=>`${t}=${e[t]}`)).join("&")}function P(e){return window[e]?window[e]:window.exports&&window.exports[e]?window.exports[e]:window.module&&window.module.exports&&window.module.exports[e]?window.module.exports[e]:null}const k={},R=function(e,t,n=null,a=()=>!0,l=h.default){const r=P(t);return r&&a(r)?Promise.resolve(r):new Promise(((a,r)=>{if(k[e])return void k[e].push({resolve:a,reject:r});k[e]=[{resolve:a,reject:r}];const i=t=>{k[e].forEach((e=>e.resolve(t)))};if(n){const e=window[n];window[n]=function(){e&&e(),i(P(t))}}l(e,(a=>{a?(k[e].forEach((e=>e.reject(a))),k[e]=null):n||i(P(t))}))}))};function O(e,t){return(0,g.default)(t.config,e.config)}function T(e,...t){const n=[].concat(...t),a={},l=Object.keys(e);for(const t of l)-1===n.indexOf(t)&&(a[t]=e[t]);return a}function I(e,...t){if(!this.player||!this.player[e]){let t=`ReactPlayer: ${this.constructor.displayName} player could not call %c${e}%c – `;return this.player?this.player[e]||(t+="The method was not available"):t+="The player was not available",console.warn(t,"font-weight: bold",""),null}return this.player[e](...t)}function A(e){return"undefined"!=typeof window&&void 0!==window.MediaStream&&e instanceof window.MediaStream}function D(e){return/^blob:/.test(e)}function N(e=document.createElement("video")){const t=!1===/iPhone|iPod/.test(navigator.userAgent);return e.webkitSupportsPresentationMode&&"function"==typeof e.webkitSetPresentationMode&&t}},833:e=>{e.exports=function(e,t,n,a){var l=n?n.call(a,e,t):void 0;if(void 0!==l)return!!l;if(e===t)return!0;if("object"!=typeof e||!e||"object"!=typeof t||!t)return!1;var r=Object.keys(e),i=Object.keys(t);if(r.length!==i.length)return!1;for(var o=Object.prototype.hasOwnProperty.bind(t),s=0;s<r.length;s++){var c=r[s];if(!o(c))return!1;var p=e[c],u=t[c];if(!1===(l=n?n.call(a,p,u,c):void 0)||void 0===l&&p!==u)return!1}return!0}},510:(e,t,n)=>{"use strict";n.r(t),n.d(t,{ServerStyleSheet:()=>ln,StyleSheetConsumer:()=>Ot,StyleSheetContext:()=>Rt,StyleSheetManager:()=>At,ThemeConsumer:()=>Ut,ThemeContext:()=>zt,ThemeProvider:()=>Gt,__PRIVATE__:()=>rn,createGlobalStyle:()=>tn,css:()=>Kt,default:()=>Xt,isStyledComponent:()=>Ke,keyframes:()=>nn,styled:()=>Xt,useTheme:()=>Wt,version:()=>ue,withTheme:()=>an});var a=function(){return a=Object.assign||function(e){for(var t,n=1,a=arguments.length;n<a;n++)for(var l in t=arguments[n])Object.prototype.hasOwnProperty.call(t,l)&&(e[l]=t[l]);return e},a.apply(this,arguments)};function l(e,t,n){if(n||2===arguments.length)for(var a,l=0,r=t.length;l<r;l++)!a&&l in t||(a||(a=Array.prototype.slice.call(t,0,l)),a[l]=t[l]);return e.concat(a||Array.prototype.slice.call(t))}Object.create,Object.create,"function"==typeof SuppressedError&&SuppressedError;var r=n(609),i=n.n(r),o=n(833),s=n.n(o),c="-ms-",p="-moz-",u="-webkit-",d="comm",m="rule",h="decl",g="@import",y="@keyframes",f="@layer",b=Math.abs,E=String.fromCharCode,v=Object.assign;function w(e){return e.trim()}function S(e,t){return(e=t.exec(e))?e[0]:e}function C(e,t,n){return e.replace(t,n)}function _(e,t,n){return e.indexOf(t,n)}function x(e,t){return 0|e.charCodeAt(t)}function P(e,t,n){return e.slice(t,n)}function k(e){return e.length}function R(e){return e.length}function O(e,t){return t.push(e),e}function T(e,t){return e.filter((function(e){return!S(e,t)}))}var I=1,A=1,D=0,N=0,F=0,$="";function L(e,t,n,a,l,r,i,o){return{value:e,root:t,parent:n,type:a,props:l,children:r,line:I,column:A,length:i,return:"",siblings:o}}function j(e,t){return v(L("",null,null,"",null,null,0,e.siblings),e,{length:-e.length},t)}function H(e){for(;e.root;)e=j(e.root,{children:[e]});O(e,e.siblings)}function M(){return F=N>0?x($,--N):0,A--,10===F&&(A=1,I--),F}function B(){return F=N<D?x($,N++):0,A++,10===F&&(A=1,I++),F}function z(){return x($,N)}function U(){return N}function W(e,t){return P($,e,t)}function G(e){switch(e){case 0:case 9:case 10:case 13:case 32:return 5;case 33:case 43:case 44:case 47:case 62:case 64:case 126:case 59:case 123:case 125:return 4;case 58:return 3;case 34:case 39:case 40:case 91:return 2;case 41:case 93:return 1}return 0}function V(e){return w(W(N-1,Y(91===e?e+2:40===e?e+1:e)))}function q(e){for(;(F=z())&&F<33;)B();return G(e)>2||G(F)>3?"":" "}function J(e,t){for(;--t&&B()&&!(F<48||F>102||F>57&&F<65||F>70&&F<97););return W(e,U()+(t<6&&32==z()&&32==B()))}function Y(e){for(;B();)switch(F){case e:return N;case 34:case 39:34!==e&&39!==e&&Y(F);break;case 40:41===e&&Y(e);break;case 92:B()}return N}function K(e,t){for(;B()&&e+F!==57&&(e+F!==84||47!==z()););return"/*"+W(t,N-1)+"*"+E(47===e?e:B())}function Z(e){for(;!G(z());)B();return W(e,N)}function Q(e,t){for(var n="",a=0;a<e.length;a++)n+=t(e[a],a,e,t)||"";return n}function X(e,t,n,a){switch(e.type){case f:if(e.children.length)break;case g:case h:return e.return=e.return||e.value;case d:return"";case y:return e.return=e.value+"{"+Q(e.children,a)+"}";case m:if(!k(e.value=e.props.join(",")))return""}return k(n=Q(e.children,a))?e.return=e.value+"{"+n+"}":""}function ee(e,t,n){switch(function(e,t){return 45^x(e,0)?(((t<<2^x(e,0))<<2^x(e,1))<<2^x(e,2))<<2^x(e,3):0}(e,t)){case 5103:return u+"print-"+e+e;case 5737:case 4201:case 3177:case 3433:case 1641:case 4457:case 2921:case 5572:case 6356:case 5844:case 3191:case 6645:case 3005:case 6391:case 5879:case 5623:case 6135:case 4599:case 4855:case 4215:case 6389:case 5109:case 5365:case 5621:case 3829:return u+e+e;case 4789:return p+e+e;case 5349:case 4246:case 4810:case 6968:case 2756:return u+e+p+e+c+e+e;case 5936:switch(x(e,t+11)){case 114:return u+e+c+C(e,/[svh]\w+-[tblr]{2}/,"tb")+e;case 108:return u+e+c+C(e,/[svh]\w+-[tblr]{2}/,"tb-rl")+e;case 45:return u+e+c+C(e,/[svh]\w+-[tblr]{2}/,"lr")+e}case 6828:case 4268:case 2903:return u+e+c+e+e;case 6165:return u+e+c+"flex-"+e+e;case 5187:return u+e+C(e,/(\w+).+(:[^]+)/,u+"box-$1$2"+c+"flex-$1$2")+e;case 5443:return u+e+c+"flex-item-"+C(e,/flex-|-self/g,"")+(S(e,/flex-|baseline/)?"":c+"grid-row-"+C(e,/flex-|-self/g,""))+e;case 4675:return u+e+c+"flex-line-pack"+C(e,/align-content|flex-|-self/g,"")+e;case 5548:return u+e+c+C(e,"shrink","negative")+e;case 5292:return u+e+c+C(e,"basis","preferred-size")+e;case 6060:return u+"box-"+C(e,"-grow","")+u+e+c+C(e,"grow","positive")+e;case 4554:return u+C(e,/([^-])(transform)/g,"$1"+u+"$2")+e;case 6187:return C(C(C(e,/(zoom-|grab)/,u+"$1"),/(image-set)/,u+"$1"),e,"")+e;case 5495:case 3959:return C(e,/(image-set\([^]*)/,u+"$1$`$1");case 4968:return C(C(e,/(.+:)(flex-)?(.*)/,u+"box-pack:$3"+c+"flex-pack:$3"),/s.+-b[^;]+/,"justify")+u+e+e;case 4200:if(!S(e,/flex-|baseline/))return c+"grid-column-align"+P(e,t)+e;break;case 2592:case 3360:return c+C(e,"template-","")+e;case 4384:case 3616:return n&&n.some((function(e,n){return t=n,S(e.props,/grid-\w+-end/)}))?~_(e+(n=n[t].value),"span",0)?e:c+C(e,"-start","")+e+c+"grid-row-span:"+(~_(n,"span",0)?S(n,/\d+/):+S(n,/\d+/)-+S(e,/\d+/))+";":c+C(e,"-start","")+e;case 4896:case 4128:return n&&n.some((function(e){return S(e.props,/grid-\w+-start/)}))?e:c+C(C(e,"-end","-span"),"span ","")+e;case 4095:case 3583:case 4068:case 2532:return C(e,/(.+)-inline(.+)/,u+"$1$2")+e;case 8116:case 7059:case 5753:case 5535:case 5445:case 5701:case 4933:case 4677:case 5533:case 5789:case 5021:case 4765:if(k(e)-1-t>6)switch(x(e,t+1)){case 109:if(45!==x(e,t+4))break;case 102:return C(e,/(.+:)(.+)-([^]+)/,"$1"+u+"$2-$3$1"+p+(108==x(e,t+3)?"$3":"$2-$3"))+e;case 115:return~_(e,"stretch",0)?ee(C(e,"stretch","fill-available"),t,n)+e:e}break;case 5152:case 5920:return C(e,/(.+?):(\d+)(\s*\/\s*(span)?\s*(\d+))?(.*)/,(function(t,n,a,l,r,i,o){return c+n+":"+a+o+(l?c+n+"-span:"+(r?i:+i-+a)+o:"")+e}));case 4949:if(121===x(e,t+6))return C(e,":",":"+u)+e;break;case 6444:switch(x(e,45===x(e,14)?18:11)){case 120:return C(e,/(.+:)([^;\s!]+)(;|(\s+)?!.+)?/,"$1"+u+(45===x(e,14)?"inline-":"")+"box$3$1"+u+"$2$3$1"+c+"$2box$3")+e;case 100:return C(e,":",":"+c)+e}break;case 5719:case 2647:case 2135:case 3927:case 2391:return C(e,"scroll-","scroll-snap-")+e}return e}function te(e,t,n,a){if(e.length>-1&&!e.return)switch(e.type){case h:return void(e.return=ee(e.value,e.length,n));case y:return Q([j(e,{value:C(e.value,"@","@"+u)})],a);case m:if(e.length)return function(e,t){return e.map(t).join("")}(n=e.props,(function(t){switch(S(t,a=/(::plac\w+|:read-\w+)/)){case":read-only":case":read-write":H(j(e,{props:[C(t,/:(read-\w+)/,":"+p+"$1")]})),H(j(e,{props:[t]})),v(e,{props:T(n,a)});break;case"::placeholder":H(j(e,{props:[C(t,/:(plac\w+)/,":"+u+"input-$1")]})),H(j(e,{props:[C(t,/:(plac\w+)/,":"+p+"$1")]})),H(j(e,{props:[C(t,/:(plac\w+)/,c+"input-$1")]})),H(j(e,{props:[t]})),v(e,{props:T(n,a)})}return""}))}}function ne(e){return function(e){return $="",e}(ae("",null,null,null,[""],e=function(e){return I=A=1,D=k($=e),N=0,[]}(e),0,[0],e))}function ae(e,t,n,a,l,r,i,o,s){for(var c=0,p=0,u=i,d=0,m=0,h=0,g=1,y=1,f=1,v=0,w="",S=l,P=r,R=a,T=w;y;)switch(h=v,v=B()){case 40:if(108!=h&&58==x(T,u-1)){-1!=_(T+=C(V(v),"&","&\f"),"&\f",b(c?o[c-1]:0))&&(f=-1);break}case 34:case 39:case 91:T+=V(v);break;case 9:case 10:case 13:case 32:T+=q(h);break;case 92:T+=J(U()-1,7);continue;case 47:switch(z()){case 42:case 47:O(re(K(B(),U()),t,n,s),s);break;default:T+="/"}break;case 123*g:o[c++]=k(T)*f;case 125*g:case 59:case 0:switch(v){case 0:case 125:y=0;case 59+p:-1==f&&(T=C(T,/\f/g,"")),m>0&&k(T)-u&&O(m>32?ie(T+";",a,n,u-1,s):ie(C(T," ","")+";",a,n,u-2,s),s);break;case 59:T+=";";default:if(O(R=le(T,t,n,c,p,l,o,w,S=[],P=[],u,r),r),123===v)if(0===p)ae(T,t,R,R,S,r,u,o,P);else switch(99===d&&110===x(T,3)?100:d){case 100:case 108:case 109:case 115:ae(e,R,R,a&&O(le(e,R,R,0,0,l,o,w,l,S=[],u,P),P),l,P,u,o,a?S:P);break;default:ae(T,R,R,R,[""],P,0,o,P)}}c=p=m=0,g=f=1,w=T="",u=i;break;case 58:u=1+k(T),m=h;default:if(g<1)if(123==v)--g;else if(125==v&&0==g++&&125==M())continue;switch(T+=E(v),v*g){case 38:f=p>0?1:(T+="\f",-1);break;case 44:o[c++]=(k(T)-1)*f,f=1;break;case 64:45===z()&&(T+=V(B())),d=z(),p=u=k(w=T+=Z(U())),v++;break;case 45:45===h&&2==k(T)&&(g=0)}}return r}function le(e,t,n,a,l,r,i,o,s,c,p,u){for(var d=l-1,h=0===l?r:[""],g=R(h),y=0,f=0,E=0;y<a;++y)for(var v=0,S=P(e,d+1,d=b(f=i[y])),_=e;v<g;++v)(_=w(f>0?h[v]+" "+S:C(S,/&\f/g,h[v])))&&(s[E++]=_);return L(e,t,n,0===l?m:o,s,c,p,u)}function re(e,t,n,a){return L(e,t,n,d,E(F),P(e,2,-2),0,a)}function ie(e,t,n,a,l){return L(e,t,n,h,P(e,0,a),P(e,a+1,-1),a,l)}var oe={animationIterationCount:1,aspectRatio:1,borderImageOutset:1,borderImageSlice:1,borderImageWidth:1,boxFlex:1,boxFlexGroup:1,boxOrdinalGroup:1,columnCount:1,columns:1,flex:1,flexGrow:1,flexPositive:1,flexShrink:1,flexNegative:1,flexOrder:1,gridRow:1,gridRowEnd:1,gridRowSpan:1,gridRowStart:1,gridColumn:1,gridColumnEnd:1,gridColumnSpan:1,gridColumnStart:1,msGridRow:1,msGridRowSpan:1,msGridColumn:1,msGridColumnSpan:1,fontWeight:1,lineHeight:1,opacity:1,order:1,orphans:1,tabSize:1,widows:1,zIndex:1,zoom:1,WebkitLineClamp:1,fillOpacity:1,floodOpacity:1,stopOpacity:1,strokeDasharray:1,strokeDashoffset:1,strokeMiterlimit:1,strokeOpacity:1,strokeWidth:1},se="undefined"!=typeof process&&void 0!==process.env&&(process.env.REACT_APP_SC_ATTR||process.env.SC_ATTR)||"data-styled",ce="active",pe="data-styled-version",ue="6.1.12",de="/*!sc*/\n",me="undefined"!=typeof window&&"HTMLElement"in window,he=Boolean("boolean"==typeof SC_DISABLE_SPEEDY?SC_DISABLE_SPEEDY:"undefined"!=typeof process&&void 0!==process.env&&void 0!==process.env.REACT_APP_SC_DISABLE_SPEEDY&&""!==process.env.REACT_APP_SC_DISABLE_SPEEDY?"false"!==process.env.REACT_APP_SC_DISABLE_SPEEDY&&process.env.REACT_APP_SC_DISABLE_SPEEDY:"undefined"!=typeof process&&void 0!==process.env&&void 0!==process.env.SC_DISABLE_SPEEDY&&""!==process.env.SC_DISABLE_SPEEDY&&"false"!==process.env.SC_DISABLE_SPEEDY&&process.env.SC_DISABLE_SPEEDY),ge={},ye=(new Set,Object.freeze([])),fe=Object.freeze({});function be(e,t,n){return void 0===n&&(n=fe),e.theme!==n.theme&&e.theme||t||n.theme}var Ee=new Set(["a","abbr","address","area","article","aside","audio","b","base","bdi","bdo","big","blockquote","body","br","button","canvas","caption","cite","code","col","colgroup","data","datalist","dd","del","details","dfn","dialog","div","dl","dt","em","embed","fieldset","figcaption","figure","footer","form","h1","h2","h3","h4","h5","h6","header","hgroup","hr","html","i","iframe","img","input","ins","kbd","keygen","label","legend","li","link","main","map","mark","menu","menuitem","meta","meter","nav","noscript","object","ol","optgroup","option","output","p","param","picture","pre","progress","q","rp","rt","ruby","s","samp","script","section","select","small","source","span","strong","style","sub","summary","sup","table","tbody","td","textarea","tfoot","th","thead","time","tr","track","u","ul","use","var","video","wbr","circle","clipPath","defs","ellipse","foreignObject","g","image","line","linearGradient","marker","mask","path","pattern","polygon","polyline","radialGradient","rect","stop","svg","text","tspan"]),ve=/[!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~-]+/g,we=/(^-|-$)/g;function Se(e){return e.replace(ve,"-").replace(we,"")}var Ce=/(a)(d)/gi,_e=52,xe=function(e){return String.fromCharCode(e+(e>25?39:97))};function Pe(e){var t,n="";for(t=Math.abs(e);t>_e;t=t/_e|0)n=xe(t%_e)+n;return(xe(t%_e)+n).replace(Ce,"$1-$2")}var ke,Re=5381,Oe=function(e,t){for(var n=t.length;n;)e=33*e^t.charCodeAt(--n);return e},Te=function(e){return Oe(Re,e)};function Ie(e){return Pe(Te(e)>>>0)}function Ae(e){return e.displayName||e.name||"Component"}function De(e){return"string"==typeof e&&!0}var Ne="function"==typeof Symbol&&Symbol.for,Fe=Ne?Symbol.for("react.memo"):60115,$e=Ne?Symbol.for("react.forward_ref"):60112,Le={childContextTypes:!0,contextType:!0,contextTypes:!0,defaultProps:!0,displayName:!0,getDefaultProps:!0,getDerivedStateFromError:!0,getDerivedStateFromProps:!0,mixins:!0,propTypes:!0,type:!0},je={name:!0,length:!0,prototype:!0,caller:!0,callee:!0,arguments:!0,arity:!0},He={$$typeof:!0,compare:!0,defaultProps:!0,displayName:!0,propTypes:!0,type:!0},Me=((ke={})[$e]={$$typeof:!0,render:!0,defaultProps:!0,displayName:!0,propTypes:!0},ke[Fe]=He,ke);function Be(e){return("type"in(t=e)&&t.type.$$typeof)===Fe?He:"$$typeof"in e?Me[e.$$typeof]:Le;var t}var ze=Object.defineProperty,Ue=Object.getOwnPropertyNames,We=Object.getOwnPropertySymbols,Ge=Object.getOwnPropertyDescriptor,Ve=Object.getPrototypeOf,qe=Object.prototype;function Je(e,t,n){if("string"!=typeof t){if(qe){var a=Ve(t);a&&a!==qe&&Je(e,a,n)}var l=Ue(t);We&&(l=l.concat(We(t)));for(var r=Be(e),i=Be(t),o=0;o<l.length;++o){var s=l[o];if(!(s in je||n&&n[s]||i&&s in i||r&&s in r)){var c=Ge(t,s);try{ze(e,s,c)}catch(e){}}}}return e}function Ye(e){return"function"==typeof e}function Ke(e){return"object"==typeof e&&"styledComponentId"in e}function Ze(e,t){return e&&t?"".concat(e," ").concat(t):e||t||""}function Qe(e,t){if(0===e.length)return"";for(var n=e[0],a=1;a<e.length;a++)n+=t?t+e[a]:e[a];return n}function Xe(e){return null!==e&&"object"==typeof e&&e.constructor.name===Object.name&&!("props"in e&&e.$$typeof)}function et(e,t,n){if(void 0===n&&(n=!1),!n&&!Xe(e)&&!Array.isArray(e))return t;if(Array.isArray(t))for(var a=0;a<t.length;a++)e[a]=et(e[a],t[a]);else if(Xe(t))for(var a in t)e[a]=et(e[a],t[a]);return e}function tt(e,t){Object.defineProperty(e,"toString",{value:t})}function nt(e){for(var t=[],n=1;n<arguments.length;n++)t[n-1]=arguments[n];return new Error("An error occurred. See https://github.com/styled-components/styled-components/blob/main/packages/styled-components/src/utils/errors.md#".concat(e," for more information.").concat(t.length>0?" Args: ".concat(t.join(", ")):""))}var at=function(){function e(e){this.groupSizes=new Uint32Array(512),this.length=512,this.tag=e}return e.prototype.indexOfGroup=function(e){for(var t=0,n=0;n<e;n++)t+=this.groupSizes[n];return t},e.prototype.insertRules=function(e,t){if(e>=this.groupSizes.length){for(var n=this.groupSizes,a=n.length,l=a;e>=l;)if((l<<=1)<0)throw nt(16,"".concat(e));this.groupSizes=new Uint32Array(l),this.groupSizes.set(n),this.length=l;for(var r=a;r<l;r++)this.groupSizes[r]=0}for(var i=this.indexOfGroup(e+1),o=(r=0,t.length);r<o;r++)this.tag.insertRule(i,t[r])&&(this.groupSizes[e]++,i++)},e.prototype.clearGroup=function(e){if(e<this.length){var t=this.groupSizes[e],n=this.indexOfGroup(e),a=n+t;this.groupSizes[e]=0;for(var l=n;l<a;l++)this.tag.deleteRule(n)}},e.prototype.getGroup=function(e){var t="";if(e>=this.length||0===this.groupSizes[e])return t;for(var n=this.groupSizes[e],a=this.indexOfGroup(e),l=a+n,r=a;r<l;r++)t+="".concat(this.tag.getRule(r)).concat(de);return t},e}(),lt=new Map,rt=new Map,it=1,ot=function(e){if(lt.has(e))return lt.get(e);for(;rt.has(it);)it++;var t=it++;return lt.set(e,t),rt.set(t,e),t},st=function(e,t){it=t+1,lt.set(e,t),rt.set(t,e)},ct="style[".concat(se,"][").concat(pe,'="').concat(ue,'"]'),pt=new RegExp("^".concat(se,'\\.g(\\d+)\\[id="([\\w\\d-]+)"\\].*?"([^"]*)')),ut=function(e,t,n){for(var a,l=n.split(","),r=0,i=l.length;r<i;r++)(a=l[r])&&e.registerName(t,a)},dt=function(e,t){for(var n,a=(null!==(n=t.textContent)&&void 0!==n?n:"").split(de),l=[],r=0,i=a.length;r<i;r++){var o=a[r].trim();if(o){var s=o.match(pt);if(s){var c=0|parseInt(s[1],10),p=s[2];0!==c&&(st(p,c),ut(e,p,s[3]),e.getTag().insertRules(c,l)),l.length=0}else l.push(o)}}},mt=function(e){for(var t=document.querySelectorAll(ct),n=0,a=t.length;n<a;n++){var l=t[n];l&&l.getAttribute(se)!==ce&&(dt(e,l),l.parentNode&&l.parentNode.removeChild(l))}};function ht(){return n.nc}var gt=function(e){var t=document.head,n=e||t,a=document.createElement("style"),l=function(e){var t=Array.from(e.querySelectorAll("style[".concat(se,"]")));return t[t.length-1]}(n),r=void 0!==l?l.nextSibling:null;a.setAttribute(se,ce),a.setAttribute(pe,ue);var i=ht();return i&&a.setAttribute("nonce",i),n.insertBefore(a,r),a},yt=function(){function e(e){this.element=gt(e),this.element.appendChild(document.createTextNode("")),this.sheet=function(e){if(e.sheet)return e.sheet;for(var t=document.styleSheets,n=0,a=t.length;n<a;n++){var l=t[n];if(l.ownerNode===e)return l}throw nt(17)}(this.element),this.length=0}return e.prototype.insertRule=function(e,t){try{return this.sheet.insertRule(t,e),this.length++,!0}catch(e){return!1}},e.prototype.deleteRule=function(e){this.sheet.deleteRule(e),this.length--},e.prototype.getRule=function(e){var t=this.sheet.cssRules[e];return t&&t.cssText?t.cssText:""},e}(),ft=function(){function e(e){this.element=gt(e),this.nodes=this.element.childNodes,this.length=0}return e.prototype.insertRule=function(e,t){if(e<=this.length&&e>=0){var n=document.createTextNode(t);return this.element.insertBefore(n,this.nodes[e]||null),this.length++,!0}return!1},e.prototype.deleteRule=function(e){this.element.removeChild(this.nodes[e]),this.length--},e.prototype.getRule=function(e){return e<this.length?this.nodes[e].textContent:""},e}(),bt=function(){function e(e){this.rules=[],this.length=0}return e.prototype.insertRule=function(e,t){return e<=this.length&&(this.rules.splice(e,0,t),this.length++,!0)},e.prototype.deleteRule=function(e){this.rules.splice(e,1),this.length--},e.prototype.getRule=function(e){return e<this.length?this.rules[e]:""},e}(),Et=me,vt={isServer:!me,useCSSOMInjection:!he},wt=function(){function e(e,t,n){void 0===e&&(e=fe),void 0===t&&(t={});var l=this;this.options=a(a({},vt),e),this.gs=t,this.names=new Map(n),this.server=!!e.isServer,!this.server&&me&&Et&&(Et=!1,mt(this)),tt(this,(function(){return function(e){for(var t=e.getTag(),n=t.length,a="",l=function(n){var l=function(e){return rt.get(e)}(n);if(void 0===l)return"continue";var r=e.names.get(l),i=t.getGroup(n);if(void 0===r||!r.size||0===i.length)return"continue";var o="".concat(se,".g").concat(n,'[id="').concat(l,'"]'),s="";void 0!==r&&r.forEach((function(e){e.length>0&&(s+="".concat(e,","))})),a+="".concat(i).concat(o,'{content:"').concat(s,'"}').concat(de)},r=0;r<n;r++)l(r);return a}(l)}))}return e.registerId=function(e){return ot(e)},e.prototype.rehydrate=function(){!this.server&&me&&mt(this)},e.prototype.reconstructWithOptions=function(t,n){return void 0===n&&(n=!0),new e(a(a({},this.options),t),this.gs,n&&this.names||void 0)},e.prototype.allocateGSInstance=function(e){return this.gs[e]=(this.gs[e]||0)+1},e.prototype.getTag=function(){return this.tag||(this.tag=(e=function(e){var t=e.useCSSOMInjection,n=e.target;return e.isServer?new bt(n):t?new yt(n):new ft(n)}(this.options),new at(e)));var e},e.prototype.hasNameForId=function(e,t){return this.names.has(e)&&this.names.get(e).has(t)},e.prototype.registerName=function(e,t){if(ot(e),this.names.has(e))this.names.get(e).add(t);else{var n=new Set;n.add(t),this.names.set(e,n)}},e.prototype.insertRules=function(e,t,n){this.registerName(e,t),this.getTag().insertRules(ot(e),n)},e.prototype.clearNames=function(e){this.names.has(e)&&this.names.get(e).clear()},e.prototype.clearRules=function(e){this.getTag().clearGroup(ot(e)),this.clearNames(e)},e.prototype.clearTag=function(){this.tag=void 0},e}(),St=/&/g,Ct=/^\s*\/\/.*$/gm;function _t(e,t){return e.map((function(e){return"rule"===e.type&&(e.value="".concat(t," ").concat(e.value),e.value=e.value.replaceAll(",",",".concat(t," ")),e.props=e.props.map((function(e){return"".concat(t," ").concat(e)}))),Array.isArray(e.children)&&"@keyframes"!==e.type&&(e.children=_t(e.children,t)),e}))}function xt(e){var t,n,a,l=void 0===e?fe:e,r=l.options,i=void 0===r?fe:r,o=l.plugins,s=void 0===o?ye:o,c=function(e,a,l){return l.startsWith(n)&&l.endsWith(n)&&l.replaceAll(n,"").length>0?".".concat(t):e},p=s.slice();p.push((function(e){e.type===m&&e.value.includes("&")&&(e.props[0]=e.props[0].replace(St,n).replace(a,c))})),i.prefix&&p.push(te),p.push(X);var u=function(e,l,r,o){void 0===l&&(l=""),void 0===r&&(r=""),void 0===o&&(o="&"),t=o,n=l,a=new RegExp("\\".concat(n,"\\b"),"g");var s=e.replace(Ct,""),c=ne(r||l?"".concat(r," ").concat(l," { ").concat(s," }"):s);i.namespace&&(c=_t(c,i.namespace));var u,d,m,h=[];return Q(c,(u=p.concat((m=function(e){return h.push(e)},function(e){e.root||(e=e.return)&&m(e)})),d=R(u),function(e,t,n,a){for(var l="",r=0;r<d;r++)l+=u[r](e,t,n,a)||"";return l})),h};return u.hash=s.length?s.reduce((function(e,t){return t.name||nt(15),Oe(e,t.name)}),Re).toString():"",u}var Pt=new wt,kt=xt(),Rt=i().createContext({shouldForwardProp:void 0,styleSheet:Pt,stylis:kt}),Ot=Rt.Consumer,Tt=i().createContext(void 0);function It(){return(0,r.useContext)(Rt)}function At(e){var t=(0,r.useState)(e.stylisPlugins),n=t[0],a=t[1],l=It().styleSheet,o=(0,r.useMemo)((function(){var t=l;return e.sheet?t=e.sheet:e.target&&(t=t.reconstructWithOptions({target:e.target},!1)),e.disableCSSOMInjection&&(t=t.reconstructWithOptions({useCSSOMInjection:!1})),t}),[e.disableCSSOMInjection,e.sheet,e.target,l]),c=(0,r.useMemo)((function(){return xt({options:{namespace:e.namespace,prefix:e.enableVendorPrefixes},plugins:n})}),[e.enableVendorPrefixes,e.namespace,n]);(0,r.useEffect)((function(){s()(n,e.stylisPlugins)||a(e.stylisPlugins)}),[e.stylisPlugins]);var p=(0,r.useMemo)((function(){return{shouldForwardProp:e.shouldForwardProp,styleSheet:o,stylis:c}}),[e.shouldForwardProp,o,c]);return i().createElement(Rt.Provider,{value:p},i().createElement(Tt.Provider,{value:c},e.children))}var Dt=function(){function e(e,t){var n=this;this.inject=function(e,t){void 0===t&&(t=kt);var a=n.name+t.hash;e.hasNameForId(n.id,a)||e.insertRules(n.id,a,t(n.rules,a,"@keyframes"))},this.name=e,this.id="sc-keyframes-".concat(e),this.rules=t,tt(this,(function(){throw nt(12,String(n.name))}))}return e.prototype.getName=function(e){return void 0===e&&(e=kt),this.name+e.hash},e}(),Nt=function(e){return e>="A"&&e<="Z"};function Ft(e){for(var t="",n=0;n<e.length;n++){var a=e[n];if(1===n&&"-"===a&&"-"===e[0])return e;Nt(a)?t+="-"+a.toLowerCase():t+=a}return t.startsWith("ms-")?"-"+t:t}var $t=function(e){return null==e||!1===e||""===e},Lt=function(e){var t,n,a=[];for(var r in e){var i=e[r];e.hasOwnProperty(r)&&!$t(i)&&(Array.isArray(i)&&i.isCss||Ye(i)?a.push("".concat(Ft(r),":"),i,";"):Xe(i)?a.push.apply(a,l(l(["".concat(r," {")],Lt(i),!1),["}"],!1)):a.push("".concat(Ft(r),": ").concat((t=r,null==(n=i)||"boolean"==typeof n||""===n?"":"number"!=typeof n||0===n||t in oe||t.startsWith("--")?String(n).trim():"".concat(n,"px")),";")))}return a};function jt(e,t,n,a){return $t(e)?[]:Ke(e)?[".".concat(e.styledComponentId)]:Ye(e)?!Ye(l=e)||l.prototype&&l.prototype.isReactComponent||!t?[e]:jt(e(t),t,n,a):e instanceof Dt?n?(e.inject(n,a),[e.getName(a)]):[e]:Xe(e)?Lt(e):Array.isArray(e)?Array.prototype.concat.apply(ye,e.map((function(e){return jt(e,t,n,a)}))):[e.toString()];var l}function Ht(e){for(var t=0;t<e.length;t+=1){var n=e[t];if(Ye(n)&&!Ke(n))return!1}return!0}var Mt=Te(ue),Bt=function(){function e(e,t,n){this.rules=e,this.staticRulesId="",this.isStatic=(void 0===n||n.isStatic)&&Ht(e),this.componentId=t,this.baseHash=Oe(Mt,t),this.baseStyle=n,wt.registerId(t)}return e.prototype.generateAndInjectStyles=function(e,t,n){var a=this.baseStyle?this.baseStyle.generateAndInjectStyles(e,t,n):"";if(this.isStatic&&!n.hash)if(this.staticRulesId&&t.hasNameForId(this.componentId,this.staticRulesId))a=Ze(a,this.staticRulesId);else{var l=Qe(jt(this.rules,e,t,n)),r=Pe(Oe(this.baseHash,l)>>>0);if(!t.hasNameForId(this.componentId,r)){var i=n(l,".".concat(r),void 0,this.componentId);t.insertRules(this.componentId,r,i)}a=Ze(a,r),this.staticRulesId=r}else{for(var o=Oe(this.baseHash,n.hash),s="",c=0;c<this.rules.length;c++){var p=this.rules[c];if("string"==typeof p)s+=p;else if(p){var u=Qe(jt(p,e,t,n));o=Oe(o,u+c),s+=u}}if(s){var d=Pe(o>>>0);t.hasNameForId(this.componentId,d)||t.insertRules(this.componentId,d,n(s,".".concat(d),void 0,this.componentId)),a=Ze(a,d)}}return a},e}(),zt=i().createContext(void 0),Ut=zt.Consumer;function Wt(){var e=(0,r.useContext)(zt);if(!e)throw nt(18);return e}function Gt(e){var t=i().useContext(zt),n=(0,r.useMemo)((function(){return function(e,t){if(!e)throw nt(14);if(Ye(e))return e(t);if(Array.isArray(e)||"object"!=typeof e)throw nt(8);return t?a(a({},t),e):e}(e.theme,t)}),[e.theme,t]);return e.children?i().createElement(zt.Provider,{value:n},e.children):null}var Vt={};function qt(e,t,n){var l=Ke(e),o=e,s=!De(e),c=t.attrs,p=void 0===c?ye:c,u=t.componentId,d=void 0===u?function(e,t){var n="string"!=typeof e?"sc":Se(e);Vt[n]=(Vt[n]||0)+1;var a="".concat(n,"-").concat(Ie(ue+n+Vt[n]));return t?"".concat(t,"-").concat(a):a}(t.displayName,t.parentComponentId):u,m=t.displayName,h=void 0===m?function(e){return De(e)?"styled.".concat(e):"Styled(".concat(Ae(e),")")}(e):m,g=t.displayName&&t.componentId?"".concat(Se(t.displayName),"-").concat(t.componentId):t.componentId||d,y=l&&o.attrs?o.attrs.concat(p).filter(Boolean):p,f=t.shouldForwardProp;if(l&&o.shouldForwardProp){var b=o.shouldForwardProp;if(t.shouldForwardProp){var E=t.shouldForwardProp;f=function(e,t){return b(e,t)&&E(e,t)}}else f=b}var v=new Bt(n,g,l?o.componentStyle:void 0);function w(e,t){return function(e,t,n){var l=e.attrs,o=e.componentStyle,s=e.defaultProps,c=e.foldedComponentIds,p=e.styledComponentId,u=e.target,d=i().useContext(zt),m=It(),h=e.shouldForwardProp||m.shouldForwardProp,g=be(t,d,s)||fe,y=function(e,t,n){for(var l,r=a(a({},t),{className:void 0,theme:n}),i=0;i<e.length;i+=1){var o=Ye(l=e[i])?l(r):l;for(var s in o)r[s]="className"===s?Ze(r[s],o[s]):"style"===s?a(a({},r[s]),o[s]):o[s]}return t.className&&(r.className=Ze(r.className,t.className)),r}(l,t,g),f=y.as||u,b={};for(var E in y)void 0===y[E]||"$"===E[0]||"as"===E||"theme"===E&&y.theme===g||("forwardedAs"===E?b.as=y.forwardedAs:h&&!h(E,f)||(b[E]=y[E]));var v=function(e,t){var n=It();return e.generateAndInjectStyles(t,n.styleSheet,n.stylis)}(o,y),w=Ze(c,p);return v&&(w+=" "+v),y.className&&(w+=" "+y.className),b[De(f)&&!Ee.has(f)?"class":"className"]=w,b.ref=n,(0,r.createElement)(f,b)}(S,e,t)}w.displayName=h;var S=i().forwardRef(w);return S.attrs=y,S.componentStyle=v,S.displayName=h,S.shouldForwardProp=f,S.foldedComponentIds=l?Ze(o.foldedComponentIds,o.styledComponentId):"",S.styledComponentId=g,S.target=l?o.target:e,Object.defineProperty(S,"defaultProps",{get:function(){return this._foldedDefaultProps},set:function(e){this._foldedDefaultProps=l?function(e){for(var t=[],n=1;n<arguments.length;n++)t[n-1]=arguments[n];for(var a=0,l=t;a<l.length;a++)et(e,l[a],!0);return e}({},o.defaultProps,e):e}}),tt(S,(function(){return".".concat(S.styledComponentId)})),s&&Je(S,e,{attrs:!0,componentStyle:!0,displayName:!0,foldedComponentIds:!0,shouldForwardProp:!0,styledComponentId:!0,target:!0}),S}function Jt(e,t){for(var n=[e[0]],a=0,l=t.length;a<l;a+=1)n.push(t[a],e[a+1]);return n}new Set;var Yt=function(e){return Object.assign(e,{isCss:!0})};function Kt(e){for(var t=[],n=1;n<arguments.length;n++)t[n-1]=arguments[n];if(Ye(e)||Xe(e))return Yt(jt(Jt(ye,l([e],t,!0))));var a=e;return 0===t.length&&1===a.length&&"string"==typeof a[0]?jt(a):Yt(jt(Jt(a,t)))}function Zt(e,t,n){if(void 0===n&&(n=fe),!t)throw nt(1,t);var r=function(a){for(var r=[],i=1;i<arguments.length;i++)r[i-1]=arguments[i];return e(t,n,Kt.apply(void 0,l([a],r,!1)))};return r.attrs=function(l){return Zt(e,t,a(a({},n),{attrs:Array.prototype.concat(n.attrs,l).filter(Boolean)}))},r.withConfig=function(l){return Zt(e,t,a(a({},n),l))},r}var Qt=function(e){return Zt(qt,e)},Xt=Qt;Ee.forEach((function(e){Xt[e]=Qt(e)}));var en=function(){function e(e,t){this.rules=e,this.componentId=t,this.isStatic=Ht(e),wt.registerId(this.componentId+1)}return e.prototype.createStyles=function(e,t,n,a){var l=a(Qe(jt(this.rules,t,n,a)),""),r=this.componentId+e;n.insertRules(r,r,l)},e.prototype.removeStyles=function(e,t){t.clearRules(this.componentId+e)},e.prototype.renderStyles=function(e,t,n,a){e>2&&wt.registerId(this.componentId+e),this.removeStyles(e,n),this.createStyles(e,t,n,a)},e}();function tn(e){for(var t=[],n=1;n<arguments.length;n++)t[n-1]=arguments[n];var r=Kt.apply(void 0,l([e],t,!1)),o="sc-global-".concat(Ie(JSON.stringify(r))),s=new en(r,o),c=function(e){var t=It(),n=i().useContext(zt),a=i().useRef(t.styleSheet.allocateGSInstance(o)).current;return t.styleSheet.server&&p(a,e,t.styleSheet,n,t.stylis),i().useLayoutEffect((function(){if(!t.styleSheet.server)return p(a,e,t.styleSheet,n,t.stylis),function(){return s.removeStyles(a,t.styleSheet)}}),[a,e,t.styleSheet,n,t.stylis]),null};function p(e,t,n,l,r){if(s.isStatic)s.renderStyles(e,ge,n,r);else{var i=a(a({},t),{theme:be(t,l,c.defaultProps)});s.renderStyles(e,i,n,r)}}return i().memo(c)}function nn(e){for(var t=[],n=1;n<arguments.length;n++)t[n-1]=arguments[n];var a=Qe(Kt.apply(void 0,l([e],t,!1))),r=Ie(a);return new Dt(r,a)}function an(e){var t=i().forwardRef((function(t,n){var l=be(t,i().useContext(zt),e.defaultProps);return i().createElement(e,a({},t,{theme:l,ref:n}))}));return t.displayName="WithTheme(".concat(Ae(e),")"),Je(t,e)}var ln=function(){function e(){var e=this;this._emitSheetCSS=function(){var t=e.instance.toString();if(!t)return"";var n=ht(),a=Qe([n&&'nonce="'.concat(n,'"'),"".concat(se,'="true"'),"".concat(pe,'="').concat(ue,'"')].filter(Boolean)," ");return"<style ".concat(a,">").concat(t,"</style>")},this.getStyleTags=function(){if(e.sealed)throw nt(2);return e._emitSheetCSS()},this.getStyleElement=function(){var t;if(e.sealed)throw nt(2);var n=e.instance.toString();if(!n)return[];var l=((t={})[se]="",t[pe]=ue,t.dangerouslySetInnerHTML={__html:n},t),r=ht();return r&&(l.nonce=r),[i().createElement("style",a({},l,{key:"sc-0-0"}))]},this.seal=function(){e.sealed=!0},this.instance=new wt({isServer:!0}),this.sealed=!1}return e.prototype.collectStyles=function(e){if(this.sealed)throw nt(2);return i().createElement(At,{sheet:this.instance},e)},e.prototype.interleaveWithNodeStream=function(e){throw nt(3)},e}(),rn={StyleSheet:wt,mainSheet:Pt};"__sc-".concat(se,"__")},609:e=>{"use strict";e.exports=window.React}},r={};function i(e){var t=r[e];if(void 0!==t)return t.exports;var n=r[e]={exports:{}};return l[e](n,n.exports,i),n.exports}i.m=l,i.n=e=>{var t=e&&e.__esModule?()=>e.default:()=>e;return i.d(t,{a:t}),t},t=Object.getPrototypeOf?e=>Object.getPrototypeOf(e):e=>e.__proto__,i.t=function(n,a){if(1&a&&(n=this(n)),8&a)return n;if("object"==typeof n&&n){if(4&a&&n.__esModule)return n;if(16&a&&"function"==typeof n.then)return n}var l=Object.create(null);i.r(l);var r={};e=e||[null,t({}),t([]),t(t)];for(var o=2&a&&n;"object"==typeof o&&!~e.indexOf(o);o=t(o))Object.getOwnPropertyNames(o).forEach((e=>r[e]=()=>n[e]));return r.default=()=>n,i.d(l,r),l},i.d=(e,t)=>{for(var n in t)i.o(t,n)&&!i.o(e,n)&&Object.defineProperty(e,n,{enumerable:!0,get:t[n]})},i.f={},i.e=e=>Promise.all(Object.keys(i.f).reduce(((t,n)=>(i.f[n](e,t),t)),[])),i.u=e=>({42:"reactPlayerTwitch",173:"reactPlayerVimeo",328:"reactPlayerDailyMotion",340:"reactPlayerWistia",353:"reactPlayerPreview",392:"reactPlayerVidyard",446:"reactPlayerYouTube",458:"reactPlayerFilePlayer",463:"reactPlayerKaltura",570:"reactPlayerMixcloud",627:"reactPlayerStreamable",723:"reactPlayerMux",887:"reactPlayerFacebook",979:"reactPlayerSoundCloud"}[e]+".js"),i.miniCssF=e=>{},i.g=function(){if("object"==typeof globalThis)return globalThis;try{return this||new Function("return this")()}catch(e){if("object"==typeof window)return window}}(),i.o=(e,t)=>Object.prototype.hasOwnProperty.call(e,t),n={},a="simplystatic-settings:",i.l=(e,t,l,r)=>{if(n[e])n[e].push(t);else{var o,s;if(void 0!==l)for(var c=document.getElementsByTagName("script"),p=0;p<c.length;p++){var u=c[p];if(u.getAttribute("src")==e||u.getAttribute("data-webpack")==a+l){o=u;break}}o||(s=!0,(o=document.createElement("script")).charset="utf-8",o.timeout=120,i.nc&&o.setAttribute("nonce",i.nc),o.setAttribute("data-webpack",a+l),o.src=e),n[e]=[t];var d=(t,a)=>{o.onerror=o.onload=null,clearTimeout(m);var l=n[e];if(delete n[e],o.parentNode&&o.parentNode.removeChild(o),l&&l.forEach((e=>e(a))),t)return t(a)},m=setTimeout(d.bind(null,void 0,{type:"timeout",target:o}),12e4);o.onerror=d.bind(null,o.onerror),o.onload=d.bind(null,o.onload),s&&document.head.appendChild(o)}},i.r=e=>{"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})},(()=>{var e;i.g.importScripts&&(e=i.g.location+"");var t=i.g.document;if(!e&&t&&(t.currentScript&&(e=t.currentScript.src),!e)){var n=t.getElementsByTagName("script");if(n.length)for(var a=n.length-1;a>-1&&(!e||!/^http(s?):/.test(e));)e=n[a--].src}if(!e)throw new Error("Automatic publicPath is not supported in this browser");e=e.replace(/#.*$/,"").replace(/\?.*$/,"").replace(/\/[^\/]+$/,"/"),i.p=e})(),(()=>{var e={57:0};i.f.j=(t,n)=>{var a=i.o(e,t)?e[t]:void 0;if(0!==a)if(a)n.push(a[2]);else{var l=new Promise(((n,l)=>a=e[t]=[n,l]));n.push(a[2]=l);var r=i.p+i.u(t),o=new Error;i.l(r,(n=>{if(i.o(e,t)&&(0!==(a=e[t])&&(e[t]=void 0),a)){var l=n&&("load"===n.type?"missing":n.type),r=n&&n.target&&n.target.src;o.message="Loading chunk "+t+" failed.\n("+l+": "+r+")",o.name="ChunkLoadError",o.type=l,o.request=r,a[1](o)}}),"chunk-"+t,t)}};var t=(t,n)=>{var a,l,[r,o,s]=n,c=0;if(r.some((t=>0!==e[t]))){for(a in o)i.o(o,a)&&(i.m[a]=o[a]);s&&s(i)}for(t&&t(n);c<r.length;c++)l=r[c],i.o(e,l)&&e[l]&&e[l][0](),e[l]=0},n=globalThis.webpackChunksimplystatic_settings=globalThis.webpackChunksimplystatic_settings||[];n.forEach(t.bind(null,0)),n.push=t.bind(null,n.push.bind(n))})(),i.nc=void 0,(()=>{"use strict";var e=i(609),t=i.n(e);const n=window.wp.element,a=window.wp.apiFetch;var l=i.n(a);function r(t,n){const a=(0,e.useRef)();(0,e.useEffect)((()=>{a.current=t}),[t]),(0,e.useEffect)((()=>{if(null!==n){let e=setInterval((function(){a.current()}),n);return()=>clearInterval(e)}}),[n])}const{__}=wp.i18n,o=(0,n.createContext)(),s=function(t){const[a,i]=(0,n.useState)(!1),[s,c]=(0,n.useState)(0),[p,u]=(0,n.useState)(!1),[d,m]=(0,n.useState)(!1),[h,g]=(0,n.useState)(!1),[y,f]=(0,n.useState)({}),[b,E]=(0,n.useState)({}),[v,w]=(0,n.useState)("yes"),[S,C]=(0,n.useState)(1),[_,x]=(0,n.useState)([]),[P,k]=(0,n.useState)(!0),R=()=>{l()({path:"/simplystatic/v1/settings"}).then((e=>{f(e)}))},O=()=>{l()({path:"/simplystatic/v1/is-running",method:"GET"}).then((e=>{var t=JSON.parse(e);i(t.running),u(t.paused),t.delayed&&c(t.delayed_until)}))},T=e=>["environments"].indexOf(e)>=0,I=e=>_.indexOf(e)>=0,A=e=>{let t=y.integrations;return!(!1===t||!t||!Array.isArray(t))&&t.indexOf(e)>=0};return r((()=>{c(s-1)}),s>0?1e3:null),r((()=>{O()}),a||s?5e3:null),(0,n.useEffect)((()=>{options.current_settings?f(options.current_settings):R(),l()({path:"/simplystatic/v1/system-status"}).then((e=>{E(e),l()({path:"/simplystatic/v1/system-status/passed"}).then((e=>{let t=JSON.parse(e);w(t.passed)}))})),O(),C(options.blog_id)}),[]),(0,e.createElement)(o.Provider,{value:{settings:y,configs:b,passedChecks:v,settingsSaved:h,setSettingsSaved:g,updateSetting:(e,t)=>{const n={...y,[e]:t};f(n)},setSettings:f,saveSettings:()=>{l()({path:"/simplystatic/v1/settings",method:"POST",data:y}).then((e=>{x([])}))},resetSettings:()=>{l()({path:"/simplystatic/v1/settings/reset",method:"POST"}).then((e=>{const t=JSON.parse(e);200===t.status&&t.data&&f(t.data)}))},resetDatabase:()=>{l()({path:"/simplystatic/v1/settings/reset-database",method:"POST"})},getSettings:R,updateFromNetwork:e=>{l()({path:"/simplystatic/v1/update-from-network",method:"POST",data:{blog_id:e}})},importSettings:e=>{f(e),l()({path:"/simplystatic/v1/settings",method:"POST",data:e})},migrateSettings:()=>{l()({path:"/simplystatic/v1/migrate",method:"POST",migrate:!0})},resetDiagnostics:()=>{l()({path:"/simplystatic/v1/reset-diagnostics",method:"POST"})},isRunning:a,setIsRunning:i,isPaused:p,setIsPaused:u,setIsResumed:m,isResumed:d,blogId:S,setBlogId:C,isPro:()=>!!options.is_multisite||!!options.connect&&!!options.connect.is_connected,isStudio:()=>!!(options.home.includes("static.studio")||options.home.includes("static1.studio")||options.home.includes("static2.studio")),isIntegrationActive:A,canRunIntegration:e=>!!A(e)&&!I(e),maybeQueueIntegration:e=>{T(e)&&(I(e)||(_.push(e),x(_)))},maybeUnqueueIntegration:e=>{if(!T(e))return;if(!I(e))return;const t=_.indexOf(e);t<0||(_.splice(t,1),x(_))},isQueuedIntegration:I,showMobileNav:P,setShowMobileNav:k,isDelayed:s}},t.children)},c=window.wp.components;var p=i(554),u=i.n(p);const{__:d}=wp.i18n,m=function({title:t,videoUrl:a}){const[l,r]=(0,n.useState)(!1);return(0,e.createElement)(e.Fragment,null,l&&(0,e.createElement)("div",{class:"simply-static-video-modal-background"},(0,e.createElement)(c.Modal,{title:t,className:"simply-static-video-modal",onRequestClose:()=>r(!1)},(0,e.createElement)(u(),{url:a,controls:!0,width:"920px",height:"560px"}))),(0,e.createElement)(c.Button,{variant:"link",className:"simply-static-video-button",onClick:()=>r(!0)},(0,e.createElement)(c.Dashicon,{icon:"format-video"})))},{__:h}=wp.i18n,g=function(){const{settings:t,updateSetting:a,saveSettings:r,settingsSaved:i,setSettingsSaved:s,isPro:p}=(0,n.useContext)(o),[u,d]=(0,n.useState)("relative"),[g,y]=(0,n.useState)(!1),[f,b]=(0,n.useState)("https://"),[E,v]=(0,n.useState)(""),[w,S]=(0,n.useState)("/"),[C,_]=(0,n.useState)(!1),[x,P]=(0,n.useState)(!1),[k,R]=(0,n.useState)(!1),[O,T]=(0,n.useState)(!1),[I,A]=(0,n.useState)(!1),[D,N]=(0,n.useState)(!1),[F,$]=(0,n.useState)([]),[L,j]=(0,n.useState)([]),[H,M]=(0,n.useState)(null),[B,z]=(0,n.useState)([]),[U,W]=(0,n.useState)([]),[G,V]=(0,n.useState)(null);return(0,n.useEffect)((()=>{M(null),l()({path:"/simplystatic/v1/crawlers",parse:!0}).then((e=>{if("string"==typeof e)try{e=JSON.parse(e)}catch(e){return void M("Error parsing API response: "+e.message)}if(e&&e.data&&e.data.length>0)if($(e.data),t.crawlers&&Array.isArray(t.crawlers)&&0!==t.crawlers.length){if(Array.isArray(t.crawlers)){const n=t.crawlers.filter((t=>e.data.some((e=>e.id===t))));if(0===n.length){const t=e.data.map((e=>e.id));j(t),a("crawlers",t)}else j(n)}}else{const t=e.data.filter((e=>e.active)).map((e=>e.id));j(t),a("crawlers",t)}else M("Invalid API response structure or empty crawlers array")})).catch((e=>{M("Error fetching crawlers: "+(e.message||"Unknown error"))})),V(null),l()({path:"/simplystatic/v1/post-types",parse:!0}).then((e=>{if("string"==typeof e)try{e=JSON.parse(e)}catch(e){return void V("Error parsing API response: "+e.message)}if(e&&e.data&&e.data.length>0)if(z(e.data),t.post_types&&Array.isArray(t.post_types)){if(Array.isArray(t.post_types)){const n=t.post_types.filter((t=>e.data.some((e=>e.name===t))));if(0===n.length){const t=e.data.map((e=>e.name));W(t),a("post_types",t)}else W(n)}}else{const t=e.data.map((e=>e.name));W(t),a("post_types",t)}else V("Invalid API response structure or empty post types array")})).catch((e=>{V("Error fetching post types: "+(e.message||"Unknown error"))}))}),[]),(0,n.useEffect)((()=>{t.destination_url_type&&d(t.destination_url_type),t.destination_scheme&&b(t.destination_scheme),t.destination_host&&v(t.destination_host),t.relative_path&&S(t.relative_path),(t.use_forms||t.use_comments)&&y(!0),t.force_replace_url&&_(t.force_replace_url),t.generate_404&&R(t.generate_404),t.add_feeds&&A(t.add_feeds),t.add_rest_api&&N(t.add_rest_api),t.smart_crawl&&T(t.smart_crawl),t.crawlers&&j(t.crawlers),void 0!==t.post_types&&W(Array.isArray(t.post_types)?t.post_types:[])}),[t]),(0,e.createElement)("div",{className:"inner-settings"},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,h("Replacing URLs","simply-static"),(0,e.createElement)(m,{title:h("How to replace URLs","simply-static"),videoUrl:"https://youtu.be/cb8jAMJlfGI"}))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,h("When exporting your static site, any links to your WordPress site will be replaced by one of the following: absolute URLs, relative URLs, or URLs contructed for offline use.","simply-static")),(0,e.createElement)(c.SelectControl,{label:h("Replacing URLs","simply-static"),value:u,options:[{label:h("Absolute URLs","simply-static"),value:"absolute"},{label:h("Relative Path","simply-static"),value:"relative"},{label:h("Offline Usage","simply-static"),value:"offline"}],onChange:e=>{d(e),a("destination_url_type",e)}}),"absolute"===u&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,{style:{minWidth:"15%"}},(0,e.createElement)(c.SelectControl,{label:h("Scheme","simply-static"),value:f,options:[{label:"https://",value:"https://"},{label:"http://",value:"http://"},{label:"//",value:"//"}],onChange:e=>{b(e),a("destination_scheme",e)}})),(0,e.createElement)(c.FlexItem,{style:{minWidth:"85%"}},(0,e.createElement)(c.TextControl,{label:h("Host","simply-static"),type:"text",placeholder:"example.com",value:E,onChange:e=>{v(e),a("destination_host",e)}}))),(0,e.createElement)("p",null,h("Convert all URLs for your WordPress site to absolute URLs at the domain specified above.","simply-static"))),"relative"===u&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.TextControl,{label:h("Path","simply-static"),type:"text",placeholder:"/",value:w,onChange:e=>{S(e),a("relative_path",e)}}),(0,e.createElement)("p",null,h("Convert all URLs for your WordPress site to relative URLs that will work at any domain.","simply-static"),(0,e.createElement)("br",null),h("Optionally specify a path above if you intend to place the files in a subdirectory.","simply-static")),(0,e.createElement)("p",null,(0,e.createElement)(c.Notice,{status:"warning",isDismissible:!1},(0,e.createElement)("b",null,h("Example","simply-static"),": "),h("enter /path above if you wanted to serve your files at www.example.com/path/","simply-static")))),"offline"===u&&(0,e.createElement)("p",null,h("Convert all URLs for your WordPress site so that you can browse the site locally on your own computer without hosting it on a web server.","simply-static")),!g&&(0,e.createElement)(c.ToggleControl,{label:h("Force URL replacements","simply-static"),help:h(C?"Replace all occurrences of the WordPress URL with the static URL (includes inline CSS and JS).":"Replace only occurrences of the WordPress URL that match our tag list.","simply-static"),checked:C,onChange:e=>{_(e),a("force_replace_url",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,h("Enhanced Crawl","simply-static"),(0,e.createElement)(m,{title:h("How Enhanced Crawl improves your static exports","simply-static"),videoUrl:"https://youtu.be/QfKxeQ1w7tU"}))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,h("Enhanced Crawl uses native WordPress functions to find all pages and files when running a static export.","simply-static")),(0,e.createElement)(c.ToggleControl,{label:(0,e.createElement)(e.Fragment,null,h("Enable Enhanced Crawl","simply-static")),help:h(O?"Find pages and files via Enhanced Crawl.":"Don't find pages and files via Enhanced Crawl.","simply-static"),checked:O,onChange:e=>{T(e),a("smart_crawl",e)}}),O&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.__experimentalSpacer,{margin:2}),H&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Notice,{status:"error",isDismissible:!1},h("Error loading crawlers: ","simply-static")," ",H),(0,e.createElement)(c.__experimentalSpacer,{margin:2})),F.length>0?(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.FormTokenField,{label:h("Active Crawlers","simply-static"),value:L.map((e=>{const t=F.find((t=>t.id===e));return t?t.name:e})),suggestions:F.map((e=>e.name)),onChange:e=>{const t=e.map((e=>{let t=F.find((t=>t.name===e));return t||(t=F.find((t=>t.name.toLowerCase()===e.toLowerCase()))),t||(t=F.find((t=>t.id===e))),t?t.id:e}));j(t),a("crawlers",t)},help:h("Select which crawlers to activate. If none selected, all crawlers will be active by default.","simply-static"),tokenizeOnSpace:!1,__experimentalExpandOnFocus:!0,__experimentalShowHowTo:!1,maxSuggestions:100,className:"horizontal-token-field"}),(0,e.createElement)(c.__experimentalSpacer,{margin:2}),L.includes("post_type")&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.__experimentalSpacer,{margin:2}),G&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Notice,{status:"error",isDismissible:!1},h("Error loading post types: ","simply-static")," ",G),(0,e.createElement)(c.__experimentalSpacer,{margin:2})),B.length>0?(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.FormTokenField,{label:h("Post Types to Include","simply-static"),value:Array.isArray(U)?U.map((e=>{const t=B.find((t=>t.name===e));return t?t.label:e})):[],suggestions:B.map((e=>e.label)),onChange:e=>{const t=e.map((e=>{let t=B.find((t=>t.label===e));return t||(t=B.find((t=>t.label.toLowerCase()===e.toLowerCase()))),t||(t=B.find((t=>t.name===e))),t?t.name:e}));W(t),a("post_types",t)},help:h("Select which post types to include in the static export. If you remove all selections, all post types will be included by default.","simply-static"),tokenizeOnSpace:!1,__experimentalExpandOnFocus:!0,__experimentalShowHowTo:!1,maxSuggestions:100,className:"horizontal-token-field"}),(0,e.createElement)(c.__experimentalSpacer,{margin:2})):(0,e.createElement)("p",null,h("Loading post types...","simply-static"))),(0,e.createElement)("div",{className:"crawler-descriptions"},F.map((t=>(0,e.createElement)("div",{key:t.id,className:"crawler-description"},(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,{className:"crawler-name"},(0,e.createElement)("strong",null,t.name,":")),(0,e.createElement)(c.FlexItem,null,t.description))))))):(0,e.createElement)("p",null,h("Loading crawlers...","simply-static"))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,h("Include","simply-static"),(0,e.createElement)(m,{title:h("Include & Exclude files and pages","simply-static"),videoUrl:"https://youtu.be/voAHfwVMLi8"}))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextareaControl,{label:h("Additional URLs","simply-static"),placeholder:options.home+"/hidden-page/",help:h("If you want to create static copies of pages or files that aren't linked to, add the URLs here (one per line).","simply-static"),value:t.additional_urls,onChange:e=>{a("additional_urls",e)}}),(0,e.createElement)(c.TextareaControl,{label:h("Additional Files and Directories","simply-static"),placeholder:options.home_path+"additional-directory/\n"+options.home_path+"additional-file.html",help:h("Sometimes you may want to include additional files (such as files referenced via AJAX) or directories. Add the paths to those files or directories here (one per line).","simply-static"),value:t.additional_files,onChange:e=>{a("additional_files",e)}}),(0,e.createElement)(c.ClipboardButton,{variant:"secondary",text:options.home_path,onCopy:()=>P(!0),onFinishCopy:()=>P(!1)},h(x?"Copied home path":"Copy home path","simply-static")),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.ToggleControl,{label:(0,e.createElement)(e.Fragment,null,h("Generate 404 Page?","simply-static"),(0,e.createElement)(m,{title:h("How to manage 404 pages?","simply-static"),videoUrl:"https://youtu.be/dnRtuQrXG-k"})),help:h(k?"Generate a 404 page based on your theme template.":"Don't generate a 404 page.","simply-static"),checked:k,onChange:e=>{R(e),a("generate_404",e)}}),(0,e.createElement)(c.ToggleControl,{label:(0,e.createElement)(e.Fragment,null,h("Include RSS Feeds?","simply-static")),help:h(I?"Include feed URLs of all your posts.":"Don't include feed URLs for all your posts.","simply-static"),checked:I,onChange:e=>{A(e),a("add_feeds",e)}}),(0,e.createElement)(c.ToggleControl,{label:(0,e.createElement)(e.Fragment,null,h("Include Rest API?","simply-static")),help:h(D?"Include all Rest API endpoints as JSON files.":"Don't include Rest API endpoints as JSON files.","simply-static"),checked:D,onChange:e=>{N(e),a("add_rest_api",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,h("Exclude","simply-static"),(0,e.createElement)(m,{title:h("Include & Exclude files and pages","simply-static"),videoUrl:"https://youtu.be/voAHfwVMLi8"}))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextareaControl,{label:h("Urls to exclude","simply-static"),placeholder:"some-directory\nsome-file.json\n.jpg",help:h("Specify URLs (or parts of URLs) you want to exclude from the processing (one per line).","simply-static"),value:t.urls_to_exclude,onChange:e=>{a("urls_to_exclude",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),i&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,h("Settings saved successfully.","simply-static"))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5})),(0,e.createElement)("div",{className:"save-settings"},(0,e.createElement)(c.Button,{onClick:()=>{r(),s(!0),setTimeout((function(){s(!1)}),2e3)},variant:"primary"},h("Save Settings","simply-static"))))},{__:y}=wp.i18n,f=function(){const{configs:t,resetDiagnostics:a}=(0,n.useContext)(o),[l,r]=(0,n.useState)(!1);return(0,e.createElement)("div",{className:"inner-settings"},(0,e.createElement)("div",null,(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,y("Diagnostics","simply-static"),(0,e.createElement)(m,{title:y("How to use diagnostics","simply-static"),videoUrl:"https://youtu.be/X59YMlz6F2s"}))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,y("Our diagnostics tool provides detailed insights into your WordPress installation and server configuration and tells you exactly what needs to be optimized to get the most out of Simply Static. Click the button below to get the latest results.","simply-static")),(0,e.createElement)("p",null,(0,e.createElement)(c.Button,{onClick:()=>{a(),r(!0),setTimeout((function(){window.location.reload()}),2e3)},variant:"secondary"},y("Reset Diagnostics","simply-static"))),l?(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,y("Diagnostics resetted successfully.","simply-static"))))):"")),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),Object.keys(t).map((n=>{const a=t[n];return(0,e.createElement)("div",{key:n},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,n)),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("div",null,(0,e.createElement)("table",{style:{width:"100%",tableLayout:"fixed"}},(0,e.createElement)("tbody",{className:"table-data"},Object.entries(a).map((t=>(0,e.createElement)("tr",{className:"table-row",key:t[0]},(0,e.createElement)("td",{className:"diagnostics-icon"}," ",t[1].test?(0,e.createElement)(c.Dashicon,{className:"icon-yes",icon:"yes"}):(0,e.createElement)(c.Dashicon,{className:"icon-no",icon:"no"})),(0,e.createElement)("td",{className:"diagnostics-test"},(0,e.createElement)("b",null,t[0])),(0,e.createElement)("td",null,t[1].test),(0,e.createElement)("td",{className:"diagnostics-result"}," ",t[1].test?(0,e.createElement)("p",null,t[1].description):(0,e.createElement)("p",null,t[1].error)))))))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}))}))))},{__:b}=wp.i18n,E=function(){const{settings:t,importSettings:a,saveSettings:l,resetSettings:r,migrateSettings:i,resetDatabase:s}=(0,n.useContext)(o),[p,u]=(0,n.useState)(!1),[d,h]=(0,n.useState)(!1),[g,y]=(0,n.useState)(!1),[f,E]=(0,n.useState)(!1),[v,w]=(0,n.useState)(!1),[S,C]=(0,n.useState)(!1),[_,x]=(0,n.useState)(!1);return(0,e.createElement)("div",{className:"inner-settings"},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,b("Migrate Settings","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,b("Migrate all of your settings to Simply Static 3.0","simply-static")),(0,e.createElement)("p",null,(0,e.createElement)(c.Button,{onClick:()=>{i(),l(),w(!0),setTimeout((function(){w(!1),location.reload()}),2e3)},variant:"primary"},b("Migrate settings","simply-static"))),v?(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,b("Settings migration successfully.","simply-static"))))):"")),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,b("Export","simply-static"),(0,e.createElement)(m,{title:b("Export & Import settings","simply-static"),videoUrl:"https://youtu.be/fmM123Y-gwg"}))),(0,e.createElement)(c.CardBody,null,p?(0,e.createElement)(e.Fragment,null,(0,e.createElement)("p",null,(0,e.createElement)("code",null,JSON.stringify(t))),(0,e.createElement)("p",null,(0,e.createElement)(c.ClipboardButton,{variant:"secondary",text:JSON.stringify(t),onCopy:()=>C(!0),onFinishCopy:()=>C(!1)},b(S?"Copied!":"Copy export data","simply-static")))):(0,e.createElement)("p",null,(0,e.createElement)(c.Button,{onClick:u,variant:"primary"},b("Export Settings","simply-static"))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,b("Import","simply-static"),(0,e.createElement)(m,{title:b("Export & Import settings","simply-static"),videoUrl:"https://youtu.be/fmM123Y-gwg"}))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,b("Paste in the JSON string you got from your export to import all settings for the plugin.","simply-static")),(0,e.createElement)("textarea",{rows:"8",name:"import-data",onChange:e=>{x(JSON.parse(e.target.value))}}),(0,e.createElement)("p",null,(0,e.createElement)(c.Button,{onClick:()=>{a(_),h(!0),setTimeout((function(){h(!1)}),2e3)},variant:"primary"},b("Import Settings","simply-static"))),d?(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,b("Settings imported successfully.","simply-static"))))):"")),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,b("Reset","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,b('By clicking the "Reset Plugin Settings", you will reset all plugin settings. This can be useful if you want to import a new set of settings or you want a fresh start.',"simply-static")),(0,e.createElement)("p",null,b('If you click the "Reset Database Table" button instead, you will keep all your settings, and we will only recreate our DB table.',"simply-static")),(0,e.createElement)("p",null,(0,e.createElement)(c.Button,{onClick:()=>{r(),y(!0),setTimeout((function(){y(!1)}),2e3)},variant:"secondary"},b("Reset Plugin Settings","simply-static")),(0,e.createElement)(c.Button,{onClick:()=>{s(),E(!0),setTimeout((function(){E(!1)}),2e3)},className:"reset-db-btn",variant:"primary"},b("Reset Database Table","simply-static"))),g?(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,b("Settings resetted successfully.","simply-static"))))):"",f?(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,b("Database table resetted successfully.","simply-static"))))):"")))},{__:v}=wp.i18n,w=function(){var t;const{settings:a,updateSetting:r,saveSettings:i,settingsSaved:s,setSettingsSaved:p,isRunning:u,isPro:d,isStudio:h}=(0,n.useContext)(o),[g,y]=(0,n.useState)("zip"),[f,b]=(0,n.useState)(!1),[E,w]=(0,n.useState)("personal"),[S,C]=(0,n.useState)("private"),[_,x]=(0,n.useState)(!1),[P,k]=(0,n.useState)(!1),[R,O]=(0,n.useState)("us-east-2"),[T,I]=(0,n.useState)("aws-iam-key"),[A,D]=(0,n.useState)(!1),[N,F]=(0,n.useState)(!1),[$,L]=(0,n.useState)(!1),[j,H]=(0,n.useState)(!1),[M]=(0,n.useState)([{label:v("ZIP Archive","simply-static"),value:"zip"},{label:v("Local Directory","simply-static"),value:"local"},{label:v("Static Studio","simply-static"),value:"simply-static-studio"},{label:v("SFTP","simply-static"),value:"sftp"},{label:v("GitHub","simply-static"),value:"github"},{label:v("AWS S3","simply-static"),value:"aws-s3"},{label:v("Bunny CDN","simply-static"),value:"cdn"},{label:v("Tiiny.host","simply-static"),value:"tiiny"}]),B=()=>{i(),p(!0),L(!1),setTimeout((function(){p(!1)}),2e3)};return(0,n.useEffect)((()=>{a.delivery_method&&y(a.delivery_method),a.clear_directory_before_export&&b(a.clear_directory_before_export),a.github_account_type&&w(a.github_account_type),a.github_repository_visibility&&C(a.github_repository_visibility),a.github_repository_visibility&&C(a.github_repository_visibility),a.github_throttle_requests&&k(a.github_throttle_requests),a.aws_empty&&x(a.aws_empty),a.aws_auth_method&&I(a.aws_auth_method),a.aws_region&&O(a.aws_region),l()({path:"/simplystatic/v1/pages"}).then((e=>{let t=e;t.unshift({label:v("No page selected","simply-static"),value:0}),F(t)}))}),[a]),(0,e.createElement)("div",{className:"inner-settings"},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,v("Deployment Settings","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,v("Choose from a variety of deployment methods. Depending on your selection we either provide a ZIP file, export to a local directory or send your files to a remote destination.","simply-static")),(0,e.createElement)(c.SelectControl,{label:v("Deployment method","simply-static"),value:g,options:M,onChange:e=>{y(e),r("delivery_method",e),L(!0)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),"simply-static-studio"===g&&(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,v("Static Studio","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,v("The all-in-one Static WordPress cloud-hosting platform.","simply-static")),(0,e.createElement)("p",null,v("Enjoy secure WordPress, the fastest exports, and the best-performing static site hosting in one package.","simply-static")),(0,e.createElement)("p",null,(0,e.createElement)("a",{class:"button button-primary",href:"https://simplystatic.com/simply-static-studio/",target:"_blank"},"Check out Static Studio")))),"zip"===g&&(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,v("ZIP","simply-static"),(0,e.createElement)(m,{title:v("How to export a ZIP file","simply-static"),videoUrl:"https://youtu.be/WHaFjDte6zI"}))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,v("Get a download link in the activity log once the static export has finished.","simply-static")))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),"local"===g&&(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,v("Local Directory","simply-static"),(0,e.createElement)(m,{title:v("How to deploy to a local directory","simply-static"),videoUrl:"https://youtu.be/ZRdXQB5slnY"}))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextControl,{label:v("Path","simply-static"),type:"text",help:v("This is the directory where your static files will be saved. We will create it automatically on the first export if it doesn't exist.","simply-static"),placeholder:options.home_path+"public_static/",value:a.local_dir,onChange:e=>{r("local_dir",e)}}),(0,e.createElement)("p",null,(0,e.createElement)(c.ClipboardButton,{variant:"secondary",text:options.home_path,onCopy:()=>D(!0),onFinishCopy:()=>D(!1)},v(A?"Copied home path":"Copy home path","simply-static"))),(0,e.createElement)("p",null,(0,e.createElement)(c.ToggleControl,{label:v("Clear Local Directory","simply-static"),help:v(f?"Clear local directory before running an export.":"Don't clear local directory before running an export.","simply-static"),checked:f,onChange:e=>{b(e),r("clear_directory_before_export",e)}})))),(0,e.createElement)(e.Fragment,null,"github"===g&&(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,(0,e.createElement)("b",null,v("GitHub","simply-static")," ",(0,e.createElement)(m,{title:v("How to deploy to a GitHub (2/2)","simply-static"),videoUrl:"https://youtu.be/HqyTKwZuUAM"}))),("free"===options.plan||!d())&&(0,e.createElement)(c.FlexItem,null,(0,e.createElement)(c.ExternalLink,{href:"https://simplystatic.com"}," ",v("Requires Simply Static Pro","simply-static"))))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,v("GitHub enables you to export your static website to one of the common static hosting providers like Netlify, Cloudflare Pages or GitHub Pages.","simply-static")),(0,e.createElement)(c.SelectControl,{label:v("Account Type","simply-static"),value:E,help:v("Depending on the account type the settings fields will change.","simply-static"),disabled:"free"===options.plan||!d(),options:[{label:v("Personal","simply-static"),value:"personal"},{label:v("Organization","simply-static"),value:"organization"}],onChange:e=>{w(e),r("github_account_type",e)}}),"organization"===E?(0,e.createElement)(c.TextControl,{label:v("Organization","simply-static"),type:"text",help:v("Enter the name of your organization.","simply-static"),disabled:"free"===options.plan||!d(),value:a.github_user,onChange:e=>{r("github_user",e)}}):(0,e.createElement)(c.TextControl,{label:v("Username","simply-static"),type:"text",help:v("Enter your GitHub username.","simply-static"),disabled:"free"===options.plan||!d(),value:a.github_user,onChange:e=>{r("github_user",e)}}),(0,e.createElement)(c.TextControl,{label:v("E-Mail","simply-static"),type:"email",help:v("Enter your GitHub email address. This will be used to commit files to your repository.","simply-static"),disabled:"free"===options.plan||!d(),value:a.github_email,onChange:e=>{r("github_email",e)}}),(0,e.createElement)(c.TextControl,{label:(0,e.createElement)(e.Fragment,null,v("Personal Access Token","simply-static"),(0,e.createElement)(m,{title:v("How to prepare your GitHub account","simply-static"),videoUrl:"https://youtu.be/fjsJJmPeKuc"})),type:"password",help:(0,e.createElement)(e.Fragment,null,v("You need a personal access token from GitHub. Learn how to get one ","simply-static"),(0,e.createElement)("a",{href:"https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic",target:"_blank"},v("here","simply-static"))),disabled:"free"===options.plan||!d(),value:a.github_personal_access_token,onChange:e=>{r("github_personal_access_token",e)}}),(0,e.createElement)(c.TextControl,{label:v("Repository","simply-static"),type:"text",help:v("Enter a name for your repository (lowercase without spaces or special characters).","simply-static"),disabled:"free"===options.plan||!d(),value:a.github_repository,onChange:e=>{r("github_repository",e)}}),(0,e.createElement)(c.Notice,{status:"warning",isDismissible:!1},(0,e.createElement)("p",null,v("Ensure to create the repository and add a readme file to it before running an export as shown in the docs ","simply-static"),(0,e.createElement)("a",{href:"https://docs.simplystatic.com/article/33-set-up-the-github-integration/",target:"_blank"},v("here","simply-static")))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.TextControl,{label:v("Folder","simply-static"),type:"text",help:v("Enter a relative path to a folder if you want to push files under it. Example: for github.com/USER/REPOSITORY/folder1, enter folder1","simply-static"),disabled:"free"===options.plan||!d(),value:a.github_folder_path,onChange:e=>{r("github_folder_path",e)}}),"organization"===E&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Notice,{status:"warning",isDismissible:!1},(0,e.createElement)("p",null,v("You need to create the repository manually within your organization before connecting it.","simply-static"))),(0,e.createElement)(c.__experimentalSpacer,{margin:5})),(0,e.createElement)(c.SelectControl,{label:v("Visiblity","simply-static"),value:S,help:v("Decide if you want to make your repository public or private.","simply-static"),disabled:"free"===options.plan||!d(),options:[{label:v("Public","simply-static"),value:"public"},{label:v("Private","simply-static"),value:"private"}],onChange:e=>{C(e),r("github_repository_visibility",e)}}),(0,e.createElement)(c.TextControl,{label:v("Branch","simply-static"),type:a.github_branch,placeholder:"main",help:v('Simply Static automatically uses "main" as branch. You may want to modify that for example to gh-pages. for GitHub Pages.',"simply-static"),disabled:"free"===options.plan||!d(),value:a.github_branch,onChange:e=>{r("github_branch",e)}}),(0,e.createElement)(c.TextControl,{label:v("Webhook URL","simply-static"),type:"url",help:v("Enter your Webhook URL here and Simply Static will send a POST request after all files are commited to GitHub.","simply-static"),disabled:"free"===options.plan||!d(),value:a.github_webhook_url,onChange:e=>{r("github_webhook_url",e)}}),(0,e.createElement)(c.ToggleControl,{label:v("Throttle Requests","simply-static"),help:v("Enable this option if you are experiencing issues with the GitHub API rate limit.","simply-static"),disabled:"free"===options.plan||!d(),checked:P,onChange:e=>{k(e),r("github_throttle_requests",e)}}),(0,e.createElement)(c.TextControl,{label:v("Batch size","simply-static"),type:"number",help:v("Enter the number of files you want to be processed in a single batch. If current export fails to deploy, lower the number.","simply-static"),disabled:"free"===options.plan||!d(),value:null!==(t=a.github_batch_size)&&void 0!==t?t:100,onChange:e=>{r("github_batch_size",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),"tiiny"===g&&(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,(0,e.createElement)("b",null,v("Tiiny.host","simply-static")," ",(0,e.createElement)(m,{title:v("How to deploy to Tiiny.host","simply-static"),videoUrl:"https://youtu.be/Y9EDaQkGl1Y"}))),("free"===options.plan||!d())&&(0,e.createElement)(c.FlexItem,null,(0,e.createElement)(c.ExternalLink,{href:"https://simplystatic.com"}," ",v("Requires Simply Static Pro","simply-static"))))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,v("Deploying to Tiiny.host is the easiest and fastest deployment option available in Simply Static Pro.","simply-static")),(0,e.createElement)(c.TextControl,{disabled:!0,label:v("E-Mail","simply-static"),type:"text",help:(0,e.createElement)(e.Fragment,null,v("This field is auto-filled with the e-mail address used for activating Simply Static Pro.","simply-static"),(0,e.createElement)("br",null),(0,e.createElement)("b",null,v("An account will be created automatically on your first deployment.","simply-static"))),value:options.admin_email}),(0,e.createElement)(c.TextControl,{label:v("Subdomain","simply-static"),type:"text",help:v("That's the part before your TLD. Your full URL is the combination of the subdomain plus the domain suffix.","simply-static"),disabled:"free"===options.plan||!d(),value:a.tiiny_subdomain,onChange:e=>{r("tiiny_subdomain",e)}}),(0,e.createElement)(c.TextControl,{label:v("Domain Suffix","simply-static"),type:"text",help:v("This defaults to tiiny.site. If you have a custom domain configured in Tiiny.host, you can also use  that one.","simply-static"),disabled:"free"===options.plan||!d(),value:a.tiiny_domain_suffix,onChange:e=>{r("tiiny_domain_suffix",e)}}),(0,e.createElement)(c.TextControl,{label:v("Password Protection","simply-static"),type:"password",help:v("Adding a password will activate password protection on your static site. The website is only visible with the password.","simply-static"),disabled:"free"===options.plan||!d(),value:a.tiiny_password,onChange:e=>{r("tiiny_password",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),"cdn"===g&&(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,(0,e.createElement)("b",null,v("Bunny CDN","simply-static"),(0,e.createElement)(m,{title:v("How to deploy to Bunny CDN","simply-static"),videoUrl:"https://youtu.be/FBRg1BI41VY"}))),("free"===options.plan||!d())&&(0,e.createElement)(c.FlexItem,null,(0,e.createElement)(c.ExternalLink,{href:"https://simplystatic.com"}," ",v("Requires Simply Static Pro","simply-static"))))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,v("Bunny CDN is a fast and reliable CDN provider that you can run your static website on.","simply-static")),(0,e.createElement)(c.TextControl,{label:v("Bunny CDN API Key","simply-static"),type:"password",help:(0,e.createElement)(e.Fragment,null,v("Enter your API Key from Bunny CDN. You can find your API-Key as described ","simply-static"),(0,e.createElement)("a",{href:"https://support.bunny.net/hc/en-us/articles/360012168840-Where-do-I-find-my-API-key",target:"_blank"},v("here","simply-static"))),disabled:"free"===options.plan||!d(),value:a.cdn_api_key,onChange:e=>{r("cdn_api_key",e)}}),(0,e.createElement)(c.TextControl,{label:v("Storage Host","simply-static"),type:"text",help:(0,e.createElement)(e.Fragment,null,v("Depending on your location, you have a different storage host. You find out which URL to use ","simply-static"),(0,e.createElement)("a",{href:"https://docs.bunny.net/reference/storage-api#storage-endpoints",target:"_blank"},v("here","simply-static"))),disabled:"free"===options.plan||!d(),value:a.cdn_storage_host,onChange:e=>{r("cdn_storage_host",e)}}),(0,e.createElement)(c.TextControl,{label:v("Bunny CDN Access Key","simply-static"),type:"password",help:v("Enter your Acess Key from Bunny CDN. You will find it within your storage zone setttings within FTP & API Access -> Password.","simply-static"),disabled:"free"===options.plan||!d(),value:a.cdn_access_key,onChange:e=>{r("cdn_access_key",e)}}),(0,e.createElement)(c.TextControl,{label:v("Pull Zone","simply-static"),type:"text",help:v("A pull zone is the connection of your CDN to the internet. Simply Static will try to find an existing pull zone with the provided name, if there is none it creates a new pull zone.","simply-static"),disabled:"free"===options.plan||!d(),value:a.cdn_pull_zone,onChange:e=>{r("cdn_pull_zone",e)}}),(0,e.createElement)(c.TextControl,{label:v("Storage Zone","simply-static"),type:"text",help:v("A storage zone contains your static files. Simply Static will try to find an existing storage zone with the provided name, if there is none it creates a new storage zone.","simply-static"),disabled:"free"===options.plan||!d(),value:a.cdn_storage_zone,onChange:e=>{r("cdn_storage_zone",e)}}),(0,e.createElement)(c.TextControl,{label:v("Subdirectory","simply-static"),type:"text",placeholder:"/subdirectory/",help:v("If you want to transfer the files to a specific subdirectory on your storage zone add the name of that directory here.","simply-static"),disabled:"free"===options.plan||!d(),value:a.cdn_directory,onChange:e=>{r("cdn_directory",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),"aws-s3"===g&&(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,(0,e.createElement)("b",null,v("Amazon AWS S3","simply-static"),(0,e.createElement)(m,{title:v("How to deploy to Amazon AWS S3","simply-static"),videoUrl:"https://youtu.be/rtn21J86Upc"}))),("free"===options.plan||!d())&&(0,e.createElement)(c.FlexItem,null,(0,e.createElement)(c.ExternalLink,{href:"https://simplystatic.com"}," ",v("Requires Simply Static Pro","simply-static"))))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.SelectControl,{label:v("Authentication Method","simply-static"),value:T,options:[{label:v("AWS IAM Access Key","simply-static"),value:"aws-iam-key"},{label:v("AWS EC2","simply-static"),value:"aws-ec2"}],disabled:"free"===options.plan||!d(),onChange:e=>{I(e),r("aws_auth_method",e)}}),"aws-iam-key"===T&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.TextControl,{label:v("Access Key ID","simply-static"),type:"text",help:(0,e.createElement)(e.Fragment,null,v("Enter your Access Key from AWS. Learn how to get one ","simply-static"),(0,e.createElement)("a",{href:"https://docs.aws.amazon.com/en_en/IAM/latest/UserGuide/id_credentials_access-keys.html",target:"_blank"},v("here","simply-static"))),disabled:"free"===options.plan||!d(),value:a.aws_access_key,onChange:e=>{r("aws_access_key",e)}}),(0,e.createElement)(c.TextControl,{label:v("Secret Access Key","simply-static"),type:"password",help:(0,e.createElement)(e.Fragment,null,v("Enter your Secret Key from AWS. Learn how to get one ","simply-static"),(0,e.createElement)("a",{href:"https://docs.aws.amazon.com/en_en/IAM/latest/UserGuide/id_credentials_access-keys.html",target:"_blank"},v("here","simply-static"))),disabled:"free"===options.plan||!d(),value:a.aws_access_secret,onChange:e=>{r("aws_access_secret",e)}})),(0,e.createElement)(c.SelectControl,{label:v("Region","simply-static"),value:R,options:[{label:v("US East (Ohio)","simply-static"),value:"us-east-2"},{label:v("US East (N. Virginia)","simply-static"),value:"us-east-1"},{label:v("US West (N. California)","simply-static"),value:"us-west-1"},{label:v("US West (Oregon)","simply-static"),value:"us-west-2"},{label:v("Africa (Cape Town)","simply-static"),value:"af-south-1"},{label:v("Asia Pacific (Hong Kong)","simply-static"),value:"ap-east-1"},{label:v("Asia Pacific (Hyderabad)","simply-static"),value:"ap-south-2"},{label:v("Asia Pacific (Jakarta)","simply-static"),value:"ap-southeast-3"},{label:v("Asia Pacific (Melbourne)","simply-static"),value:"ap-southeast-4"},{label:v("Asia Pacific (Mumbai)","simply-static"),value:"ap-south-1"},{label:v("Asia Pacific (Osaka)","simply-static"),value:"ap-northeast-3"},{label:v("Asia Pacific (Seoul)","simply-static"),value:"ap-northeast-2"},{label:v("Asia Pacific (Singapore)","simply-static"),value:"ap-southeast-1"},{label:v("Asia Pacific (Sydney)","simply-static"),value:"ap-southeast-2"},{label:v("Asia Pacific (Tokyo)","simply-static"),value:"ap-northeast-1"},{label:v("Canada (Central)","simply-static"),value:"ca-central-1"},{label:v("Europe (Frankfurt)","simply-static"),value:"eu-central-1"},{label:v("Europe (Ireland)","simply-static"),value:"eu-west-1"},{label:v("Europe (London)","simply-static"),value:"eu-west-2"},{label:v("Europe (Milan)","simply-static"),value:"eu-south-1"},{label:v("Europe (Paris)","simply-static"),value:"eu-west-3"},{label:v("Europe (Spain)","simply-static"),value:"eu-south-2"},{label:v("Europe (Stockholm)","simply-static"),value:"eu-north-1"},{label:v("Europe (Zurich)","simply-static"),value:"eu-central-2"},{label:v("Middle East (Bahrain)","simply-static"),value:"me-south-1"},{label:v("Middle East (UAE)","simply-static"),value:"me-central-1"},{label:v("South America (São Paulo)","simply-static"),value:"sa-east-1"},{label:v("AWS GovCloud (US-East)","simply-static"),value:"us-gov-east-1"},{label:v("AWS GovCloud (US-West)","simply-static"),value:"us-gov-west-1"}],disabled:"free"===options.plan||!d(),onChange:e=>{O(e),r("aws_region",e)}}),(0,e.createElement)(c.TextControl,{label:v("Bucket","simply-static"),type:"text",help:v("Add the name of your bucket here.","simply-static"),disabled:"free"===options.plan||!d(),value:a.aws_bucket,onChange:e=>{r("aws_bucket",e)}}),(0,e.createElement)(c.TextControl,{label:v("Subdirectory","simply-static"),type:"text",help:v("Add an optional subdirectory for your bucket","simply-static"),disabled:"free"===options.plan||!d(),value:a.aws_subdirectory,onChange:e=>{r("aws_subdirectory",e)}}),(0,e.createElement)(c.TextControl,{label:v("Cloudfront Distribution ID","simply-static"),type:"text",help:v("We automatically invalidate the cache after each export.","simply-static"),disabled:"free"===options.plan||!d(),value:a.aws_distribution_id,onChange:e=>{r("aws_distribution_id",e)}}),(0,e.createElement)(c.TextControl,{label:v("Webhook URL","simply-static"),type:"url",help:v("Enter your Webhook URL here and Simply Static will send a POST request after all files are transferred to AWS S3.","simply-static"),disabled:"free"===options.plan||!d(),value:a.aws_webhook_url,onChange:e=>{r("aws_webhook_url",e)}}),(0,e.createElement)(c.ToggleControl,{label:v("Empty bucket before new export?","simply-static"),help:v(_?"Clear bucket before new export.":"Don't clear bucket before new export.","simply-static"),disabled:"free"===options.plan||!d(),checked:_,onChange:e=>{x(e),r("aws_empty",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),"sftp"===g&&(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,(0,e.createElement)("b",null,v("SFTP","simply-static")," ",(0,e.createElement)(m,{title:v("How to deploy via SFTP","simply-static"),videoUrl:"https://youtu.be/6-QR9wZA3VQ"}))),("free"===options.plan||!d())&&(0,e.createElement)(c.FlexItem,null,(0,e.createElement)(c.ExternalLink,{href:"https://simplystatic.com"}," ",v("Requires Simply Static Pro","simply-static"))))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextControl,{label:v("Host","simply-static"),type:"text",help:v("Enter your SFTP host.","simply-static"),value:a.sftp_host,disabled:"free"===options.plan||!d(),onChange:e=>{r("sftp_host",e)}}),(0,e.createElement)(c.TextControl,{label:v("Port","simply-static"),type:"number",disabled:"free"===options.plan||!d(),help:v("Enter your SFTP port.","simply-static"),value:a.sftp_port,onChange:e=>{r("sftp_port",e)}}),(0,e.createElement)(c.TextControl,{label:v("SFTP username","simply-static"),help:v("Enter your SFTP username.","simply-static"),type:"text",disabled:"free"===options.plan||!d(),placeholder:"username",value:a.sftp_user,onChange:e=>{r("sftp_user",e)}}),(0,e.createElement)(c.TextControl,{label:v("SFTP password","simply-static"),type:"password",disabled:"free"===options.plan||!d(),help:v("Enter your SFTP password.","simply-static"),value:a.sftp_pass,onChange:e=>{r("sftp_pass",e)}}),(0,e.createElement)(c.TextareaControl,{label:v("SFTP private key","simply-static"),disabled:"free"===options.plan||!d(),placeholder:v("OPTIONAL: This is only required if you need to authenticate via a private key to access your SFTP server.","simply-static"),help:v("Enter your SFTP private key if you want passwordless upload and the server is configured to allow it. You can set it as a constant in wp-config.php by using define('SSP_SFTP_KEY', 'YOUR_KEY')","simply-static"),value:a.sftp_private_key,onChange:e=>{r("sftp_private_key",e)}}),(0,e.createElement)(c.TextControl,{label:v("SFTP folder","simply-static"),help:v('Leave empty to upload to the default SFTP folder. Enter a folder path where you want the static files to be uploaded to (example: "uploads" will upload to uploads folder. "uploads/new-folder" will upload files to "new-folder"). ',"simply-static"),type:"text",disabled:"free"===options.plan||!d(),placeholder:"",value:a.sftp_folder,onChange:e=>{r("sftp_folder",e)}})))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),s&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,v("Settings saved successfully.","simply-static"))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5})),(0,e.createElement)("div",{className:"save-settings"},"free"===options.plan?(0,e.createElement)(e.Fragment,null,"zip"===g&&(0,e.createElement)(c.Button,{onClick:B,variant:"primary"},v("Save Settings","simply-static")),"local"===g&&(0,e.createElement)(c.Button,{onClick:B,variant:"primary"},v("Save Settings","simply-static"))):(0,e.createElement)(c.Button,{onClick:B,variant:"primary"},v("Save Settings","simply-static")),"pro"===options.plan&&d()&&(0,e.createElement)(c.Button,{disabled:u||$||j,variant:"secondary",isBusy:u||j,onClick:()=>{H(!0),l()({path:"/simplystatic/v1/apply-single",method:"POST"}).then((e=>{404===parseInt(e.status)?alert(e.message):window.location.reload()}))}},$&&v("Save settings to test","simply-static"),!$&&v("Test Deployment","simply-static"))))},{__:S}=wp.i18n,C=function(){const{settings:t,updateSetting:a,saveSettings:r,settingsSaved:i,setSettingsSaved:s,isPro:p}=(0,n.useContext)(o),[u,d]=(0,n.useState)("allowed_http_origins"),[h,g]=(0,n.useState)(!1),[y,f]=(0,n.useState)(!1),[b,E]=(0,n.useState)(!1);return(0,n.useEffect)((()=>{l()({path:"/simplystatic/v1/pages-slugs"}).then((e=>{let t=e;t.unshift({label:S("No page selected","simply-static"),value:""}),E(t)})),t.fix_cors&&d(t.fix_cors),t.use_forms&&g(t.use_forms),t.use_comments&&f(t.use_comments)}),[t]),(0,e.createElement)("div",{className:"inner-settings"},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,(0,e.createElement)("b",null,S("Forms","simply-static"))),("free"===options.plan||!p())&&(0,e.createElement)(c.FlexItem,null,(0,e.createElement)(c.ExternalLink,{href:"https://simplystatic.com"}," ",S("Requires Simply Static Pro","simply-static"))))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.ToggleControl,{label:S("Use forms?","simply-static"),help:S(h?"Use Forms on your static website.":"Don't use forms on your static website.","simply-static"),disabled:"free"===options.plan||!p(),checked:h,onChange:e=>{g(e),a("use_forms",e)}}),h&&options.form_connection_url&&"free"!==options.plan&&(0,e.createElement)(c.Button,{href:options.form_connection_url,variant:"secondary"},S("Create a form connection","simply-static")))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,(0,e.createElement)("b",null,S("Comments","simply-static"))),("free"===options.plan||!p())&&(0,e.createElement)(c.FlexItem,null,(0,e.createElement)(c.ExternalLink,{href:"https://simplystatic.com"}," ",S("Requires Simply Static Pro","simply-static"))))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.ToggleControl,{label:S("Use comments?","simply-static"),help:S(y?"Use comments on your static website.":"Don't use comments on your static website.","simply-static"),disabled:"free"===options.plan||!p(),checked:y,onChange:e=>{f(e),a("use_comments",e)}}),y&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.SelectControl,{label:S("Select a redirect page","content-protector"),options:b,help:S("The post will be regenerated after comment submission, but it might take a while so its good practice to redirect the visitor.","simply-static"),disabled:"free"===options.plan||!p(),value:t.comment_redirect,onChange:e=>{a("comment_redirect",e)}})))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,(0,e.createElement)("b",null,S("CORS","simply-static"),(0,e.createElement)(m,{title:S("How to deal with CORS","simply-static"),videoUrl:"https://youtu.be/fArtvZhkU14"}))),("free"===options.plan||!p())&&(0,e.createElement)(c.FlexItem,null,(0,e.createElement)(c.ExternalLink,{href:"https://simplystatic.com"}," ",S("Requires Simply Static Pro","simply-static"))))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,S("When using Forms and Comments in Simply Static Pro you may encounter CORS issues as you make requests from your static website to your original one.","simply-static")),(0,e.createElement)(c.Notice,{status:"warning",isDismissible:!1},(0,e.createElement)("p",null,S("Due to the variety of server setups out there, you may need to make changes on your server.","simply-static"))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.TextControl,{label:S("Static URL","simply-static"),type:"url",placeholder:"https://static-site.com",help:S("Add the URL of your static website to allow CORS from it.","simply-static"),disabled:"free"===options.plan||!p(),value:t.static_url,onChange:e=>{a("static_url",e)}}),(0,e.createElement)(c.SelectControl,{label:S("Select CORS method","simply-static"),value:u,help:S("Choose one of the methods to allow CORS for your website.","simply-static"),disabled:"free"===options.plan||!p(),options:[{label:"allowed_http_origins",value:"allowed_http_origins"},{label:"wp_headers",value:"wp_headers"}],onChange:e=>{d(e),a("fix_cors",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,(0,e.createElement)("b",null,S("Embed Dynamic Content (iFrame)","simply-static"),(0,e.createElement)(m,{title:S("Embed Dynamic Content (iFrame)","simply-static"),videoUrl:"https://youtu.be/ZGRaG_Jma7E"}))),("free"===options.plan||!p())&&(0,e.createElement)(c.FlexItem,null,(0,e.createElement)(c.ExternalLink,{href:"https://simplystatic.com"}," ",S("Requires Simply Static Pro","simply-static"))))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,S("We replace the HTML of the URLs with an iFrame that embeds the content directly from your WordPress website.","simply-static"),(0,e.createElement)("br",null),S("This way you can use dynamic elements on your static website without the need of a specific integration.","simply-static")),(0,e.createElement)(c.Notice,{status:"warning",isDismissible:!1},(0,e.createElement)("p",null,S("This requires your WordPress website to be online all the time.","simply-static"))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.TextareaControl,{label:S("URLs to embed as an iFrame","simply-static"),placeholder:options.home+"/my-form-page/",help:S("If you want to embed specific pages from your WordPress website into your static website, add the URLs here (one per line).","simply-static"),disabled:"free"===options.plan||!p(),value:t.iframe_urls,onChange:e=>{a("iframe_urls",e)}}),(0,e.createElement)(c.TextareaControl,{label:S("Custom CSS","simply-static"),help:S("These styles will only apply to the embedded pages, not your entire website.","simply-static"),disabled:"free"===options.plan||!p(),value:t.iframe_custom_css,onChange:e=>{a("iframe_custom_css",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),i&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,S("Settings saved successfully.","simply-static"))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5})),(0,e.createElement)("div",{className:"save-settings"},"pro"===options.plan&&p()&&(0,e.createElement)(c.Button,{onClick:()=>{r(),s(!0),setTimeout((function(){s(!1),h&&(localStorage.setItem("ss-initial-page","/forms"),window.location.reload())}),2e3)},variant:"primary"},S("Save Settings","simply-static"))))},{__:_}=wp.i18n,x=function(){const{settings:t,updateSetting:a,saveSettings:l,settingsSaved:r,setSettingsSaved:i,isPro:s}=(0,n.useContext)(o),[p,u]=(0,n.useState)(!1),[d,h]=(0,n.useState)("fuse"),[g,y]=(0,n.useState)(!1),f=()=>y(!0);return(0,n.useEffect)((()=>{t.use_search&&u(t.use_search),t.search_type&&h(t.search_type)}),[t]),(0,e.createElement)("div",{className:"inner-settings"},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,(0,e.createElement)("b",null,_("Search","simply-static"))),("free"===options.plan||!s())&&(0,e.createElement)(c.FlexItem,null,(0,e.createElement)(c.ExternalLink,{href:"https://simplystatic.com"}," ",_("Requires Simply Static Pro","simply-static"))))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.ToggleControl,{label:_("Use search?","simply-static"),help:_(p?"Use search on your static website.":"Don't use search on your static website.","simply-static"),disabled:"free"===options.plan||!s(),checked:p,onChange:e=>{u(e),a("use_search",e)}}),(0,e.createElement)(c.SelectControl,{label:_("Search Type","simply-static"),value:d,help:_("Decide which search type you want to use. Fuse runs locally based on a file, and Algolia is an external API service.","simply-static"),options:[{label:"Fuse JS",value:"fuse"},{label:"Algolia API",value:"algolia"}],onChange:e=>{h(e),a("search_type",e)}}))),(0,e.createElement)(e.Fragment,null,g&&(0,e.createElement)(c.Modal,{title:_("How to select data with meta tags","simply-static"),onRequestClose:()=>y(!1)},(0,e.createElement)("p",null,_("Targeting for excerpt in the meta description tag.","simply-static")),(0,e.createElement)("pre",null,'<meta name="description" content="This content is what we want as excerpt" />'),(0,e.createElement)("p",null,_("Adding such meta in the excerpt field would be:","simply-static")),(0,e.createElement)("pre",null,"description|content"),(0,e.createElement)("p",null,_("Targeting for title in the property meta tag.","simply-static")),(0,e.createElement)("pre",null,'<meta property="og:title" content="This content is what we want as excerpt" />'),(0,e.createElement)("p",null,_("Adding such meta in the excerpt field would be:","simply-static")),(0,e.createElement)("pre",null,"property|og:title"),(0,e.createElement)("p",null,_('If the second item (after | ) is not <code>content</code>, we\'ll use it as value of that attribute (<code>property="og:title"</code> in this example) and use <code>content</code> for value.',"simply-static")),(0,e.createElement)("p",null,(0,e.createElement)("strong",null,_("Caution: Use meta tags that exist everywhere for title.","simply-static")))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,(0,e.createElement)("b",null,_("Indexing","simply-static"))),("free"===options.plan||!s())&&(0,e.createElement)(c.FlexItem,null,(0,e.createElement)(c.ExternalLink,{href:"https://simplystatic.com"}," ",_("Requires Simply Static Pro","simply-static"))))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextControl,{label:_("CSS-Selector for Title","simply-static"),type:"text",placeholder:"title",help:[_("Add the CSS selector which contains the title of the page/post","simply-static")," ",(0,e.createElement)(c.Button,{variant:"link",onClick:f},_("Or meta tags. Click for more information.","simply-static"))],disabled:"free"===options.plan||!s(),value:t.search_index_title,onChange:e=>{a("search_index_title",e)}}),(0,e.createElement)(c.TextControl,{label:_("CSS-Selector for Content","simply-static"),type:"text",placeholder:"body",help:[_("Add the CSS selector which contains the content of the page/post.","simply-static")," ",(0,e.createElement)(c.Button,{variant:"link",onClick:f},_("Or meta tags. Click for more information.","simply-static"))],disabled:"free"===options.plan||!s(),value:t.search_index_content,onChange:e=>{a("search_index_content",e)}}),(0,e.createElement)(c.TextControl,{label:_("CSS-Selector for Excerpt","simply-static"),type:"text",placeholder:".entry-content",help:[_("Add the CSS selector which contains the excerpt of the page/post.","simply-static")," ",(0,e.createElement)(c.Button,{variant:"link",onClick:f},_("Or meta tags. Click for more information.","simply-static"))],disabled:"free"===options.plan||!s(),value:t.search_index_excerpt,onChange:e=>{a("search_index_excerpt",e)}}),(0,e.createElement)(c.TextareaControl,{label:_("Exclude URLs","simply-static"),placeholder:"author\narchive\ncategory",help:_("Exclude URLs from indexing (one per line). You can use full URLs, parts of an URL or plain words (like stop words).","simply-static"),disabled:"free"===options.plan||!s(),value:t.search_excludable,onChange:e=>{a("search_excludable",e)}})))),"fuse"===d&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,(0,e.createElement)("b",null,_("Fuse.js","simply-static"),(0,e.createElement)(m,{title:_("How to add search with FuseJS","simply-static"),videoUrl:"https://youtu.be/K34l1DXjCHk"}))),("free"===options.plan||!s())&&(0,e.createElement)(c.FlexItem,null,(0,e.createElement)(c.ExternalLink,{href:"https://simplystatic.com"}," ",_("Requires Simply Static Pro","simply-static"))))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextControl,{label:_("CSS-Selector","simply-static"),type:"text",help:_("Add the CSS selector of your search element here.","simply-static"),disabled:"free"===options.plan||!s(),value:t.fuse_selector,onChange:e=>{a("fuse_selector",e)}}),(0,e.createElement)(c.__experimentalNumberControl,{label:_("Threshold","simply-static"),isShiftStepEnabled:!0,step:.1,min:.1,max:1,help:_(" A threshold of 0.0 requires a perfect match, a threshold of 1.0 would match anything.","simply-static"),disabled:"free"===options.plan||!s(),value:t.fuse_threshold,placeholder:.1,onChange:e=>{a("fuse_threshold",e)}})))),"algolia"===d&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,(0,e.createElement)("b",null,_("Algolia API","simply-static"),(0,e.createElement)(m,{title:_("How to add search with the Algolia API","simply-static"),videoUrl:"https://youtu.be/H9PNZSl0KnU"}))),("free"===options.plan||!s())&&(0,e.createElement)(c.FlexItem,null,(0,e.createElement)(c.ExternalLink,{href:"https://simplystatic.com"}," ",_("Requires Simply Static Pro","simply-static"))))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextControl,{label:_("Application ID","simply-static"),type:"password",help:_("Add your Algolia App ID.","simply-static"),disabled:"free"===options.plan||!s(),value:t.algolia_app_id,onChange:e=>{a("algolia_app_id",e)}}),(0,e.createElement)(c.TextControl,{label:_("Admin API Key","simply-static"),type:"password",help:_("Add your Algolia Admin API Key.","simply-static"),disabled:"free"===options.plan||!s(),value:t.algolia_admin_api_key,onChange:e=>{a("algolia_admin_api_key",e)}}),(0,e.createElement)(c.TextControl,{label:_("Search-Only API Key","simply-static"),type:"password",help:_("Add your Algolia Search-Only API Key here. This is the only key that will be visible on your static site.","simply-static"),disabled:"free"===options.plan||!s(),value:t.algolia_search_api_key,onChange:e=>{a("algolia_search_api_key",e)}}),(0,e.createElement)(c.TextControl,{label:_("Name for your index","simply-static"),type:"text",help:_("Add your Algolia index name here.","simply-static"),disabled:"free"===options.plan||!s(),value:t.algolia_index,onChange:e=>{a("algolia_index",e)}}),(0,e.createElement)(c.TextControl,{label:_("CSS-Selector","simply-static"),type:"text",help:_("Add the CSS selector of your search element here.","simply-static"),disabled:"free"===options.plan||!s(),value:t.algolia_selector,onChange:e=>{a("algolia_selector",e)}}),(0,e.createElement)("p",null,(0,e.createElement)(c.Notice,{status:"warning",isDismissible:!1},_("If you have multiple search elements with different CSS selectors, separate them by a comma (,) such as: .search-field, .search-field2","simply-static")))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),r&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,_("Settings saved successfully.","simply-static"))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5})),(0,e.createElement)("div",{className:"save-settings"},"pro"===options.plan&&s()&&(0,e.createElement)(c.Button,{onClick:()=>{l(),i(!0),setTimeout((function(){i(!1)}),2e3)},variant:"primary"},_("Save Settings","simply-static"))))},{__:P}=wp.i18n,k=function(){const{settings:t,updateSetting:a,saveSettings:l,settingsSaved:r,setSettingsSaved:i,isPro:s,isStudio:p}=(0,n.useContext)(o),[u,d]=(0,n.useState)(!1),[h,g]=(0,n.useState)(!1);return(0,n.useEffect)((()=>{t.debugging_mode&&d(t.debugging_mode),t.server_cron&&g(t.server_cron)}),[t]),(0,e.createElement)("div",{className:"inner-settings"},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,P("Basic Auth","simply-static"),(0,e.createElement)(m,{title:P("How to set up basic auth","simply-static"),videoUrl:"https://youtu.be/6udSR3_zSOU"}))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("p",null,P("If you've secured WordPress with HTTP Basic Auth you need to specify the username and password to use below.","simply-static")),(0,e.createElement)(c.TextControl,{label:P("Basic Auth Username","simply-static"),autoComplete:"off",type:"text",value:t.http_basic_auth_username,onChange:e=>{a("http_basic_auth_username",e)}}),(0,e.createElement)(c.TextControl,{label:P("Basic Auth Password","simply-static"),type:"password",autoComplete:"off",value:t.http_basic_auth_password,onChange:e=>{a("http_basic_auth_password",e)}}),(0,e.createElement)("p",null,(0,e.createElement)(c.ToggleControl,{label:P("Enable Basic Auth","simply-static"),help:(0,e.createElement)(e.Fragment,null,"free"===options.plan?(0,e.createElement)(e.Fragment,null,P("Automatically setting up Basic Auth requires Simply Static Pro.","simply-static")):(0,e.createElement)(e.Fragment,null,P("Once enabled we will put your entire website behind password protection.","simply-static"))),disabled:"free"===options.plan||!s(),checked:t.http_basic_auth_on,onChange:e=>{a("http_basic_auth_on",e)}}),t.http_basic_auth_on&&(!t.http_basic_auth_username||!t.http_basic_auth_password)&&(0,e.createElement)(c.Notice,{status:"warning",isDismissible:!1},P("Requires Username & Password to work","simply-static"))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),!p()&&(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,P("Temporary Files","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextControl,{label:P("Temporary Files Directory","simply-static"),type:"text",placeholder:options.temp_files_dir,help:P("Optionally specify the directory to save your temporary files. This directory must exist and be writeable.","simply-static"),value:t.temp_files_dir,onChange:e=>{a("temp_files_dir",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,P("Whitelist Plugins","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextareaControl,{label:P("Whitelist plugins in diagnostics","simply-static"),placeholder:"autoptimize\nwp-search-with-algolia\nwp-rocket",help:P("If you want to exclude certain plugins from the diagnostics check add the plugin slugs here (one per line).","simply-static"),value:t.whitelist_plugins,onChange:e=>{a("whitelist_plugins",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),!p()&&(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,P("Proxy Setup","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextControl,{label:P("Origin URL","simply-static"),type:"url",help:P("If the URL of your WordPress installation differs from the public-facing URL (Proxy Setup), add the public URL here.","simply-static"),placeholder:options.home,autoComplete:"off",value:t.origin_url,onChange:e=>{a("origin_url",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,P("Debug Log","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.ToggleControl,{label:P("Activate Debug Log","simply-static"),help:P("Enable it to download the debug log from Simply Static -> Generate.","simply-static"),checked:u,onChange:e=>{d(e),a("debugging_mode",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),!p()&&(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,P("Cron","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.ToggleControl,{label:P("Use server-side cron job","simply-static"),help:P("Enable this if you use a server-side cron job instead of the default WP-Cron.","simply-static"),checked:h,onChange:e=>{g(e),a("server_cron",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),r&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,P("Settings saved successfully.","simply-static"))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5})),(0,e.createElement)("div",{className:"save-settings"},(0,e.createElement)(c.Button,{onClick:()=>{l(),i(!0),setTimeout((function(){i(!1)}),2e3)},variant:"primary"},P("Save Settings","simply-static"))))},{__:R}=wp.i18n,O=function({integration:t,settings:a,toggleIntegration:l}){const{isQueuedIntegration:r}=(0,n.useContext)(o);let i=t.active;const s=t.pro,p=t.can_run,u=t.always_active,d=r(t.id);void 0!==a.integrations&&!1!==a.integrations&&(i=a.integrations.indexOf(t.id)>=0);let h="pro"===options.plan||!s;return(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,{className:"ss-integration"},(0,e.createElement)("div",null,(0,e.createElement)("strong",null,t.name||t.id,p&&d&&(0,e.createElement)("em",{class:"ss-text-notice"},R("Requires saving settings","simply-static")),"redirection"===t.id&&(0,e.createElement)(m,{title:R("Automated Redirects with Redirection","simply-static"),videoUrl:"https://youtu.be/sS4BQcZ4dN8"}),"complianz"===t.id&&(0,e.createElement)(m,{title:R("Cookie Consent with Complianz","simply-static"),videoUrl:"https://youtu.be/GPKYtt8A5QE"})),""!=t.description&&[(0,e.createElement)("br",null),t.description]),!p&&(0,e.createElement)("span",{className:"ss-align-right ss-no-shrink"},(0,e.createElement)("em",null,"Missing Plugin"),!h&&(0,e.createElement)("div",null,(0,e.createElement)(c.Button,{variant:"link",href:"https://simplystatic.com/pricing/"},R("Requires Simply Static Pro","simply-static")))),p&&h&&!u&&(0,e.createElement)(c.ToggleControl,{className:"integration-toggle",checked:i,onChange:e=>{l(t.id,e)}}),p&&h&&u&&(0,e.createElement)("em",null,"Always Active"),p&&!h&&(0,e.createElement)(c.Button,{variant:"primary",href:"https://simplystatic.com/pricing/"},R("Get the Pro version","simply-static"))))},{__:T}=wp.i18n,I=function(){const{settings:t,updateSetting:a,saveSettings:l,settingsSaved:r,setSettingsSaved:i,maybeQueueIntegration:s,maybeUnqueueIntegration:p}=(0,n.useContext)(o),u=(e,n)=>{n?(e=>{let n=t.integrations;!1===n&&(n=[]),n.indexOf(e)>=0||(n.push(e),a("integrations",n),s(e))})(e):(e=>{let n=t.integrations;!1===n&&(n=[]);const l=n.indexOf(e);l<0||(n.splice(l,1),a("integrations",n),p(e))})(e)},d=Object.keys(options.integrations).filter((e=>options.integrations[e].can_run&&!options.integrations[e].always_active)),m=Object.keys(options.integrations).filter((e=>!options.integrations[e].can_run&&!options.integrations[e].always_active));return(0,e.createElement)("div",{className:"inner-settings"},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,T("Integrations","simply-static"))),(0,e.createElement)(c.CardBody,null,T("Control Integrations that will be active during the export of the static site.","simply-static"))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),d.map((n=>{const a=options.integrations[n];return(0,e.createElement)(O,{integration:a,settings:t,toggleIntegration:u})})),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),m.map((n=>{const a=options.integrations[n];return(0,e.createElement)(O,{integration:a,settings:t,toggleIntegration:u})})),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),r&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,T("Settings saved successfully.","simply-static"))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5})),(0,e.createElement)("div",{className:"save-settings"},(0,e.createElement)(c.Button,{onClick:()=>{l(),i(!0),setTimeout((function(){i(!1)}),2e3)},variant:"primary"},T("Save Settings","simply-static"))))};function A(e,t){var n="function"==typeof Symbol&&e[Symbol.iterator];if(!n)return e;var a,l,r=n.call(e),i=[];try{for(;(void 0===t||t-- >0)&&!(a=r.next()).done;)i.push(a.value)}catch(e){l={error:e}}finally{try{a&&!a.done&&(n=r.return)&&n.call(r)}finally{if(l)throw l.error}}return i}"function"==typeof SuppressedError&&SuppressedError;var D,N,F=function(e){var n=e.children;return t().createElement("div",{className:"react-terminal-line"},n)};!function(e,t){void 0===t&&(t={});var n=t.insertAt;if(e&&"undefined"!=typeof document){var a=document.head||document.getElementsByTagName("head")[0],l=document.createElement("style");l.type="text/css","top"===n&&a.firstChild?a.insertBefore(l,a.firstChild):a.appendChild(l),l.styleSheet?l.styleSheet.cssText=e:l.appendChild(document.createTextNode(e))}}("/**\n * Modfied version of [termynal.js](https://github.com/ines/termynal/blob/master/termynal.css).\n *\n * @author Ines Montani <ines@ines.io>\n * @version 0.0.1\n * @license MIT\n */\n .react-terminal-wrapper {\n  width: 100%;\n  background: #252a33;\n  color: #eee;\n  font-size: 18px;\n  font-family: 'Fira Mono', Consolas, Menlo, Monaco, 'Courier New', Courier, monospace;\n  border-radius: 4px;\n  padding: 75px 45px 35px;\n  position: relative;\n  -webkit-box-sizing: border-box;\n          box-sizing: border-box;\n }\n\n.react-terminal {\n  overflow: auto;\n  display: flex;\n  flex-direction: column;\n}\n\n.react-terminal-wrapper.react-terminal-light {\n  background: #ddd;\n  color: #1a1e24;\n}\n\n.react-terminal-window-buttons {\n  position: absolute;\n  top: 15px;\n  left: 15px;\n  display: flex;\n  flex-direction: row;\n  gap: 10px;\n}\n\n.react-terminal-window-buttons button {\n  width: 15px;\n  height: 15px;\n  border-radius: 50%;\n  border: 0;\n}\n\n.react-terminal-window-buttons button.clickable {\n  cursor: pointer;\n}\n\n.react-terminal-window-buttons button.red-btn {\n  background: #d9515d;\n}\n\n.react-terminal-window-buttons button.yellow-btn {\n  background: #f4c025;\n}\n\n.react-terminal-window-buttons button.green-btn {\n  background: #3ec930;\n}\n\n.react-terminal-wrapper:after {\n  content: attr(data-terminal-name);\n  position: absolute;\n  color: #a2a2a2;\n  top: 5px;\n  left: 0;\n  width: 100%;\n  text-align: center;\n  pointer-events: none;\n}\n\n.react-terminal-wrapper.react-terminal-light:after {\n  color: #D76D77;\n}\n\n.react-terminal-line {\n  white-space: pre;\n}\n\n.react-terminal-line:before {\n  /* Set up defaults and ensure empty lines are displayed. */\n  content: '';\n  display: inline-block;\n  vertical-align: middle;\n  color: #a2a2a2;\n}\n\n.react-terminal-light .react-terminal-line:before {\n  color: #D76D77;\n}\n\n.react-terminal-input:before {\n  margin-right: 0.75em;\n  content: '$';\n}\n\n.react-terminal-input[data-terminal-prompt]:before {\n  content: attr(data-terminal-prompt);\n}\n\n.react-terminal-wrapper:focus-within .react-terminal-active-input .cursor {\n  position: relative;\n  display: inline-block;\n  width: 0.55em;\n  height: 1em;\n  top: 0.225em;\n  background: #fff;\n  -webkit-animation: blink 1s infinite;\n          animation: blink 1s infinite;\n}\n\n/* Cursor animation */\n\n@-webkit-keyframes blink {\n  50% {\n      opacity: 0;\n  }\n}\n\n@keyframes blink {\n  50% {\n      opacity: 0;\n  }\n}\n\n.terminal-hidden-input {\n    position: fixed;\n    left: -1000px;\n}\n\n/* .react-terminal-progress {\n  display: flex;\n  margin: .5rem 0;\n}\n\n.react-terminal-progress-bar {\n  background-color: #fff;\n  border-radius: .25rem;\n  width: 25%;\n}\n\n.react-terminal-wrapper.react-terminal-light .react-terminal-progress-bar {\n  background-color: #000;\n} */\n"),(N=D||(D={}))[N.Light=0]="Light",N[N.Dark=1]="Dark";var $=function(n){var a=n.name,l=n.prompt,r=n.height,i=void 0===r?"600px":r,o=n.colorMode,s=n.onInput,c=n.children,p=n.startingInputValue,u=void 0===p?"":p,d=n.redBtnCallback,m=n.yellowBtnCallback,h=n.greenBtnCallback,g=n.scrollToPosition,y=void 0===g||g,f=A((0,e.useState)(""),2),b=f[0],E=f[1],v=A((0,e.useState)(0),2),w=v[0],S=v[1],C=(0,e.useRef)(null);(0,e.useEffect)((function(){E(u.trim())}),[u]),(0,e.useEffect)((function(){var e,t;if(null!=s){var n=[],a=function(e){var t=function(){var t;return null===(t=null==e?void 0:e.querySelector(".terminal-hidden-input"))||void 0===t?void 0:t.focus()};null==e||e.addEventListener("click",t),n.push({terminalEl:e,listener:t})};try{for(var l=function(e){var t="function"==typeof Symbol&&Symbol.iterator,n=t&&e[t],a=0;if(n)return n.call(e);if(e&&"number"==typeof e.length)return{next:function(){return e&&a>=e.length&&(e=void 0),{value:e&&e[a++],done:!e}}};throw new TypeError(t?"Object is not iterable.":"Symbol.iterator is not defined.")}(document.getElementsByClassName("react-terminal-wrapper")),r=l.next();!r.done;r=l.next())a(r.value)}catch(t){e={error:t}}finally{try{r&&!r.done&&(t=l.return)&&t.call(l)}finally{if(e)throw e.error}}return function(){n.forEach((function(e){e.terminalEl.removeEventListener("click",e.listener)}))}}}),[s]);var _=["react-terminal-wrapper"];return o===D.Light&&_.push("react-terminal-light"),t().createElement("div",{className:_.join(" "),"data-terminal-name":a},t().createElement("div",{className:"react-terminal-window-buttons"},t().createElement("button",{className:(m?"clickable":"")+" red-btn",disabled:!d,onClick:d}),t().createElement("button",{className:(m?"clickable":"")+" yellow-btn",disabled:!m,onClick:m}),t().createElement("button",{className:(h?"clickable":"")+" green-btn",disabled:!h,onClick:h})),t().createElement("div",{className:"react-terminal",style:{height:i}},c,"function"==typeof s&&t().createElement("div",{className:"react-terminal-line react-terminal-input react-terminal-active-input","data-terminal-prompt":l||"$",key:"terminal-line-prompt"},b,t().createElement("span",{className:"cursor",style:{left:w+1+"px"}})),t().createElement("div",{ref:C})),t().createElement("input",{className:"terminal-hidden-input",placeholder:"Terminal Hidden Input",value:b,autoFocus:null!=s,onChange:function(e){E(e.target.value)},onKeyDown:function(e){var t,n;if(s)if("Enter"===e.key)s(b),S(0),E(""),y&&setTimeout((function(){var e;return null===(e=null==C?void 0:C.current)||void 0===e?void 0:e.scrollIntoView({behavior:"auto",block:"nearest"})}),500);else if(["ArrowLeft","ArrowRight","ArrowDown","ArrowUp","Delete"].includes(e.key)){var a=e.currentTarget,l="",r=b.length-(a.selectionStart||0);r=(t=r)>(n=b.length)?n:t<0?0:t,"ArrowLeft"===e.key?(r>b.length-1&&r--,l=b.slice(b.length-1-r)):"ArrowRight"===e.key||"Delete"===e.key?l=b.slice(b.length-r+1):"ArrowUp"===e.key&&(l=b.slice(0));var i=function(e,t){var n=document.createElement("span");n.style.visibility="hidden",n.style.position="absolute",n.style.fontSize=window.getComputedStyle(e).fontSize,n.style.fontFamily=window.getComputedStyle(e).fontFamily,n.innerText=t,document.body.appendChild(n);var a=n.getBoundingClientRect().width;return document.body.removeChild(n),-a}(a,l);S(i)}}}))};const{__:L}=wp.i18n,j=function(){const{isRunning:t,isResumed:a,isPaused:i,blogId:s}=(0,n.useContext)(o),[c,p]=(0,n.useState)([(0,e.createElement)(F,null,"Waiting for new export..")]);function u(){l()({path:"/simplystatic/v1/activity-log?blog_id="+s+"&is_network_admin="+options.is_network,method:"GET"}).then((t=>{var n=JSON.parse(t),a=[];for(var l in n.data){var r=n.data[l].datetime,i=n.data[l].message,o=l.includes("pause")||l.includes("cancel"),s=l.includes("resume");a.push((0,e.createElement)(F,null,"[",r,"] ",(0,e.createElement)("span",{className:`${o?"is-error":""} ${s?"is-success":""}`,dangerouslySetInnerHTML:{__html:i}})))}p(a)}))}return r((()=>{u()}),t?2500:null),(0,n.useEffect)((()=>{t&&!a&&p([(0,e.createElement)(F,null,"Waiting for new export..")]),t&&a&&p([(0,e.createElement)(F,null,"Resuming the export..")]),u()}),[t]),(0,e.createElement)($,{name:L("Activity Log","simply-static"),height:"250px",colorMode:D.Dark},c)};var H=i(757);const M=function(){const{isRunning:t,blogId:a,isPro:i,settings:s}=(0,n.useContext)(o),[p,u]=(0,n.useState)([]),[d,m]=(0,n.useState)(!1),[h,g]=(0,n.useState)(25),[y,f]=(0,n.useState)(0),[b,E]=(0,n.useState)(""),[v,w]=(0,n.useState)([]),[S,C]=(0,n.useState)(!1),[_,x]=(0,n.useState)(0),[P,k]=(0,n.useState)("export"),[R,O]=(0,n.useState)(null);(0,n.useEffect)((()=>{s&&"zip"===s.delivery_method?k("export"):l()({path:"/simplystatic/v1/export-type",method:"GET"}).then((e=>{const t=JSON.parse(e);200===t.status&&t.data&&(s&&"zip"===s.delivery_method?k("export"):(k(t.data.export_type),O(t.data.export_type_id)))})).catch((e=>{console.error("Error fetching export type:",e),s&&"zip"===s.delivery_method?k("export"):options.last_export_end?k("Update"):k("export")}))}),[s]);const T=[{name:"Code",selector:e=>e.code,sortable:!0,maxWidth:"100px"},{name:"URL",selector:t=>{const n=t&&"string"==typeof t.url?t.url:"";if(!n)return(0,e.createElement)("span",null,"-");let a=n;if(n.startsWith("/"))a=n;else try{const e=new URL(n);a=e.pathname+e.search+e.hash}catch(e){}return(0,e.createElement)("a",{target:"_blank",href:n},a)},sortable:!0,sortFunction:(e,t)=>e.url.localeCompare(t.url)}],I={name:"Export-Type",selector:e=>"Build"===P||"Single"===P?`${P} (ID: ${R})`:P,sortable:!0,maxWidth:"200px"},A={name:"Notes",wrap:!0,selector:t=>(0,e.createElement)("span",{dangerouslySetInnerHTML:{__html:t.notes}}),sortable:!0,sortFunction:(e,t)=>{const n=e.notes.replace(/<[^>]*>/g,""),a=t.notes.replace(/<[^>]*>/g,"");return n.localeCompare(a)}},D=i()?[...T,I,A]:[...T,A];function N(e,t=!1){var n;((e=null!==(n=e)&&void 0!==n?n:1)!==y||t)&&m(!0),l()({path:`/simplystatic/v1/export-log?page=${e}&per_page=${h}&blog_id=${a}&is_network_admin=${options.is_network}`,method:"GET"}).then((n=>{var a=JSON.parse(n);if(e!==y||t){u(a.data),m(!1);const e=a.data.total_static_pages||0,t=Math.ceil(e/h);x(t)}else p.total_static_pages=a.data.total_static_pages,u(p);f(e)}))}async function F(){C(!0);try{const e=await l()({path:`/simplystatic/v1/export-log?page=1&per_page=${h}&blog_id=${a}&is_network_admin=${options.is_network}`,method:"GET"}),t=JSON.parse(e),n=t.data.total_static_pages||0;let r=Math.ceil(n/h);const i=20;r>i&&(console.log(`Site has ${r} pages of data, limiting to ${i} pages to prevent timeouts`),r=i);const o=5;let s=[];t.data&&t.data.static_pages&&(s=[...t.data.static_pages]);for(let e=2;e<=r;e+=o){const t=Math.min(e+o-1,r);console.log(`Fetching batch of pages ${e} to ${t}`);const n=[];for(let r=e;r<=t;r++)n.push(l()({path:`/simplystatic/v1/export-log?page=${r}&per_page=${h}&blog_id=${a}&is_network_admin=${options.is_network}`,method:"GET"}));(await Promise.all(n)).forEach((e=>{const t=JSON.parse(e);t.data&&t.data.static_pages&&(s=[...s,...t.data.static_pages])}))}return w(s),console.log(`Fetched ${s.length} total items from ${r} pages (out of ${Math.ceil(n/h)} total pages)`),s}catch(e){return console.error("Error fetching all data:",e),[]}finally{C(!1)}}const[$,L]=(0,n.useState)(0);r((()=>{N();const e=Date.now();b&&v.length>0&&e-$>3e4&&(console.log("Refreshing all data for search (30-second interval)"),F(),L(e))}),t?5e3:null),(0,n.useEffect)((()=>{N(1,!0),t&&l()({path:"/simplystatic/v1/export-type",method:"GET"}).then((e=>{const t=JSON.parse(e);200===t.status&&t.data&&(k(t.data.export_type),O(t.data.export_type_id))})).catch((e=>{console.error("Error fetching export type:",e)}))}),[t]);const j=(b&&v.length>0&&"Build"!==P&&"Single"!==P?v:p.static_pages||[]).filter((e=>{if(!b)return!0;const t=b.toLowerCase();return e.code&&e.code.toString().toLowerCase().includes(t)||e.url&&e.url.toLowerCase().includes(t)||e.notes&&e.notes.toLowerCase().includes(t)}));return(0,e.createElement)("div",{className:"log-table-container"},(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,(0,e.createElement)("input",{id:"export-search",className:"ss-export-log-search",type:"text",placeholder:"Search...",value:b,onChange:async e=>{const t=e.target.value;E(t),t&&0===v.length&&"Build"!==P&&"Single"!==P&&(await F(),L(Date.now()))}}))),(0,e.createElement)(H.Ay,{columns:D,data:b?j:p.static_pages||[],pagination:!0,paginationServer:!b,paginationTotalRows:b?j.length:p.total_static_pages,paginationPerPage:25,paginationRowsPerPageOptions:[25,50,100,200],progressPending:d||S&&b,progressComponent:(0,e.createElement)("div",{style:{padding:"24px",textAlign:"center"}},(0,e.createElement)(c.Spinner,null),(0,e.createElement)("div",{style:{marginTop:"8px"}},S&&b?"Loading all data for search...":"Loading...")),onChangeRowsPerPage:(e,t)=>{g(e),N(t,!0)},onChangePage:b?void 0:e=>{N(e)}}))},{__:B}=wp.i18n,z=function(){const[t,a]=(0,n.useState)(!1);return(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Button,{variant:"primary",href:options.log_file,download:!0,style:{marginRight:"10px"}},B("Download Log","simply-static")),(0,e.createElement)(c.Button,{variant:"secondary",onClick:()=>{l()({path:"/simplystatic/v1/delete-log",method:"POST"}),a(!0),setTimeout((function(){a(!1)}),2e3)}},B("Clear Log","simply-static")),t&&(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,B("Log file cleared.","simply-static"))))))},{__:U}=wp.i18n,W=function(){const{settings:t,blogId:a,setBlogId:l}=(0,n.useContext)(o),[r,i]=(0,n.useState)(""),[s,p]=(0,n.useState)("");return(0,e.createElement)("div",{className:"inner-settings"},!options.is_network&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(j,null),(0,e.createElement)(c.__experimentalSpacer,{margin:5})),(0,e.createElement)(c.Flex,{align:"top"},options.is_network&&(0,e.createElement)(c.FlexItem,{isBlock:!0},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,U("Multisite","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.SelectControl,{label:U("Choose a site to export","simply-static"),value:a,options:options.sites.map((function(e){return{label:`${e.name} (${e.url})`,value:e.blog_id}})),onChange:e=>{l(e),options.sites.some((t=>{t.blog_id===e&&(i(t.settings_url),p(t.activity_log_url))}))}}),r&&(0,e.createElement)("p",null,(0,e.createElement)(c.Button,{isPrimary:!0,href:r},"Switch to Site settings"),(0,e.createElement)(c.Button,{style:{marginLeft:"5px"},isSecondary:!0,href:s},"Check progress"))))),t.debugging_mode&&options.log_file&&!options.is_network&&(0,e.createElement)(c.FlexItem,{isBlock:!0},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,U("Debugging","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(z,null))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)("b",null,U("Export Log","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(M,null))))},{__:G}=wp.i18n,V=function(){const{settings:t,updateSetting:a,saveSettings:r,settingsSaved:i,setSettingsSaved:s,isPro:p}=(0,n.useContext)(o),[u,d]=(0,n.useState)(!1),[h,g]=(0,n.useState)(!1),[y,f]=(0,n.useState)(!1),[b,E]=(0,n.useState)(!1),[v,w]=(0,n.useState)(!1),[S,C]=(0,n.useState)(!1),[_,x]=(0,n.useState)("wp-content"),[P,k]=(0,n.useState)("wp-includes"),[R,O]=(0,n.useState)("wp-content/uploads"),[T,I]=(0,n.useState)("wp-content/plugins"),[A,D]=(0,n.useState)("wp-content/themes"),[N,F]=(0,n.useState)("style"),[$,L]=(0,n.useState)("author"),[j,H]=(0,n.useState)(!1),[M,B]=(0,n.useState)(!1),[z,U]=(0,n.useState)(!1),[W,V]=(0,n.useState)(!1),[q,J]=(0,n.useState)(!1),[Y,K]=(0,n.useState)(!1),[Z,Q]=(0,n.useState)(!1),[X,ee]=(0,n.useState)(!1),[te,ne]=(0,n.useState)(!1),[ae,le]=(0,n.useState)(!1),[re,ie]=(0,n.useState)(!1),[oe,se]=(0,n.useState)(!1),[ce,pe]=(0,n.useState)(!1),[ue,de]=(0,n.useState)(!1);return(0,n.useEffect)((()=>{t.use_minify&&d(t.use_minify),t.minify_html&&g(t.minify_html),t.minify_css&&f(t.minify_css),t.minify_inline_css&&E(t.minify_inline_css),t.minify_js&&w(t.minify_js),t.minify_inline_js&&C(t.minify_inline_js),t.wp_content_directory&&x(t.wp_content_directory),t.wp_includes_directory&&k(t.wp_includes_directory),t.wp_uploads_directory&&O(t.wp_uploads_directory),t.wp_plugins_directory&&I(t.wp_plugins_directory),t.wp_themes_directory&&D(t.wp_themes_directory),t.theme_style_name&&F(t.theme_style_name),t.author_url&&L(t.author_url),t.hide_comments&&U(t.hide_comments),t.hide_version&&V(t.hide_version),t.hide_generator&&K(t.hide_generator),t.hide_prefetch&&J(t.hide_prefetch),t.hide_rsd&&Q(t.hide_rsd),t.hide_emotes&&ee(t.hide_emotes),t.disable_xmlrpc&&ne(t.disable_xmlrpc),t.disable_embed&&le(t.disable_embed),t.disable_db_debug&&ie(t.disable_db_debug),t.disable_wlw_manifest&&se(t.disable_wlw_manifest),t.disable_directory_browsing&&pe(t.disable_directory_browsing)}),[t]),(0,e.createElement)("div",{className:"inner-settings"},(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,(0,e.createElement)("b",null,G("Minify","simply-static"),(0,e.createElement)(m,{title:G("How to minify HTML, CSS and JavaScript?","simply-static"),videoUrl:"https://youtu.be/52IKv5ai-i4"}))),("free"===options.plan||!p())&&(0,e.createElement)(c.FlexItem,null,(0,e.createElement)(c.ExternalLink,{href:"https://simplystatic.com"}," ",G("Requires Simply Static Pro","simply-static"))))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.ToggleControl,{label:G("Minify Files?","simply-static"),help:G(u?"Enable minify files on your static website.":"Don't enable minify files on your static website.","simply-static"),disabled:"free"===options.plan||!p(),checked:u,onChange:e=>{d(e),a("use_minify",e)}}),u&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.ToggleControl,{label:G("Minify HTML","simply-static"),help:G(h?"Minify HTML files.":"Don't minify HTML files.","simply-static"),disabled:"free"===options.plan||!p(),checked:h,onChange:e=>{g(e),a("minify_html",e)}}),h&&(0,e.createElement)(c.ToggleControl,{label:G("Leave quotes inside HTML attributes","simply-static"),help:G("If there are issues with comments or JavaScript when minifying HTML, toggle this ON.","simply-static"),disabled:"free"===options.plan||!p(),checked:t.minify_html_leave_quotes,onChange:e=>{a("minify_html_leave_quotes",e)}}),(0,e.createElement)(c.ToggleControl,{label:G("Minify CSS","simply-static"),help:G(y?"Minify CSS files.":"Don't minify CSS files.","simply-static"),disabled:"free"===options.plan||!p(),checked:y,onChange:e=>{f(e),a("minify_css",e)}}),y&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.TextareaControl,{label:G("Exclude Stylesheet URLs","simply-static"),help:G("Exclude URLs from minification (one per line).","simply-static"),disabled:"free"===options.plan||!p(),value:t.minify_css_exclude,onChange:e=>{a("minify_css_exclude",e)}}),(0,e.createElement)(c.ToggleControl,{label:G("Minify Inline CSS","simply-static"),help:G(b?"Minify Inline CSS.":"Don't minify Inline CSS.","simply-static"),disabled:"free"===options.plan||!p(),checked:b,onChange:e=>{E(e),a("minify_inline_css",e)}})),(0,e.createElement)(c.ToggleControl,{label:G("Minify JavaScript","simply-static"),help:G(v?"Minify JavaScript files.":"Don't minify JavaScript files.","simply-static"),disabled:"free"===options.plan||!p(),checked:v,onChange:e=>{w(e),a("minify_js",e)}}),v&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.TextareaControl,{label:G("Exclude JavaScript URLs","simply-static"),help:G("Exclude URLs from minification (one per line).","simply-static"),disabled:"free"===options.plan||!p(),value:t.minify_js_exclude,onChange:e=>{a("minify_js_exclude",e)}}),(0,e.createElement)(c.ToggleControl,{label:G("Minify Inline JavaScript","simply-static"),help:G(S?"Minify Inline JavaScript.":"Don't minify Inline JavaScript.","simply-static"),disabled:"free"===options.plan||!p(),checked:S,onChange:e=>{C(e),a("minify_inline_js",e)}}))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,(0,e.createElement)("b",null,G("Image Optimization","simply-static"),(0,e.createElement)(m,{title:G("How to optimize images with ShortPixel?","simply-static"),videoUrl:"https://youtu.be/OIfKcXz3cxY"}))),("free"===options.plan||!p())&&(0,e.createElement)(c.FlexItem,null,(0,e.createElement)(c.ExternalLink,{href:"https://simplystatic.com"}," ",G("Requires Simply Static Pro","simply-static"))))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.ToggleControl,{label:G("Optimize Images with ShortPixel?","simply-static"),help:t.shortpixel_enabled?G("Optimize images.","simply-static"):G("Don't optimize images.","simply-static"),disabled:"free"===options.plan||!p(),checked:t.shortpixel_enabled,onChange:e=>{a("shortpixel_enabled",e)}}),t.shortpixel_enabled&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.TextControl,{label:G("ShortPixel API Key","simply-static"),type:"password",value:t.shortpixel_api_key,disabled:"free"===options.plan||!p(),onChange:e=>{a("shortpixel_api_key",e)}}),(0,e.createElement)(c.__experimentalSpacer,{padding:1}),(0,e.createElement)(c.ToggleControl,{label:G("Convert to webP","simply-static"),checked:t.shortpixel_webp_enabled,disabled:"free"===options.plan||!p(),onChange:e=>{a("shortpixel_webp_enabled",e)}}),(0,e.createElement)(c.__experimentalSpacer,{padding:1}),(0,e.createElement)(c.ToggleControl,{label:G("Backup the original images?","simply-static"),checked:t.shortpixel_backup_enabled,disabled:"free"===options.plan||!p(),onChange:e=>{a("shortpixel_backup_enabled",e)}}),t.shortpixel_backup_enabled&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Notice,{status:"warning",isDismissible:!1},G("It will preserve every image which might increase your disk space usage.","simply-static")),(0,e.createElement)(c.__experimentalSpacer,{padding:1}),(0,e.createElement)(c.Button,{disabled:ue,onClick:()=>{de(!0),l()({path:"/simplystatic/v1/shortpixel-restore",method:"POST"}).then((e=>{const t=JSON.parse(e);de(!1),alert(t.message)})).catch((e=>{de(!1),alert(e.message)}))},variant:"secondary"},!ue&&G("Restore Original Images","simply-static"),ue&&[(0,e.createElement)(c.Dashicon,{icon:"update spin"}),G("Restoring...","simply-static")]))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,(0,e.createElement)("b",null,G("Replace","simply-static"),(0,e.createElement)(m,{title:G("How to replace WP default paths","simply-static"),videoUrl:"https://youtu.be/GedyNJJMGaY"}))),("free"===options.plan||!p())&&(0,e.createElement)(c.FlexItem,null,(0,e.createElement)(c.ExternalLink,{href:"https://simplystatic.com"}," ",G("Requires Simply Static Pro","simply-static"))))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.TextControl,{label:G("wp-content directory","simply-static"),help:G('Replace the "wp-content" directory.',"simply-static"),disabled:"free"===options.plan||!p(),type:"text",placeholder:"wp-content",value:_,onChange:e=>{a("wp_content_directory",e)}}),(0,e.createElement)(c.TextControl,{label:G("wp-includes directory","simply-static"),help:G('Replace the "wp-includes" directory.',"simply-static"),disabled:"free"===options.plan||!p(),type:"text",placeholder:"wp-includes",value:P,onChange:e=>{a("wp_includes_directory",e)}}),(0,e.createElement)(c.TextControl,{label:G("uploads directory","simply-static"),help:G('Replace the "wp-content/uploads" directory.',"simply-static"),disabled:"free"===options.plan||!p(),type:"text",placeholder:"uploads",value:R,onChange:e=>{O(e),a("wp_uploads_directory",e)}}),(0,e.createElement)(c.TextControl,{label:G("plugins directory","simply-static"),help:G('Replace the "wp-content/plugins" directory.',"simply-static"),disabled:"free"===options.plan||!p(),type:"text",placeholder:"plugins",value:T,onChange:e=>{I(e),a("wp_plugins_directory",e)}}),(0,e.createElement)(c.TextControl,{label:G("themes directory","simply-static"),help:G('Replace the "wp-content/themes" directory.',"simply-static"),disabled:"free"===options.plan||!p(),type:"text",placeholder:"themes",value:A,onChange:e=>{D(e),a("wp_themes_directory",e)}}),(0,e.createElement)(c.__experimentalInputControl,{label:G("Theme style name","simply-static"),help:G("Replace the style.css filename.","simply-static"),disabled:"free"===options.plan||!p(),type:"text",className:"ss-theme-style-name",suffix:".css",placeholder:"style",value:N,onChange:e=>{F(e),a("theme_style_name",e)}}),(0,e.createElement)(c.TextControl,{label:G("Author URL","simply-static"),help:G("Replace the author url.","simply-static"),disabled:"free"===options.plan||!p(),type:"text",placeholder:"author",value:$,onChange:e=>{L(e),a("author_url",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,(0,e.createElement)("b",null,G("Hide","simply-static"),(0,e.createElement)(m,{title:G("How to hide and disable WP core features","simply-static"),videoUrl:"https://youtu.be/GijIsrfFB8o"}))),("free"===options.plan||!p())&&(0,e.createElement)(c.FlexItem,null,(0,e.createElement)(c.ExternalLink,{href:"https://simplystatic.com"}," ",G("Requires Simply Static Pro","simply-static"))))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.ToggleControl,{label:G("Hide HTML Comments","simply-static"),checked:z,disabled:"free"===options.plan||!p(),onChange:e=>{U(e),a("hide_comments",e)}}),(0,e.createElement)(c.ToggleControl,{label:G("Hide WordPress Version","simply-static"),checked:W,disabled:"free"===options.plan||!p(),onChange:e=>{V(e),a("hide_version",e)}}),(0,e.createElement)(c.ToggleControl,{label:G("Hide WordPress Generator Meta","simply-static"),checked:Y,disabled:"free"===options.plan||!p(),onChange:e=>{K(e),a("hide_generator",e)}}),(0,e.createElement)(c.ToggleControl,{label:G("Hide DNS Prefetch WordPress link","simply-static"),checked:q,disabled:"free"===options.plan||!p(),onChange:e=>{J(e),a("hide_prefetch",e)}}),(0,e.createElement)(c.ToggleControl,{label:G("Hide RSD Header","simply-static"),checked:Z,disabled:"free"===options.plan||!p(),onChange:e=>{Q(e),a("hide_rsd",e)}}),(0,e.createElement)(c.ToggleControl,{label:G("Hide Emojis if you don't use them","simply-static"),checked:X,disabled:"free"===options.plan||!p(),onChange:e=>{ee(e),a("hide_emotes",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Card,null,(0,e.createElement)(c.CardHeader,null,(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,null,(0,e.createElement)("b",null,G("Disable","simply-static"),(0,e.createElement)(m,{title:G("How to hide and disable WP core features","simply-static"),videoUrl:"https://youtu.be/GijIsrfFB8o"}))),("free"===options.plan||!p())&&(0,e.createElement)(c.FlexItem,null,(0,e.createElement)(c.ExternalLink,{href:"https://simplystatic.com"}," ",G("Requires Simply Static Pro","simply-static"))))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)(c.ToggleControl,{label:G("Disable XML-RPC","simply-static"),checked:te,disabled:"free"===options.plan||!p(),onChange:e=>{ne(e),a("disable_xmlrpc",e)}}),(0,e.createElement)(c.ToggleControl,{label:G("Disable Embed Scripts","simply-static"),checked:ae,disabled:"free"===options.plan||!p(),onChange:e=>{le(e),a("disable_embed",e)}}),(0,e.createElement)(c.ToggleControl,{label:G("Disable DB Debug in Frontend","simply-static"),checked:re,disabled:"free"===options.plan||!p(),onChange:e=>{ie(e),a("disable_db_debug",e)}}),(0,e.createElement)(c.ToggleControl,{label:G("Disable WLW Manifest Scripts","simply-static"),checked:oe,disabled:"free"===options.plan||!p(),onChange:e=>{se(e),a("disable_wlw_manifest",e)}}))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),i&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1},(0,e.createElement)("p",null,G("Settings saved successfully.","simply-static"))))),(0,e.createElement)(c.__experimentalSpacer,{margin:5})),(0,e.createElement)("div",{className:"save-settings"},"pro"===options.plan&&p()&&(0,e.createElement)(c.Button,{onClick:()=>{r(),s(!0),setTimeout((function(){s(!1)}),2e3)},variant:"primary"},G("Save Settings","simply-static"))))},{__:q}=wp.i18n;function J({onClose:t,setSelectableEnvironments:a,setSelectedEnvironment:r}){const[i,o]=(0,n.useState)(""),[s,p]=(0,n.useState)(!1);return(0,e.createElement)("div",{className:"ss-environment-form"},(0,e.createElement)(c.TextControl,{label:"Name",onChange:e=>o(e),value:i}),(0,e.createElement)("p",null,q("A new environment will be created with the current configuration.","simply-static")),(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexBlock,null,(0,e.createElement)(c.Button,{variant:"primary",onClick:()=>{p(!0),l()({path:"/simplystatic/v1/environment",method:"POST",data:{title:i}}).then((e=>{let n=Object.keys(e.environments).map((function(t){return{label:e.environments[t],value:t}}));a(n),r(e.current_environment),t()})).catch((e=>{alert(e.message)})).finally((()=>p(!1)))},isBusy:s},q(s?"Creating...":"Create","simply-static"))),(0,e.createElement)(c.FlexBlock,null,(0,e.createElement)(c.Button,{variant:"secondary",onClick:t},q("Cancel","simply-static")))))}const{__:Y}=wp.i18n;function K({onChange:t,current:n,environments:a,disabled:l,onDelete:r}){return(0,e.createElement)(c.Flex,null,(0,e.createElement)(c.FlexItem,{style:{minWidth:"80%"}},(0,e.createElement)(c.SelectControl,{disabled:l,value:n,options:a,help:Y("Choose an environment or create a new one to configure settings.","simply-static"),onChange:t})),(0,e.createElement)(c.FlexItem,null,(0,e.createElement)(c.Button,{className:"environment-delete-button",variant:"tertiary",label:Y("Delete selected environment","simply-static"),showToolTip:!0,size:"small",icon:"trash",disabled:l,onClick:r})))}const{__:Z}=wp.i18n;function Q({getSettings:t,isRunning:a}){const[r,i]=(0,n.useState)(""),[o,s]=(0,n.useState)([]),[p,u]=(0,n.useState)(!1),[d,m]=(0,n.useState)(!1);return(0,n.useEffect)((()=>{l()({path:"/simplystatic/v1/environment",method:"GET"}).then((e=>{let t=Object.keys(e.environments).map((function(t){return{label:e.environments[t],value:t}}));s(t),i(e.current_environment)}))}),[]),(0,e.createElement)("div",{className:"environment-container"},(0,e.createElement)("h4",{className:"settings-headline"}," ",Z("Environment","simply-static")),!p&&r&&(0,e.createElement)("p",null,"Current: ",(0,e.createElement)("strong",null,d?Z("Changing ...","simply-static"):o.filter((e=>e.value===r)).pop().label)),!p&&o.length>0&&(0,e.createElement)(K,{onChange:e=>{m(!0),l()({path:"/simplystatic/v1/environment",method:"PUT",data:{version:e}}).then((()=>{t(),i(e)})).catch((e=>alert(e.message))).finally((()=>{m(!1)}))},environments:o,onDelete:()=>{m(!0),l()({path:"/simplystatic/v1/environment",method:"DELETE",data:{version:r}}).then((e=>{t();let n=Object.keys(e.environments).map((function(t){return{label:e.environments[t],value:t}}));s(n),i(e.current_environment)})).catch((e=>alert(e.message))).finally((()=>{m(!1)}))},current:r,disabled:a||d}),!p&&(0,e.createElement)(c.Button,{disabled:a||d,variant:"primary",size:"large",onClick:()=>u(!0)},"Create an Environment"),p&&(0,e.createElement)(J,{onClose:()=>u(!1),setSelectedEnvironment:i,setSelectableEnvironments:s}))}const{__:X}=wp.i18n,ee=function(){const{isRunning:t,setIsRunning:a,isResumed:r,setIsResumed:i,isPaused:s,setIsPaused:p,blogId:u,settings:d,updateFromNetwork:m,getSettings:h,passedChecks:y,isPro:b,isStudio:v,canRunIntegration:S,showMobileNav:_,setShowMobileNav:P,isDelayed:R}=(0,n.useContext)(o),[O,T]=(0,n.useState)({activeItem:"/"}),[A,D]=(0,n.useState)(localStorage.getItem("ss-initial-page")?localStorage.getItem("ss-initial-page"):options.initial),[N,F]=(0,n.useState)(!1),[$,L]=(0,n.useState)(!1),[j,H]=(0,n.useState)("current"),[M,B]=(0,n.useState)([]),[z,U]=(0,n.useState)(!1),[G,q]=(0,n.useState)("export");(0,n.useEffect)((()=>{L(t||s);let e=localStorage.getItem("ss-initial-page");if(N||(F(!0),e?(T(e),D(e),localStorage.removeItem("ss-initial-page")):(T(options.initial),D(options.initial))),options.selectable_sites&&!options.is_network&&options.is_multisite){let e=options.selectable_sites.map((function(e){return{label:`${e.name}`,value:e.blog_id}}));e.unshift({label:X("Use current settings","simply-static"),value:"current"}),B(e)}}),[options,t,s]),(0,n.useEffect)((()=>{q("export")}),[d]);const J=()=>{L(!0),i(!1),p(!1),l()({path:"/simplystatic/v1/start-export",method:"POST",data:{blog_id:u,type:G}}).then((e=>{var t=JSON.parse(e);if(500===t.status)return alert(t.message),void L(!1);a(!0)}))},Y=()=>{l()({path:"/simplystatic/v1/cancel-export",method:"POST",data:{blog_id:u}}).then((e=>{i(!1),p(!1),a(!1),L(!1)}))},K=()=>{l()({path:"/simplystatic/v1/pause-export",method:"POST",data:{blog_id:u}}).then((e=>{a(!1),i(!1),p(!0)}))},Z=()=>{l()({path:"/simplystatic/v1/resume-export",method:"POST",data:{blog_id:u}}).then((e=>{i(!0),p(!1),a(!0)}))};let ee="";if(Object.keys(options.builds).length){const t=Object.keys(options.builds).map((t=>(0,e.createElement)("option",{value:t},options.builds[t])));t.sort(((e,t)=>e.props.children.localeCompare(t.props.children))),ee=(0,e.createElement)("optgroup",{label:"Builds"},t)}return(0,e.createElement)("div",{className:"plugin-settings-container"},(0,e.createElement)(c.__experimentalNavigatorProvider,{initialPath:A},(0,e.createElement)(c.Flex,null,(0,e.createElement)("a",{onClick:()=>{P(!_)},className:"show-nav"},(0,e.createElement)(c.Dashicon,{icon:"align-center"})," ",X("Toggle menu","simply-static")),(0,e.createElement)(c.FlexItem,{className:_?"toggle-nav sidebar":"sidebar"},options.is_network?(0,e.createElement)(c.Card,{className:"plugin-nav"},(0,e.createElement)("div",{className:"plugin-logo"},(0,e.createElement)("img",{alt:"Logo",src:options.logo})),"pro"===options.plan&&b()?(0,e.createElement)("p",{className:"version-number"},"Free: ",(0,e.createElement)("b",null,options.version),(0,e.createElement)("br",null),"Pro: ",(0,e.createElement)("b",null,options.version_pro)):(0,e.createElement)("p",{className:"version-number"},"Version: ",(0,e.createElement)("b",null,options.version)),(0,e.createElement)("div",{className:"generate-container "+($?"generating":"")},!$&&(0,e.createElement)(c.Button,{onClick:()=>{q("export"),J()},disabled:$||R,className:"/"===O?"is-active-item generate":"generate"},!$&&[(0,e.createElement)(c.Dashicon,{icon:"update"}),X("Generate","simply-static")],!$&&R>0&&(0,e.createElement)(e.Fragment,null,R,"s"),$&&[(0,e.createElement)(c.Dashicon,{icon:"update spin"}),X("Generating...","simply-static")]),$&&(0,e.createElement)(e.Fragment,null,!s&&(0,e.createElement)(c.Button,{label:X("Pause","simply-static"),showToolTip:!0,className:"ss-generate-media-button",onClick:()=>K()},(0,e.createElement)(c.Dashicon,{icon:"controls-pause"})),s&&(0,e.createElement)(c.Button,{label:X("Resume","simply-static"),showToolTip:!0,className:"ss-generate-media-button",onClick:()=>Z()},(0,e.createElement)(c.Dashicon,{icon:"controls-play"})),(0,e.createElement)(c.Button,{onClick:()=>Y(),label:X("Cancel","simply-static"),className:"ss-generate-cancel-button",showToolTip:!0},(0,e.createElement)(c.Dashicon,{icon:"no"})))),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.__experimentalSpacer,{margin:5}),(0,e.createElement)(c.Button,{href:"https://simplystatic.com/changelogs/",target:"_blank"},(0,e.createElement)(c.Dashicon,{icon:"editor-ul"})," ",X("Changelog","simply-static")),(0,e.createElement)(c.Button,{href:"https://docs.simplystatic.com",target:"_blank"},(0,e.createElement)(c.Dashicon,{icon:"admin-links"})," ",X("Documentation","simply-static")),"free"===options.plan&&(0,e.createElement)(c.Button,{href:"https://simplystatic.com",target:"_blank"},(0,e.createElement)(c.Dashicon,{icon:"admin-site-alt3"}),"Simply Static Pro")):(0,e.createElement)(c.Card,{className:"plugin-nav"},(0,e.createElement)("div",{className:"plugin-logo"},(0,e.createElement)("img",{alt:"Logo",src:options.logo})),"pro"===options.plan&&b()?(0,e.createElement)(e.Fragment,null,v()?(0,e.createElement)("p",{className:"version-number"},"Free: ",(0,e.createElement)("b",null,options.version),(0,e.createElement)("br",null),"Pro: ",(0,e.createElement)("b",null,options.version_pro),(0,e.createElement)("br",null),"Studio: ",(0,e.createElement)("b",null,options.version_studio)):(0,e.createElement)("p",{className:"version-number"},"Free: ",(0,e.createElement)("b",null,options.version),(0,e.createElement)("br",null),"Pro: ",(0,e.createElement)("b",null,options.version_pro))):(0,e.createElement)("p",{className:"version-number"},"Version: ",(0,e.createElement)("b",null,options.version)),(0,e.createElement)("div",{className:"generate-container "+($?"generating":"")},(0,e.createElement)(c.SelectControl,{className:"generate-type",value:G,disabled:$,onChange:e=>{q(e)}},(0,e.createElement)("option",{value:"export"},X("Export","simply-static")),"zip"!==d.delivery_method&&"tiiny"!==d.delivery_method&&(0,e.createElement)(e.Fragment,null,"pro"===options.plan&&b()?(0,e.createElement)("option",{value:"update"},X("Export Changes","simply-static")):(0,e.createElement)("option",{disabled:!0,value:"update"},X("Export Changes (Requires Simply Static Pro)","simply-static"))),ee),(0,e.createElement)("div",{className:"generate-buttons-container"},!$&&(0,e.createElement)(c.Button,{onClick:()=>{J()},disabled:$||R,className:"/"===O?"is-active-item generate":"generate"},!$&&[(0,e.createElement)(c.Dashicon,{icon:"update"}),X("Generate","simply-static")],!$&&R>0&&(0,e.createElement)(e.Fragment,null," ",R,"s"),$&&(0,e.createElement)(c.Dashicon,{icon:"update spin"})),$&&(0,e.createElement)(e.Fragment,null,!s&&(0,e.createElement)(c.Button,{label:X("Pause","simply-static"),className:"ss-generate-media-button",showToolTip:!0,onClick:()=>K()},(0,e.createElement)(c.Dashicon,{icon:"controls-pause"})),s&&(0,e.createElement)(c.Button,{label:X("Resume","simply-static"),className:"ss-generate-media-button",showToolTip:!0,onClick:()=>Z()},(0,e.createElement)(c.Dashicon,{icon:"controls-play"})),(0,e.createElement)(c.Button,{onClick:()=>Y(),label:X("Cancel","simply-static"),className:"ss-generate-cancel-button",showToolTip:!0},(0,e.createElement)(c.Dashicon,{icon:"no"}))))),(0,e.createElement)(c.CardBody,null,"pro"===options.plan&&b()&&(0,e.createElement)(e.Fragment,null,!options.is_network&&S("environments")&&(0,e.createElement)(Q,{isRunning:t,getSettings:h})),!options.is_network&&options.is_multisite&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)("h4",{className:"settings-headline"}," ",X("Import","simply-static")),(0,e.createElement)(c.SelectControl,{value:j,options:M,help:X("Choose a subsite to import settings from.","simply-static"),onChange:e=>{H(e)}}),"current"!==j&&(0,e.createElement)(c.Button,{isPrimary:!0,onClick:()=>{(e=>{m(e),U(!0),setTimeout((function(){U(!1),window.location.reload()}),2e3)})(j)}},X("Import Settings","simply-static")),z?(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"success",isDismissible:!1,className:"upgrade-network-notice"},(0,e.createElement)("p",null,X("Settings successfully imported.","simply-static"))))):""),(0,e.createElement)("h4",{className:"settings-headline"}," ",X("Tools","simply-static")),(0,e.createElement)(c.__experimentalNavigatorButton,{onClick:()=>{T("/"),P(!_)},className:"/"===O?"is-active-item generate":"generate",path:"/"},(0,e.createElement)(c.Dashicon,{icon:"update"})," ",X("Activity Log","simply-static")),(0,e.createElement)(c.__experimentalNavigatorButton,{onClick:()=>{T("/diagnostics"),P(!_)},className:"/diagnostics"===O?"is-active-item":"",path:"/diagnostics"},(0,e.createElement)(c.Dashicon,{icon:"bell"})," ",X("Diagnostics","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("h4",{className:"settings-headline"}," ",X("Settings","simply-static")),(0,e.createElement)(c.__experimentalNavigatorButton,{onClick:()=>{T("/general"),P(!_)},className:"/general"===O?"is-active-item":"",path:"/general"},(0,e.createElement)(c.Dashicon,{icon:"admin-generic"})," ",X("General","simply-static")),!options.is_network&&!options.hidden_settings.includes("deployment")&&(0,e.createElement)(c.__experimentalNavigatorButton,{onClick:()=>{T("/deployment"),P(!_)},className:"/deployment"===O?"is-active-item":"",path:"/deployment"},(0,e.createElement)(c.Dashicon,{icon:"migrate"})," ",X("Deploy","simply-static")),!options.is_network&&(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.__experimentalNavigatorButton,{onClick:()=>{T("/forms"),P(!_)},className:"/forms"===O?"is-active-item":"",path:"/forms"},(0,e.createElement)(c.Dashicon,{icon:"align-center"})," ",X("Forms","simply-static")),(0,e.createElement)(c.__experimentalNavigatorButton,{onClick:()=>{T("/search"),P(!_)},className:"/search"===O?"is-active-item":"",path:"/search"},(0,e.createElement)(c.Dashicon,{icon:"search"})," ",X("Search","simply-static")),(0,e.createElement)(c.__experimentalNavigatorButton,{onClick:()=>{T("/optimize"),P(!_)},className:"/optimize"===O?"is-active-item":"",path:"/optimize"},(0,e.createElement)(c.Dashicon,{icon:"dashboard"})," ",X("Optimize","simply-static")))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("h4",{className:"settings-headline"}," ",X("Advanced","simply-static")),(0,e.createElement)(c.__experimentalNavigatorButton,{onClick:()=>{T("/integrations"),P(!_)},className:"/integrations"===O?"is-active-item":"",path:"/integrations"},(0,e.createElement)(c.Dashicon,{icon:"block-default"})," ",X("Integrations","simply-static")),(0,e.createElement)(c.__experimentalNavigatorButton,{onClick:()=>{T("/utilities"),P(!_)},className:"/utilities"===O?"is-active-item":"",path:"/utilities"},(0,e.createElement)(c.Dashicon,{icon:"admin-tools"})," ",X("Utilities","simply-static")),(0,e.createElement)(c.__experimentalNavigatorButton,{onClick:()=>{T("/debug"),P(!_)},className:"/debug"===O?"is-active-item":"",path:"/debug"},(0,e.createElement)(c.Dashicon,{icon:"editor-help"})," ",X("Debug","simply-static"))),(0,e.createElement)(c.CardBody,null,(0,e.createElement)("h4",{className:"settings-headline"},"Learn"),(0,e.createElement)(c.Button,{href:"https://docs.simplystatic.com",target:"_blank"},(0,e.createElement)(c.Dashicon,{icon:"admin-links"})," ",X("Documentation","simply-static")),(0,e.createElement)(c.Button,{href:"https://www.youtube.com/playlist?list=PLcpe8_rNg8U5g1gCOa0Ge6T17f50nSvmg",target:"_blank"},(0,e.createElement)(c.Dashicon,{icon:"format-video"})," ",X("Video Course","simply-static")),(0,e.createElement)(c.Button,{href:"https://simplystatic.com/tutorials/",target:"_blank"},(0,e.createElement)(c.Dashicon,{icon:"edit"})," ",X("Tutorials","simply-static"))))),(0,e.createElement)(c.FlexItem,{isBlock:!0,className:_?"":"toggle-nav"},(0,e.createElement)("div",{class:"plugin-settings"},"no"!==y||options.is_network?"":(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(c.Notice,{status:"notice",isDismissible:!1,className:"/"==O?"diagnostics-notice diagnostics-notice-generate":"diagnostics-notice"},(0,e.createElement)("p",null,X("There are errors in diagnostics that may negatively affect your static export.","simply-static"),(0,e.createElement)("br",null),X("Please review them and get them fixed to avoid problems.","simply-static")),(0,e.createElement)(c.__experimentalNavigatorButton,{isSecondary:!0,onClick:()=>{T("/diagnostics"),P(!_)},className:"/diagnostics"===O?"is-active-item":"",path:"/diagnostics"},(0,e.createElement)(c.Dashicon,{icon:"editor-help"})," ",X("Visit Diagnostics","simply-static"))))),"pro"!==options.plan||b()?"":(0,e.createElement)(c.Animate,{type:"slide-in",options:{origin:"top"}},(()=>(0,e.createElement)(e.Fragment,null,(0,e.createElement)(c.Notice,{status:"error",isDismissible:!1,className:"/"==O?"diagnostics-notice diagnostics-notice-generate":"diagnostics-notice"},(0,e.createElement)("p",null,X("You are using the pro version without a valid license.","simply-static"),(0,e.createElement)("br",null),X("We have temporarily disabled all the pro features now. Please contact our support to have the problem solved.","simply-static")),(0,e.createElement)(c.Button,{isPrimary:!0,href:"https://simplystatic.com/support/",target:"_blank"},"Contact Support")),(0,e.createElement)(c.__experimentalSpacer,{margin:"5px"})))),"/"===O&&(0,e.createElement)(c.__experimentalNavigatorScreen,{path:"/"},(0,e.createElement)(W,null)),"/diagnostics"===O&&(0,e.createElement)(c.__experimentalNavigatorScreen,{path:"/diagnostics"},(0,e.createElement)(f,null)),"/general"===O&&(0,e.createElement)(c.__experimentalNavigatorScreen,{path:"/general"},(0,e.createElement)(g,null)),"/deployment"===O&&(0,e.createElement)(c.__experimentalNavigatorScreen,{path:"/deployment"},(0,e.createElement)(w,null)),"/forms"===O&&(0,e.createElement)(c.__experimentalNavigatorScreen,{path:"/forms"},(0,e.createElement)(C,null)),"/search"===O&&(0,e.createElement)(c.__experimentalNavigatorScreen,{path:"/search"},(0,e.createElement)(x,null)),"/optimize"===O&&(0,e.createElement)(c.__experimentalNavigatorScreen,{path:"/optimize"},(0,e.createElement)(V,null)),"/utilities"===O&&(0,e.createElement)(c.__experimentalNavigatorScreen,{path:"/utilities"},(0,e.createElement)(E,null)),"/debug"===O&&(0,e.createElement)(c.__experimentalNavigatorScreen,{path:"/debug"},(0,e.createElement)(k,null)),"/integrations"===O&&(0,e.createElement)(c.__experimentalNavigatorScreen,{path:"/integrations"},(0,e.createElement)(I,null)))))))},te=function(){return(0,e.createElement)(s,null,(0,e.createElement)("div",null,(0,e.createElement)(ee,null)))};"simplystatic-settings"===options.screen&&(0,n.createRoot)(document.getElementById("simplystatic-settings")).render((0,e.createElement)(te,null))})()})();
+`;var Le=l.memo((function({rowsPerPage:e,rowCount:t,currentPage:n,direction:o=De.direction,paginationRowsPerPageOptions:a=De.paginationRowsPerPageOptions,paginationIconLastPage:r=De.paginationIconLastPage,paginationIconFirstPage:i=De.paginationIconFirstPage,paginationIconNext:s=De.paginationIconNext,paginationIconPrevious:d=De.paginationIconPrevious,paginationComponentOptions:c=De.paginationComponentOptions,onChangeRowsPerPage:g=De.onChangeRowsPerPage,onChangePage:p=De.onChangePage}){const b=(()=>{const e="object"==typeof window;function t(){return{width:e?window.innerWidth:void 0,height:e?window.innerHeight:void 0}}const[n,o]=l.useState(t);return l.useEffect((()=>{if(!e)return()=>null;function n(){o(t())}return window.addEventListener("resize",n),()=>window.removeEventListener("resize",n)}),[]),n})(),m=ie(o),f=b.width&&b.width>599,h=u(t,e),w=n*e,x=w-e+1,C=1===n,y=n===h,v=Object.assign(Object.assign({},He),c),R=n===h?`${x}-${t} ${v.rangeSeparatorText} ${t}`:`${x}-${w} ${v.rangeSeparatorText} ${t}`,S=l.useCallback((()=>p(n-1)),[n,p]),E=l.useCallback((()=>p(n+1)),[n,p]),O=l.useCallback((()=>p(1)),[p]),$=l.useCallback((()=>p(u(t,e))),[p,t,e]),P=l.useCallback((e=>g(Number(e.target.value),n)),[n,g]),k=a.map((e=>l.createElement("option",{key:e,value:e},e)));v.selectAllRowsItem&&k.push(l.createElement("option",{key:-1,value:t},v.selectAllRowsItemText));const D=l.createElement(ke,{onChange:P,defaultValue:e,"aria-label":v.rowsPerPageText},k);return l.createElement(je,{className:"rdt_Pagination"},!v.noRowsPerPage&&f&&l.createElement(l.Fragment,null,l.createElement(Ae,null,v.rowsPerPageText),D),f&&l.createElement(Me,null,R),l.createElement(Te,null,l.createElement(Fe,{id:"pagination-first-page",type:"button","aria-label":"First Page","aria-disabled":C,onClick:O,disabled:C,$isRTL:m},i),l.createElement(Fe,{id:"pagination-previous-page",type:"button","aria-label":"Previous Page","aria-disabled":C,onClick:S,disabled:C,$isRTL:m},d),!v.noRowsPerPage&&!f&&D,l.createElement(Fe,{id:"pagination-next-page",type:"button","aria-label":"Next Page","aria-disabled":y,onClick:E,disabled:y,$isRTL:m},s),l.createElement(Fe,{id:"pagination-last-page",type:"button","aria-label":"Last Page","aria-disabled":y,onClick:$,disabled:y,$isRTL:m},r)))}));const _e=(e,t)=>{const n=l.useRef(!0);l.useEffect((()=>{n.current?n.current=!1:e()}),t)};function ze(e){return e&&e.__esModule&&Object.prototype.hasOwnProperty.call(e,"default")?e.default:e}var Ne=function(e){return function(e){return!!e&&"object"==typeof e}(e)&&!function(e){var t=Object.prototype.toString.call(e);return"[object RegExp]"===t||"[object Date]"===t||function(e){return e.$$typeof===We}(e)}(e)};var We="function"==typeof Symbol&&Symbol.for?Symbol.for("react.element"):60103;function Be(e,t){return!1!==t.clone&&t.isMergeableObject(e)?Ye((n=e,Array.isArray(n)?[]:{}),e,t):e;// removed by dead control flow
+ var n; }function Ge(e,t,n){return e.concat(t).map((function(e){return Be(e,n)}))}function Ve(e){return Object.keys(e).concat(function(e){return Object.getOwnPropertySymbols?Object.getOwnPropertySymbols(e).filter((function(t){return Object.propertyIsEnumerable.call(e,t)})):[]}(e))}function Ue(e,t){try{return t in e}catch(e){return!1}}function qe(e,t,n){var o={};return n.isMergeableObject(e)&&Ve(e).forEach((function(t){o[t]=Be(e[t],n)})),Ve(t).forEach((function(a){(function(e,t){return Ue(e,t)&&!(Object.hasOwnProperty.call(e,t)&&Object.propertyIsEnumerable.call(e,t))})(e,a)||(Ue(e,a)&&n.isMergeableObject(t[a])?o[a]=function(e,t){if(!t.customMerge)return Ye;var n=t.customMerge(e);return"function"==typeof n?n:Ye}(a,n)(e[a],t[a],n):o[a]=Be(t[a],n))})),o}function Ye(e,t,n){(n=n||{}).arrayMerge=n.arrayMerge||Ge,n.isMergeableObject=n.isMergeableObject||Ne,n.cloneUnlessOtherwiseSpecified=Be;var o=Array.isArray(t);return o===Array.isArray(e)?o?n.arrayMerge(e,t,n):qe(e,t,n):Be(t,n)}Ye.all=function(e,t){if(!Array.isArray(e))throw new Error("first argument should be an array");return e.reduce((function(e,n){return Ye(e,n,t)}),{})};var Ke=ze(Ye);const Je={text:{primary:"rgba(0, 0, 0, 0.87)",secondary:"rgba(0, 0, 0, 0.54)",disabled:"rgba(0, 0, 0, 0.38)"},background:{default:"#FFFFFF"},context:{background:"#e3f2fd",text:"rgba(0, 0, 0, 0.87)"},divider:{default:"rgba(0,0,0,.12)"},button:{default:"rgba(0,0,0,.54)",focus:"rgba(0,0,0,.12)",hover:"rgba(0,0,0,.12)",disabled:"rgba(0, 0, 0, .18)"},selected:{default:"#e3f2fd",text:"rgba(0, 0, 0, 0.87)"},highlightOnHover:{default:"#EEEEEE",text:"rgba(0, 0, 0, 0.87)"},striped:{default:"#FAFAFA",text:"rgba(0, 0, 0, 0.87)"}},Qe={default:Je,light:Je,dark:{text:{primary:"#FFFFFF",secondary:"rgba(255, 255, 255, 0.7)",disabled:"rgba(0,0,0,.12)"},background:{default:"#424242"},context:{background:"#E91E63",text:"#FFFFFF"},divider:{default:"rgba(81, 81, 81, 1)"},button:{default:"#FFFFFF",focus:"rgba(255, 255, 255, .54)",hover:"rgba(255, 255, 255, .12)",disabled:"rgba(255, 255, 255, .18)"},selected:{default:"rgba(0, 0, 0, .7)",text:"#FFFFFF"},highlightOnHover:{default:"rgba(0, 0, 0, .7)",text:"#FFFFFF"},striped:{default:"rgba(0, 0, 0, .87)",text:"#FFFFFF"}}};function Xe(e,t,n,o){const[r,i]=l.useState((()=>g(e))),[s,d]=l.useState(""),c=l.useRef("");_e((()=>{i(g(e))}),[e]);const u=l.useCallback((e=>{var t,n,o;const{attributes:a}=e.target,l=null===(t=a.getNamedItem("data-column-id"))||void 0===t?void 0:t.value;l&&(c.current=(null===(o=null===(n=r[h(r,l)])||void 0===n?void 0:n.id)||void 0===o?void 0:o.toString())||"",d(c.current))}),[r]),p=l.useCallback((e=>{var n;const{attributes:o}=e.target,a=null===(n=o.getNamedItem("data-column-id"))||void 0===n?void 0:n.value;if(a&&c.current&&a!==c.current){const e=h(r,c.current),n=h(r,a),o=[...r];o[e]=r[n],o[n]=r[e],i(o),t(o)}}),[t,r]),b=l.useCallback((e=>{e.preventDefault()}),[]),m=l.useCallback((e=>{e.preventDefault()}),[]),f=l.useCallback((e=>{e.preventDefault(),c.current="",d("")}),[]),w=function(e=!1){return e?a.ASC:a.DESC}(o),x=l.useMemo((()=>r[h(r,null==n?void 0:n.toString())]||{}),[n,r]);return{tableColumns:r,draggingColumnId:s,handleDragStart:u,handleDragEnter:p,handleDragOver:b,handleDragLeave:m,handleDragEnd:f,defaultSortDirection:w,defaultSortColumn:x}}var Ze=l.memo((function(e){const{data:n=De.data,columns:o=De.columns,title:r=De.title,actions:i=De.actions,keyField:d=De.keyField,striped:c=De.striped,highlightOnHover:g=De.highlightOnHover,pointerOnHover:b=De.pointerOnHover,dense:m=De.dense,selectableRows:h=De.selectableRows,selectableRowsSingle:w=De.selectableRowsSingle,selectableRowsHighlight:C=De.selectableRowsHighlight,selectableRowsNoSelectAll:v=De.selectableRowsNoSelectAll,selectableRowsVisibleOnly:E=De.selectableRowsVisibleOnly,selectableRowSelected:O=De.selectableRowSelected,selectableRowDisabled:$=De.selectableRowDisabled,selectableRowsComponent:P=De.selectableRowsComponent,selectableRowsComponentProps:D=De.selectableRowsComponentProps,onRowExpandToggled:H=De.onRowExpandToggled,onSelectedRowsChange:j=De.onSelectedRowsChange,expandableIcon:F=De.expandableIcon,onChangeRowsPerPage:T=De.onChangeRowsPerPage,onChangePage:I=De.onChangePage,paginationServer:M=De.paginationServer,paginationServerOptions:A=De.paginationServerOptions,paginationTotalRows:L=De.paginationTotalRows,paginationDefaultPage:_=De.paginationDefaultPage,paginationResetDefaultPage:z=De.paginationResetDefaultPage,paginationPerPage:N=De.paginationPerPage,paginationRowsPerPageOptions:W=De.paginationRowsPerPageOptions,paginationIconLastPage:B=De.paginationIconLastPage,paginationIconFirstPage:G=De.paginationIconFirstPage,paginationIconNext:V=De.paginationIconNext,paginationIconPrevious:U=De.paginationIconPrevious,paginationComponent:q=De.paginationComponent,paginationComponentOptions:Y=De.paginationComponentOptions,responsive:K=De.responsive,progressPending:J=De.progressPending,progressComponent:X=De.progressComponent,persistTableHead:Z=De.persistTableHead,noDataComponent:ee=De.noDataComponent,disabled:te=De.disabled,noTableHead:ne=De.noTableHead,noHeader:oe=De.noHeader,fixedHeader:le=De.fixedHeader,fixedHeaderScrollHeight:ie=De.fixedHeaderScrollHeight,pagination:se=De.pagination,subHeader:de=De.subHeader,subHeaderAlign:ce=De.subHeaderAlign,subHeaderWrap:ge=De.subHeaderWrap,subHeaderComponent:ue=De.subHeaderComponent,noContextMenu:pe=De.noContextMenu,contextMessage:be=De.contextMessage,contextActions:fe=De.contextActions,contextComponent:he=De.contextComponent,expandableRows:we=De.expandableRows,onRowClicked:Oe=De.onRowClicked,onRowDoubleClicked:$e=De.onRowDoubleClicked,onRowMouseEnter:Pe=De.onRowMouseEnter,onRowMouseLeave:ke=De.onRowMouseLeave,sortIcon:He=De.sortIcon,onSort:je=De.onSort,sortFunction:Fe=De.sortFunction,sortServer:Te=De.sortServer,expandableRowsComponent:Ie=De.expandableRowsComponent,expandableRowsComponentProps:Me=De.expandableRowsComponentProps,expandableRowDisabled:Ae=De.expandableRowDisabled,expandableRowsHideExpander:ze=De.expandableRowsHideExpander,expandOnRowClicked:Ne=De.expandOnRowClicked,expandOnRowDoubleClicked:We=De.expandOnRowDoubleClicked,expandableRowExpanded:Be=De.expandableRowExpanded,expandableInheritConditionalStyles:Ge=De.expandableInheritConditionalStyles,defaultSortFieldId:Ve=De.defaultSortFieldId,defaultSortAsc:Ue=De.defaultSortAsc,clearSelectedRows:qe=De.clearSelectedRows,conditionalRowStyles:Ye=De.conditionalRowStyles,theme:Je=De.theme,customStyles:Ze=De.customStyles,direction:et=De.direction,onColumnOrderChange:tt=De.onColumnOrderChange,className:nt,ariaLabel:ot}=e,{tableColumns:at,draggingColumnId:lt,handleDragStart:rt,handleDragEnter:it,handleDragOver:st,handleDragLeave:dt,handleDragEnd:ct,defaultSortDirection:gt,defaultSortColumn:ut}=Xe(o,tt,Ve,Ue),[{rowsPerPage:pt,currentPage:bt,selectedRows:mt,allSelected:ft,selectedCount:ht,selectedColumn:wt,sortDirection:xt,toggleOnSelectedRowsChange:Ct},yt]=l.useReducer(x,{allSelected:!1,selectedCount:0,selectedRows:[],selectedColumn:ut,toggleOnSelectedRowsChange:!1,sortDirection:gt,currentPage:_,rowsPerPage:N,selectedRowsFlag:!1,contextMessage:De.contextMessage}),{persistSelectedOnSort:vt=!1,persistSelectedOnPageChange:Rt=!1}=A,St=!(!M||!Rt&&!vt),Et=se&&!J&&n.length>0,Ot=q||Le,$t=l.useMemo((()=>((e={},t="default",n="default")=>{const o=Qe[t]?t:n;return Ke({table:{style:{color:(a=Qe[o]).text.primary,backgroundColor:a.background.default}},tableWrapper:{style:{display:"table"}},responsiveWrapper:{style:{}},header:{style:{fontSize:"22px",color:a.text.primary,backgroundColor:a.background.default,minHeight:"56px",paddingLeft:"16px",paddingRight:"8px"}},subHeader:{style:{backgroundColor:a.background.default,minHeight:"52px"}},head:{style:{color:a.text.primary,fontSize:"12px",fontWeight:500}},headRow:{style:{backgroundColor:a.background.default,minHeight:"52px",borderBottomWidth:"1px",borderBottomColor:a.divider.default,borderBottomStyle:"solid"},denseStyle:{minHeight:"32px"}},headCells:{style:{paddingLeft:"16px",paddingRight:"16px"},draggingStyle:{cursor:"move"}},contextMenu:{style:{backgroundColor:a.context.background,fontSize:"18px",fontWeight:400,color:a.context.text,paddingLeft:"16px",paddingRight:"8px",transform:"translate3d(0, -100%, 0)",transitionDuration:"125ms",transitionTimingFunction:"cubic-bezier(0, 0, 0.2, 1)",willChange:"transform"},activeStyle:{transform:"translate3d(0, 0, 0)"}},cells:{style:{paddingLeft:"16px",paddingRight:"16px",wordBreak:"break-word"},draggingStyle:{}},rows:{style:{fontSize:"13px",fontWeight:400,color:a.text.primary,backgroundColor:a.background.default,minHeight:"48px","&:not(:last-of-type)":{borderBottomStyle:"solid",borderBottomWidth:"1px",borderBottomColor:a.divider.default}},denseStyle:{minHeight:"32px"},selectedHighlightStyle:{"&:nth-of-type(n)":{color:a.selected.text,backgroundColor:a.selected.default,borderBottomColor:a.background.default}},highlightOnHoverStyle:{color:a.highlightOnHover.text,backgroundColor:a.highlightOnHover.default,transitionDuration:"0.15s",transitionProperty:"background-color",borderBottomColor:a.background.default,outlineStyle:"solid",outlineWidth:"1px",outlineColor:a.background.default},stripedStyle:{color:a.striped.text,backgroundColor:a.striped.default}},expanderRow:{style:{color:a.text.primary,backgroundColor:a.background.default}},expanderCell:{style:{flex:"0 0 48px"}},expanderButton:{style:{color:a.button.default,fill:a.button.default,backgroundColor:"transparent",borderRadius:"2px",transition:"0.25s",height:"100%",width:"100%","&:hover:enabled":{cursor:"pointer"},"&:disabled":{color:a.button.disabled},"&:hover:not(:disabled)":{cursor:"pointer",backgroundColor:a.button.hover},"&:focus":{outline:"none",backgroundColor:a.button.focus},svg:{margin:"auto"}}},pagination:{style:{color:a.text.secondary,fontSize:"13px",minHeight:"56px",backgroundColor:a.background.default,borderTopStyle:"solid",borderTopWidth:"1px",borderTopColor:a.divider.default},pageButtonsStyle:{borderRadius:"50%",height:"40px",width:"40px",padding:"8px",margin:"px",cursor:"pointer",transition:"0.4s",color:a.button.default,fill:a.button.default,backgroundColor:"transparent","&:disabled":{cursor:"unset",color:a.button.disabled,fill:a.button.disabled},"&:hover:not(:disabled)":{backgroundColor:a.button.hover},"&:focus":{outline:"none",backgroundColor:a.button.focus}}},noData:{style:{display:"flex",alignItems:"center",justifyContent:"center",color:a.text.primary,backgroundColor:a.background.default}},progress:{style:{display:"flex",alignItems:"center",justifyContent:"center",color:a.text.primary,backgroundColor:a.background.default}}},e);// removed by dead control flow
+ var a; })(Ze,Je)),[Ze,Je]),Pt=l.useMemo((()=>Object.assign({},"auto"!==et&&{dir:et})),[et]),kt=l.useMemo((()=>{if(Te)return n;if((null==wt?void 0:wt.sortFunction)&&"function"==typeof wt.sortFunction){const e=wt.sortFunction,t=xt===a.ASC?e:(t,n)=>-1*e(t,n);return[...n].sort(t)}return function(e,t,n,o){return t?o&&"function"==typeof o?o(e.slice(0),t,n):e.slice(0).sort(((e,o)=>{const a=t(e),l=t(o);if("asc"===n){if(a<l)return-1;if(a>l)return 1}if("desc"===n){if(a>l)return-1;if(a<l)return 1}return 0})):e}(n,null==wt?void 0:wt.selector,xt,Fe)}),[Te,wt,xt,n,Fe]),Dt=l.useMemo((()=>{if(se&&!M){const e=bt*pt,t=e-pt;return kt.slice(t,e)}return kt}),[bt,se,M,pt,kt]),Ht=l.useCallback((e=>{yt(e)}),[]),jt=l.useCallback((e=>{yt(e)}),[]),Ft=l.useCallback((e=>{yt(e)}),[]),Tt=l.useCallback(((e,t)=>Oe(e,t)),[Oe]),It=l.useCallback(((e,t)=>$e(e,t)),[$e]),Mt=l.useCallback(((e,t)=>Pe(e,t)),[Pe]),At=l.useCallback(((e,t)=>ke(e,t)),[ke]),Lt=l.useCallback((e=>yt({type:"CHANGE_PAGE",page:e,paginationServer:M,visibleOnly:E,persistSelectedOnPageChange:Rt})),[M,Rt,E]),_t=l.useCallback((e=>{const t=u(L||Dt.length,e),n=p(bt,t);M||Lt(n),yt({type:"CHANGE_ROWS_PER_PAGE",page:n,rowsPerPage:e})}),[bt,Lt,M,L,Dt.length]);if(se&&!M&&kt.length>0&&0===Dt.length){const e=u(kt.length,pt),t=p(bt,e);Lt(t)}_e((()=>{j({allSelected:ft,selectedCount:ht,selectedRows:mt.slice(0)})}),[Ct]),_e((()=>{je(wt,xt,kt.slice(0))}),[wt,xt]),_e((()=>{I(bt,L||kt.length)}),[bt]),_e((()=>{T(pt,bt)}),[pt]),_e((()=>{Lt(_)}),[_,z]),_e((()=>{if(se&&M&&L>0){const e=u(L,pt),t=p(bt,e);bt!==t&&Lt(t)}}),[L]),l.useEffect((()=>{yt({type:"CLEAR_SELECTED_ROWS",selectedRowsFlag:qe})}),[w,qe]),l.useEffect((()=>{if(!O)return;const e=kt.filter((e=>O(e))),t=w?e.slice(0,1):e;yt({type:"SELECT_MULTIPLE_ROWS",keyField:d,selectedRows:t,totalRows:kt.length,mergeSelections:St})}),[n,O]);const zt=E?Dt:kt,Nt=Rt||w||v;return l.createElement(t.ThemeProvider,{theme:$t},!oe&&(!!r||!!i)&&l.createElement(me,{title:r,actions:i,showMenu:!pe,selectedCount:ht,direction:et,contextActions:fe,contextComponent:he,contextMessage:be}),de&&l.createElement(xe,{align:ce,wrapContent:ge},ue),l.createElement(ye,Object.assign({$responsive:K,$fixedHeader:le,$fixedHeaderScrollHeight:ie,className:nt},Pt),l.createElement(Re,null,J&&!Z&&l.createElement(ve,null,X),l.createElement(y,Object.assign({disabled:te,className:"rdt_Table",role:"table"},ot&&{"aria-label":ot}),!ne&&(!!Z||kt.length>0&&!J)&&l.createElement(R,{className:"rdt_TableHead",role:"rowgroup",$fixedHeader:le},l.createElement(S,{className:"rdt_TableHeadRow",role:"row",$dense:m},h&&(Nt?l.createElement(k,{style:{flex:"0 0 48px"}}):l.createElement(re,{allSelected:ft,selectedRows:mt,selectableRowsComponent:P,selectableRowsComponentProps:D,selectableRowDisabled:$,rowData:zt,keyField:d,mergeSelections:St,onSelectAllRows:jt})),we&&!ze&&l.createElement(Se,null),at.map((e=>l.createElement(ae,{key:e.id,column:e,selectedColumn:wt,disabled:J||0===kt.length,pagination:se,paginationServer:M,persistSelectedOnSort:vt,selectableRowsVisibleOnly:E,sortDirection:xt,sortIcon:He,sortServer:Te,onSort:Ht,onDragStart:rt,onDragOver:st,onDragEnd:ct,onDragEnter:it,onDragLeave:dt,draggingColumnId:lt}))))),!kt.length&&!J&&l.createElement(Ee,null,ee),J&&Z&&l.createElement(ve,null,X),!J&&kt.length>0&&l.createElement(Ce,{className:"rdt_TableBody",role:"rowgroup"},Dt.map(((e,t)=>{const n=s(e,d),o=function(e=""){return"number"!=typeof e&&(!e||0===e.length)}(n)?t:n,a=f(e,mt,d),r=!!(we&&Be&&Be(e)),i=!!(we&&Ae&&Ae(e));return l.createElement(Q,{id:o,key:o,keyField:d,"data-row-id":o,columns:at,row:e,rowCount:kt.length,rowIndex:t,selectableRows:h,expandableRows:we,expandableIcon:F,highlightOnHover:g,pointerOnHover:b,dense:m,expandOnRowClicked:Ne,expandOnRowDoubleClicked:We,expandableRowsComponent:Ie,expandableRowsComponentProps:Me,expandableRowsHideExpander:ze,defaultExpanderDisabled:i,defaultExpanded:r,expandableInheritConditionalStyles:Ge,conditionalRowStyles:Ye,selected:a,selectableRowsHighlight:C,selectableRowsComponent:P,selectableRowsComponentProps:D,selectableRowDisabled:$,selectableRowsSingle:w,striped:c,onRowExpandToggled:H,onRowClicked:Tt,onRowDoubleClicked:It,onRowMouseEnter:Mt,onRowMouseLeave:At,onSelectedRow:Ft,draggingColumnId:lt,onDragStart:rt,onDragOver:st,onDragEnd:ct,onDragEnter:it,onDragLeave:dt})})))))),Et&&l.createElement("div",null,l.createElement(Ot,{onChangePage:Lt,onChangeRowsPerPage:_t,rowCount:L||kt.length,currentPage:bt,rowsPerPage:pt,direction:et,paginationRowsPerPageOptions:W,paginationIconLastPage:B,paginationIconFirstPage:G,paginationIconNext:V,paginationIconPrevious:U,paginationComponentOptions:Y})))}));exports.STOP_PROP_TAG=G,exports.createTheme=function(e="default",t,n="default"){return Qe[e]||(Qe[e]=Ke(Qe[n],t||{})),Qe[e]=Ke(Qe[e],t||{}),Qe[e]},exports["default"]=Ze,exports.defaultThemes=Qe;
+//# sourceMappingURL=index.cjs.js.map
+
+
+/***/ }),
+
+/***/ "./node_modules/react-fast-compare/index.js":
+/*!**************************************************!*\
+  !*** ./node_modules/react-fast-compare/index.js ***!
+  \**************************************************/
+/***/ ((module) => {
+
+/* global Map:readonly, Set:readonly, ArrayBuffer:readonly */
+
+var hasElementType = typeof Element !== 'undefined';
+var hasMap = typeof Map === 'function';
+var hasSet = typeof Set === 'function';
+var hasArrayBuffer = typeof ArrayBuffer === 'function' && !!ArrayBuffer.isView;
+
+// Note: We **don't** need `envHasBigInt64Array` in fde es6/index.js
+
+function equal(a, b) {
+  // START: fast-deep-equal es6/index.js 3.1.3
+  if (a === b) return true;
+
+  if (a && b && typeof a == 'object' && typeof b == 'object') {
+    if (a.constructor !== b.constructor) return false;
+
+    var length, i, keys;
+    if (Array.isArray(a)) {
+      length = a.length;
+      if (length != b.length) return false;
+      for (i = length; i-- !== 0;)
+        if (!equal(a[i], b[i])) return false;
+      return true;
+    }
+
+    // START: Modifications:
+    // 1. Extra `has<Type> &&` helpers in initial condition allow es6 code
+    //    to co-exist with es5.
+    // 2. Replace `for of` with es5 compliant iteration using `for`.
+    //    Basically, take:
+    //
+    //    ```js
+    //    for (i of a.entries())
+    //      if (!b.has(i[0])) return false;
+    //    ```
+    //
+    //    ... and convert to:
+    //
+    //    ```js
+    //    it = a.entries();
+    //    while (!(i = it.next()).done)
+    //      if (!b.has(i.value[0])) return false;
+    //    ```
+    //
+    //    **Note**: `i` access switches to `i.value`.
+    var it;
+    if (hasMap && (a instanceof Map) && (b instanceof Map)) {
+      if (a.size !== b.size) return false;
+      it = a.entries();
+      while (!(i = it.next()).done)
+        if (!b.has(i.value[0])) return false;
+      it = a.entries();
+      while (!(i = it.next()).done)
+        if (!equal(i.value[1], b.get(i.value[0]))) return false;
+      return true;
+    }
+
+    if (hasSet && (a instanceof Set) && (b instanceof Set)) {
+      if (a.size !== b.size) return false;
+      it = a.entries();
+      while (!(i = it.next()).done)
+        if (!b.has(i.value[0])) return false;
+      return true;
+    }
+    // END: Modifications
+
+    if (hasArrayBuffer && ArrayBuffer.isView(a) && ArrayBuffer.isView(b)) {
+      length = a.length;
+      if (length != b.length) return false;
+      for (i = length; i-- !== 0;)
+        if (a[i] !== b[i]) return false;
+      return true;
+    }
+
+    if (a.constructor === RegExp) return a.source === b.source && a.flags === b.flags;
+    // START: Modifications:
+    // Apply guards for `Object.create(null)` handling. See:
+    // - https://github.com/FormidableLabs/react-fast-compare/issues/64
+    // - https://github.com/epoberezkin/fast-deep-equal/issues/49
+    if (a.valueOf !== Object.prototype.valueOf && typeof a.valueOf === 'function' && typeof b.valueOf === 'function') return a.valueOf() === b.valueOf();
+    if (a.toString !== Object.prototype.toString && typeof a.toString === 'function' && typeof b.toString === 'function') return a.toString() === b.toString();
+    // END: Modifications
+
+    keys = Object.keys(a);
+    length = keys.length;
+    if (length !== Object.keys(b).length) return false;
+
+    for (i = length; i-- !== 0;)
+      if (!Object.prototype.hasOwnProperty.call(b, keys[i])) return false;
+    // END: fast-deep-equal
+
+    // START: react-fast-compare
+    // custom handling for DOM elements
+    if (hasElementType && a instanceof Element) return false;
+
+    // custom handling for React/Preact
+    for (i = length; i-- !== 0;) {
+      if ((keys[i] === '_owner' || keys[i] === '__v' || keys[i] === '__o') && a.$$typeof) {
+        // React-specific: avoid traversing React elements' _owner
+        // Preact-specific: avoid traversing Preact elements' __v and __o
+        //    __v = $_original / $_vnode
+        //    __o = $_owner
+        // These properties contain circular references and are not needed when
+        // comparing the actual elements (and not their owners)
+        // .$$typeof and ._store on just reasonable markers of elements
+
+        continue;
+      }
+
+      // all other properties should be traversed as usual
+      if (!equal(a[keys[i]], b[keys[i]])) return false;
+    }
+    // END: react-fast-compare
+
+    // START: fast-deep-equal
+    return true;
+  }
+
+  return a !== a && b !== b;
+}
+// end fast-deep-equal
+
+module.exports = function isEqual(a, b) {
+  try {
+    return equal(a, b);
+  } catch (error) {
+    if (((error.message || '').match(/stack|recursion/i))) {
+      // warn on circular references, don't crash
+      // browsers give this different errors name and messages:
+      // chrome/safari: "RangeError", "Maximum call stack size exceeded"
+      // firefox: "InternalError", too much recursion"
+      // edge: "Error", "Out of stack space"
+      console.warn('react-fast-compare cannot handle circular refs');
+      return false;
+    }
+    // some other error. we should definitely know about these
+    throw error;
+  }
+};
+
+
+/***/ }),
+
+/***/ "./node_modules/react-player/lib/Player.js":
+/*!*************************************************!*\
+  !*** ./node_modules/react-player/lib/Player.js ***!
+  \*************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var __publicField = (obj, key, value) => {
+  __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
+var Player_exports = {};
+__export(Player_exports, {
+  default: () => Player
+});
+module.exports = __toCommonJS(Player_exports);
+var import_react = __toESM(__webpack_require__(/*! react */ "react"));
+var import_react_fast_compare = __toESM(__webpack_require__(/*! react-fast-compare */ "./node_modules/react-fast-compare/index.js"));
+var import_props = __webpack_require__(/*! ./props */ "./node_modules/react-player/lib/props.js");
+var import_utils = __webpack_require__(/*! ./utils */ "./node_modules/react-player/lib/utils.js");
+const SEEK_ON_PLAY_EXPIRY = 5e3;
+class Player extends import_react.Component {
+  constructor() {
+    super(...arguments);
+    __publicField(this, "mounted", false);
+    __publicField(this, "isReady", false);
+    __publicField(this, "isPlaying", false);
+    // Track playing state internally to prevent bugs
+    __publicField(this, "isLoading", true);
+    // Use isLoading to prevent onPause when switching URL
+    __publicField(this, "loadOnReady", null);
+    __publicField(this, "startOnPlay", true);
+    __publicField(this, "seekOnPlay", null);
+    __publicField(this, "onDurationCalled", false);
+    __publicField(this, "handlePlayerMount", (player) => {
+      if (this.player) {
+        this.progress();
+        return;
+      }
+      this.player = player;
+      this.player.load(this.props.url);
+      this.progress();
+    });
+    __publicField(this, "getInternalPlayer", (key) => {
+      if (!this.player)
+        return null;
+      return this.player[key];
+    });
+    __publicField(this, "progress", () => {
+      if (this.props.url && this.player && this.isReady) {
+        const playedSeconds = this.getCurrentTime() || 0;
+        const loadedSeconds = this.getSecondsLoaded();
+        const duration = this.getDuration();
+        if (duration) {
+          const progress = {
+            playedSeconds,
+            played: playedSeconds / duration
+          };
+          if (loadedSeconds !== null) {
+            progress.loadedSeconds = loadedSeconds;
+            progress.loaded = loadedSeconds / duration;
+          }
+          if (progress.playedSeconds !== this.prevPlayed || progress.loadedSeconds !== this.prevLoaded) {
+            this.props.onProgress(progress);
+          }
+          this.prevPlayed = progress.playedSeconds;
+          this.prevLoaded = progress.loadedSeconds;
+        }
+      }
+      this.progressTimeout = setTimeout(this.progress, this.props.progressFrequency || this.props.progressInterval);
+    });
+    __publicField(this, "handleReady", () => {
+      if (!this.mounted)
+        return;
+      this.isReady = true;
+      this.isLoading = false;
+      const { onReady, playing, volume, muted } = this.props;
+      onReady();
+      if (!muted && volume !== null) {
+        this.player.setVolume(volume);
+      }
+      if (this.loadOnReady) {
+        this.player.load(this.loadOnReady, true);
+        this.loadOnReady = null;
+      } else if (playing) {
+        this.player.play();
+      }
+      this.handleDurationCheck();
+    });
+    __publicField(this, "handlePlay", () => {
+      this.isPlaying = true;
+      this.isLoading = false;
+      const { onStart, onPlay, playbackRate } = this.props;
+      if (this.startOnPlay) {
+        if (this.player.setPlaybackRate && playbackRate !== 1) {
+          this.player.setPlaybackRate(playbackRate);
+        }
+        onStart();
+        this.startOnPlay = false;
+      }
+      onPlay();
+      if (this.seekOnPlay) {
+        this.seekTo(this.seekOnPlay);
+        this.seekOnPlay = null;
+      }
+      this.handleDurationCheck();
+    });
+    __publicField(this, "handlePause", (e) => {
+      this.isPlaying = false;
+      if (!this.isLoading) {
+        this.props.onPause(e);
+      }
+    });
+    __publicField(this, "handleEnded", () => {
+      const { activePlayer, loop, onEnded } = this.props;
+      if (activePlayer.loopOnEnded && loop) {
+        this.seekTo(0);
+      }
+      if (!loop) {
+        this.isPlaying = false;
+        onEnded();
+      }
+    });
+    __publicField(this, "handleError", (...args) => {
+      this.isLoading = false;
+      this.props.onError(...args);
+    });
+    __publicField(this, "handleDurationCheck", () => {
+      clearTimeout(this.durationCheckTimeout);
+      const duration = this.getDuration();
+      if (duration) {
+        if (!this.onDurationCalled) {
+          this.props.onDuration(duration);
+          this.onDurationCalled = true;
+        }
+      } else {
+        this.durationCheckTimeout = setTimeout(this.handleDurationCheck, 100);
+      }
+    });
+    __publicField(this, "handleLoaded", () => {
+      this.isLoading = false;
+    });
+  }
+  componentDidMount() {
+    this.mounted = true;
+  }
+  componentWillUnmount() {
+    clearTimeout(this.progressTimeout);
+    clearTimeout(this.durationCheckTimeout);
+    if (this.isReady && this.props.stopOnUnmount) {
+      this.player.stop();
+      if (this.player.disablePIP) {
+        this.player.disablePIP();
+      }
+    }
+    this.mounted = false;
+  }
+  componentDidUpdate(prevProps) {
+    if (!this.player) {
+      return;
+    }
+    const { url, playing, volume, muted, playbackRate, pip, loop, activePlayer, disableDeferredLoading } = this.props;
+    if (!(0, import_react_fast_compare.default)(prevProps.url, url)) {
+      if (this.isLoading && !activePlayer.forceLoad && !disableDeferredLoading && !(0, import_utils.isMediaStream)(url)) {
+        console.warn(`ReactPlayer: the attempt to load ${url} is being deferred until the player has loaded`);
+        this.loadOnReady = url;
+        return;
+      }
+      this.isLoading = true;
+      this.startOnPlay = true;
+      this.onDurationCalled = false;
+      this.player.load(url, this.isReady);
+    }
+    if (!prevProps.playing && playing && !this.isPlaying) {
+      this.player.play();
+    }
+    if (prevProps.playing && !playing && this.isPlaying) {
+      this.player.pause();
+    }
+    if (!prevProps.pip && pip && this.player.enablePIP) {
+      this.player.enablePIP();
+    }
+    if (prevProps.pip && !pip && this.player.disablePIP) {
+      this.player.disablePIP();
+    }
+    if (prevProps.volume !== volume && volume !== null) {
+      this.player.setVolume(volume);
+    }
+    if (prevProps.muted !== muted) {
+      if (muted) {
+        this.player.mute();
+      } else {
+        this.player.unmute();
+        if (volume !== null) {
+          setTimeout(() => this.player.setVolume(volume));
+        }
+      }
+    }
+    if (prevProps.playbackRate !== playbackRate && this.player.setPlaybackRate) {
+      this.player.setPlaybackRate(playbackRate);
+    }
+    if (prevProps.loop !== loop && this.player.setLoop) {
+      this.player.setLoop(loop);
+    }
+  }
+  getDuration() {
+    if (!this.isReady)
+      return null;
+    return this.player.getDuration();
+  }
+  getCurrentTime() {
+    if (!this.isReady)
+      return null;
+    return this.player.getCurrentTime();
+  }
+  getSecondsLoaded() {
+    if (!this.isReady)
+      return null;
+    return this.player.getSecondsLoaded();
+  }
+  seekTo(amount, type, keepPlaying) {
+    if (!this.isReady) {
+      if (amount !== 0) {
+        this.seekOnPlay = amount;
+        setTimeout(() => {
+          this.seekOnPlay = null;
+        }, SEEK_ON_PLAY_EXPIRY);
+      }
+      return;
+    }
+    const isFraction = !type ? amount > 0 && amount < 1 : type === "fraction";
+    if (isFraction) {
+      const duration = this.player.getDuration();
+      if (!duration) {
+        console.warn("ReactPlayer: could not seek using fraction \u2013\xA0duration not yet available");
+        return;
+      }
+      this.player.seekTo(duration * amount, keepPlaying);
+      return;
+    }
+    this.player.seekTo(amount, keepPlaying);
+  }
+  render() {
+    const Player2 = this.props.activePlayer;
+    if (!Player2) {
+      return null;
+    }
+    return /* @__PURE__ */ import_react.default.createElement(
+      Player2,
+      {
+        ...this.props,
+        onMount: this.handlePlayerMount,
+        onReady: this.handleReady,
+        onPlay: this.handlePlay,
+        onPause: this.handlePause,
+        onEnded: this.handleEnded,
+        onLoaded: this.handleLoaded,
+        onError: this.handleError
+      }
+    );
+  }
+}
+__publicField(Player, "displayName", "Player");
+__publicField(Player, "propTypes", import_props.propTypes);
+__publicField(Player, "defaultProps", import_props.defaultProps);
+
+
+/***/ }),
+
+/***/ "./node_modules/react-player/lib/ReactPlayer.js":
+/*!******************************************************!*\
+  !*** ./node_modules/react-player/lib/ReactPlayer.js ***!
+  \******************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var __publicField = (obj, key, value) => {
+  __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
+var ReactPlayer_exports = {};
+__export(ReactPlayer_exports, {
+  createReactPlayer: () => createReactPlayer
+});
+module.exports = __toCommonJS(ReactPlayer_exports);
+var import_react = __toESM(__webpack_require__(/*! react */ "react"));
+var import_deepmerge = __toESM(__webpack_require__(/*! deepmerge */ "./node_modules/deepmerge/dist/cjs.js"));
+var import_memoize_one = __toESM(__webpack_require__(/*! memoize-one */ "./node_modules/memoize-one/dist/memoize-one.esm.js"));
+var import_react_fast_compare = __toESM(__webpack_require__(/*! react-fast-compare */ "./node_modules/react-fast-compare/index.js"));
+var import_props = __webpack_require__(/*! ./props */ "./node_modules/react-player/lib/props.js");
+var import_utils = __webpack_require__(/*! ./utils */ "./node_modules/react-player/lib/utils.js");
+var import_Player = __toESM(__webpack_require__(/*! ./Player */ "./node_modules/react-player/lib/Player.js"));
+const Preview = (0, import_utils.lazy)(() => __webpack_require__.e(/*! import() | reactPlayerPreview */ "reactPlayerPreview").then(__webpack_require__.t.bind(__webpack_require__, /*! ./Preview */ "./node_modules/react-player/lib/Preview.js", 23)));
+const IS_BROWSER = typeof window !== "undefined" && window.document && typeof document !== "undefined";
+const IS_GLOBAL = typeof __webpack_require__.g !== "undefined" && __webpack_require__.g.window && __webpack_require__.g.window.document;
+const SUPPORTED_PROPS = Object.keys(import_props.propTypes);
+const UniversalSuspense = IS_BROWSER || IS_GLOBAL ? import_react.Suspense : () => null;
+const customPlayers = [];
+const createReactPlayer = (players, fallback) => {
+  var _a;
+  return _a = class extends import_react.Component {
+    constructor() {
+      super(...arguments);
+      __publicField(this, "state", {
+        showPreview: !!this.props.light
+      });
+      // Use references, as refs is used by React
+      __publicField(this, "references", {
+        wrapper: (wrapper) => {
+          this.wrapper = wrapper;
+        },
+        player: (player) => {
+          this.player = player;
+        }
+      });
+      __publicField(this, "handleClickPreview", (e) => {
+        this.setState({ showPreview: false });
+        this.props.onClickPreview(e);
+      });
+      __publicField(this, "showPreview", () => {
+        this.setState({ showPreview: true });
+      });
+      __publicField(this, "getDuration", () => {
+        if (!this.player)
+          return null;
+        return this.player.getDuration();
+      });
+      __publicField(this, "getCurrentTime", () => {
+        if (!this.player)
+          return null;
+        return this.player.getCurrentTime();
+      });
+      __publicField(this, "getSecondsLoaded", () => {
+        if (!this.player)
+          return null;
+        return this.player.getSecondsLoaded();
+      });
+      __publicField(this, "getInternalPlayer", (key = "player") => {
+        if (!this.player)
+          return null;
+        return this.player.getInternalPlayer(key);
+      });
+      __publicField(this, "seekTo", (fraction, type, keepPlaying) => {
+        if (!this.player)
+          return null;
+        this.player.seekTo(fraction, type, keepPlaying);
+      });
+      __publicField(this, "handleReady", () => {
+        this.props.onReady(this);
+      });
+      __publicField(this, "getActivePlayer", (0, import_memoize_one.default)((url) => {
+        for (const player of [...customPlayers, ...players]) {
+          if (player.canPlay(url)) {
+            return player;
+          }
+        }
+        if (fallback) {
+          return fallback;
+        }
+        return null;
+      }));
+      __publicField(this, "getConfig", (0, import_memoize_one.default)((url, key) => {
+        const { config } = this.props;
+        return import_deepmerge.default.all([
+          import_props.defaultProps.config,
+          import_props.defaultProps.config[key] || {},
+          config,
+          config[key] || {}
+        ]);
+      }));
+      __publicField(this, "getAttributes", (0, import_memoize_one.default)((url) => {
+        return (0, import_utils.omit)(this.props, SUPPORTED_PROPS);
+      }));
+      __publicField(this, "renderActivePlayer", (url) => {
+        if (!url)
+          return null;
+        const player = this.getActivePlayer(url);
+        if (!player)
+          return null;
+        const config = this.getConfig(url, player.key);
+        return /* @__PURE__ */ import_react.default.createElement(
+          import_Player.default,
+          {
+            ...this.props,
+            key: player.key,
+            ref: this.references.player,
+            config,
+            activePlayer: player.lazyPlayer || player,
+            onReady: this.handleReady
+          }
+        );
+      });
+    }
+    shouldComponentUpdate(nextProps, nextState) {
+      return !(0, import_react_fast_compare.default)(this.props, nextProps) || !(0, import_react_fast_compare.default)(this.state, nextState);
+    }
+    componentDidUpdate(prevProps) {
+      const { light } = this.props;
+      if (!prevProps.light && light) {
+        this.setState({ showPreview: true });
+      }
+      if (prevProps.light && !light) {
+        this.setState({ showPreview: false });
+      }
+    }
+    renderPreview(url) {
+      if (!url)
+        return null;
+      const { light, playIcon, previewTabIndex, oEmbedUrl, previewAriaLabel } = this.props;
+      return /* @__PURE__ */ import_react.default.createElement(
+        Preview,
+        {
+          url,
+          light,
+          playIcon,
+          previewTabIndex,
+          previewAriaLabel,
+          oEmbedUrl,
+          onClick: this.handleClickPreview
+        }
+      );
+    }
+    render() {
+      const { url, style, width, height, fallback: fallback2, wrapper: Wrapper } = this.props;
+      const { showPreview } = this.state;
+      const attributes = this.getAttributes(url);
+      const wrapperRef = typeof Wrapper === "string" ? this.references.wrapper : void 0;
+      return /* @__PURE__ */ import_react.default.createElement(Wrapper, { ref: wrapperRef, style: { ...style, width, height }, ...attributes }, /* @__PURE__ */ import_react.default.createElement(UniversalSuspense, { fallback: fallback2 }, showPreview ? this.renderPreview(url) : this.renderActivePlayer(url)));
+    }
+  }, __publicField(_a, "displayName", "ReactPlayer"), __publicField(_a, "propTypes", import_props.propTypes), __publicField(_a, "defaultProps", import_props.defaultProps), __publicField(_a, "addCustomPlayer", (player) => {
+    customPlayers.push(player);
+  }), __publicField(_a, "removeCustomPlayers", () => {
+    customPlayers.length = 0;
+  }), __publicField(_a, "canPlay", (url) => {
+    for (const Player2 of [...customPlayers, ...players]) {
+      if (Player2.canPlay(url)) {
+        return true;
+      }
+    }
+    return false;
+  }), __publicField(_a, "canEnablePIP", (url) => {
+    for (const Player2 of [...customPlayers, ...players]) {
+      if (Player2.canEnablePIP && Player2.canEnablePIP(url)) {
+        return true;
+      }
+    }
+    return false;
+  }), _a;
+};
+
+
+/***/ }),
+
+/***/ "./node_modules/react-player/lib/index.js":
+/*!************************************************!*\
+  !*** ./node_modules/react-player/lib/index.js ***!
+  \************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var src_exports = {};
+__export(src_exports, {
+  default: () => src_default
+});
+module.exports = __toCommonJS(src_exports);
+var import_players = __toESM(__webpack_require__(/*! ./players */ "./node_modules/react-player/lib/players/index.js"));
+var import_ReactPlayer = __webpack_require__(/*! ./ReactPlayer */ "./node_modules/react-player/lib/ReactPlayer.js");
+const fallback = import_players.default[import_players.default.length - 1];
+var src_default = (0, import_ReactPlayer.createReactPlayer)(import_players.default, fallback);
+
+
+/***/ }),
+
+/***/ "./node_modules/react-player/lib/patterns.js":
+/*!***************************************************!*\
+  !*** ./node_modules/react-player/lib/patterns.js ***!
+  \***************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var patterns_exports = {};
+__export(patterns_exports, {
+  AUDIO_EXTENSIONS: () => AUDIO_EXTENSIONS,
+  DASH_EXTENSIONS: () => DASH_EXTENSIONS,
+  FLV_EXTENSIONS: () => FLV_EXTENSIONS,
+  HLS_EXTENSIONS: () => HLS_EXTENSIONS,
+  MATCH_URL_DAILYMOTION: () => MATCH_URL_DAILYMOTION,
+  MATCH_URL_FACEBOOK: () => MATCH_URL_FACEBOOK,
+  MATCH_URL_FACEBOOK_WATCH: () => MATCH_URL_FACEBOOK_WATCH,
+  MATCH_URL_KALTURA: () => MATCH_URL_KALTURA,
+  MATCH_URL_MIXCLOUD: () => MATCH_URL_MIXCLOUD,
+  MATCH_URL_MUX: () => MATCH_URL_MUX,
+  MATCH_URL_SOUNDCLOUD: () => MATCH_URL_SOUNDCLOUD,
+  MATCH_URL_STREAMABLE: () => MATCH_URL_STREAMABLE,
+  MATCH_URL_TWITCH_CHANNEL: () => MATCH_URL_TWITCH_CHANNEL,
+  MATCH_URL_TWITCH_VIDEO: () => MATCH_URL_TWITCH_VIDEO,
+  MATCH_URL_VIDYARD: () => MATCH_URL_VIDYARD,
+  MATCH_URL_VIMEO: () => MATCH_URL_VIMEO,
+  MATCH_URL_WISTIA: () => MATCH_URL_WISTIA,
+  MATCH_URL_YOUTUBE: () => MATCH_URL_YOUTUBE,
+  VIDEO_EXTENSIONS: () => VIDEO_EXTENSIONS,
+  canPlay: () => canPlay
+});
+module.exports = __toCommonJS(patterns_exports);
+var import_utils = __webpack_require__(/*! ./utils */ "./node_modules/react-player/lib/utils.js");
+const MATCH_URL_YOUTUBE = /(?:youtu\.be\/|youtube(?:-nocookie|education)?\.com\/(?:embed\/|v\/|watch\/|watch\?v=|watch\?.+&v=|shorts\/|live\/))((\w|-){11})|youtube\.com\/playlist\?list=|youtube\.com\/user\//;
+const MATCH_URL_SOUNDCLOUD = /(?:soundcloud\.com|snd\.sc)\/[^.]+$/;
+const MATCH_URL_VIMEO = /vimeo\.com\/(?!progressive_redirect).+/;
+const MATCH_URL_MUX = /stream\.mux\.com\/(?!\w+\.m3u8)(\w+)/;
+const MATCH_URL_FACEBOOK = /^https?:\/\/(www\.)?facebook\.com.*\/(video(s)?|watch|story)(\.php?|\/).+$/;
+const MATCH_URL_FACEBOOK_WATCH = /^https?:\/\/fb\.watch\/.+$/;
+const MATCH_URL_STREAMABLE = /streamable\.com\/([a-z0-9]+)$/;
+const MATCH_URL_WISTIA = /(?:wistia\.(?:com|net)|wi\.st)\/(?:medias|embed)\/(?:iframe\/)?([^?]+)/;
+const MATCH_URL_TWITCH_VIDEO = /(?:www\.|go\.)?twitch\.tv\/videos\/(\d+)($|\?)/;
+const MATCH_URL_TWITCH_CHANNEL = /(?:www\.|go\.)?twitch\.tv\/([a-zA-Z0-9_]+)($|\?)/;
+const MATCH_URL_DAILYMOTION = /^(?:(?:https?):)?(?:\/\/)?(?:www\.)?(?:(?:dailymotion\.com(?:\/embed)?\/video)|dai\.ly)\/([a-zA-Z0-9]+)(?:_[\w_-]+)?(?:[\w.#_-]+)?/;
+const MATCH_URL_MIXCLOUD = /mixcloud\.com\/([^/]+\/[^/]+)/;
+const MATCH_URL_VIDYARD = /vidyard.com\/(?:watch\/)?([a-zA-Z0-9-_]+)/;
+const MATCH_URL_KALTURA = /^https?:\/\/[a-zA-Z]+\.kaltura.(com|org)\/p\/([0-9]+)\/sp\/([0-9]+)00\/embedIframeJs\/uiconf_id\/([0-9]+)\/partner_id\/([0-9]+)(.*)entry_id.([a-zA-Z0-9-_].*)$/;
+const AUDIO_EXTENSIONS = /\.(m4a|m4b|mp4a|mpga|mp2|mp2a|mp3|m2a|m3a|wav|weba|aac|oga|spx)($|\?)/i;
+const VIDEO_EXTENSIONS = /\.(mp4|og[gv]|webm|mov|m4v)(#t=[,\d+]+)?($|\?)/i;
+const HLS_EXTENSIONS = /\.(m3u8)($|\?)/i;
+const DASH_EXTENSIONS = /\.(mpd)($|\?)/i;
+const FLV_EXTENSIONS = /\.(flv)($|\?)/i;
+const canPlayFile = (url) => {
+  if (url instanceof Array) {
+    for (const item of url) {
+      if (typeof item === "string" && canPlayFile(item)) {
+        return true;
+      }
+      if (canPlayFile(item.src)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  if ((0, import_utils.isMediaStream)(url) || (0, import_utils.isBlobUrl)(url)) {
+    return true;
+  }
+  return AUDIO_EXTENSIONS.test(url) || VIDEO_EXTENSIONS.test(url) || HLS_EXTENSIONS.test(url) || DASH_EXTENSIONS.test(url) || FLV_EXTENSIONS.test(url);
+};
+const canPlay = {
+  youtube: (url) => {
+    if (url instanceof Array) {
+      return url.every((item) => MATCH_URL_YOUTUBE.test(item));
+    }
+    return MATCH_URL_YOUTUBE.test(url);
+  },
+  soundcloud: (url) => MATCH_URL_SOUNDCLOUD.test(url) && !AUDIO_EXTENSIONS.test(url),
+  vimeo: (url) => MATCH_URL_VIMEO.test(url) && !VIDEO_EXTENSIONS.test(url) && !HLS_EXTENSIONS.test(url),
+  mux: (url) => MATCH_URL_MUX.test(url),
+  facebook: (url) => MATCH_URL_FACEBOOK.test(url) || MATCH_URL_FACEBOOK_WATCH.test(url),
+  streamable: (url) => MATCH_URL_STREAMABLE.test(url),
+  wistia: (url) => MATCH_URL_WISTIA.test(url),
+  twitch: (url) => MATCH_URL_TWITCH_VIDEO.test(url) || MATCH_URL_TWITCH_CHANNEL.test(url),
+  dailymotion: (url) => MATCH_URL_DAILYMOTION.test(url),
+  mixcloud: (url) => MATCH_URL_MIXCLOUD.test(url),
+  vidyard: (url) => MATCH_URL_VIDYARD.test(url),
+  kaltura: (url) => MATCH_URL_KALTURA.test(url),
+  file: canPlayFile
+};
+
+
+/***/ }),
+
+/***/ "./node_modules/react-player/lib/players/index.js":
+/*!********************************************************!*\
+  !*** ./node_modules/react-player/lib/players/index.js ***!
+  \********************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var players_exports = {};
+__export(players_exports, {
+  default: () => players_default
+});
+module.exports = __toCommonJS(players_exports);
+var import_utils = __webpack_require__(/*! ../utils */ "./node_modules/react-player/lib/utils.js");
+var import_patterns = __webpack_require__(/*! ../patterns */ "./node_modules/react-player/lib/patterns.js");
+var players_default = [
+  {
+    key: "youtube",
+    name: "YouTube",
+    canPlay: import_patterns.canPlay.youtube,
+    lazyPlayer: (0, import_utils.lazy)(() => __webpack_require__.e(/*! import() | reactPlayerYouTube */ "reactPlayerYouTube").then(__webpack_require__.t.bind(__webpack_require__, /*! ./YouTube */ "./node_modules/react-player/lib/players/YouTube.js", 23)))
+  },
+  {
+    key: "soundcloud",
+    name: "SoundCloud",
+    canPlay: import_patterns.canPlay.soundcloud,
+    lazyPlayer: (0, import_utils.lazy)(() => __webpack_require__.e(/*! import() | reactPlayerSoundCloud */ "reactPlayerSoundCloud").then(__webpack_require__.t.bind(__webpack_require__, /*! ./SoundCloud */ "./node_modules/react-player/lib/players/SoundCloud.js", 23)))
+  },
+  {
+    key: "vimeo",
+    name: "Vimeo",
+    canPlay: import_patterns.canPlay.vimeo,
+    lazyPlayer: (0, import_utils.lazy)(() => __webpack_require__.e(/*! import() | reactPlayerVimeo */ "reactPlayerVimeo").then(__webpack_require__.t.bind(__webpack_require__, /*! ./Vimeo */ "./node_modules/react-player/lib/players/Vimeo.js", 23)))
+  },
+  {
+    key: "mux",
+    name: "Mux",
+    canPlay: import_patterns.canPlay.mux,
+    lazyPlayer: (0, import_utils.lazy)(() => __webpack_require__.e(/*! import() | reactPlayerMux */ "reactPlayerMux").then(__webpack_require__.t.bind(__webpack_require__, /*! ./Mux */ "./node_modules/react-player/lib/players/Mux.js", 23)))
+  },
+  {
+    key: "facebook",
+    name: "Facebook",
+    canPlay: import_patterns.canPlay.facebook,
+    lazyPlayer: (0, import_utils.lazy)(() => __webpack_require__.e(/*! import() | reactPlayerFacebook */ "reactPlayerFacebook").then(__webpack_require__.t.bind(__webpack_require__, /*! ./Facebook */ "./node_modules/react-player/lib/players/Facebook.js", 23)))
+  },
+  {
+    key: "streamable",
+    name: "Streamable",
+    canPlay: import_patterns.canPlay.streamable,
+    lazyPlayer: (0, import_utils.lazy)(() => __webpack_require__.e(/*! import() | reactPlayerStreamable */ "reactPlayerStreamable").then(__webpack_require__.t.bind(__webpack_require__, /*! ./Streamable */ "./node_modules/react-player/lib/players/Streamable.js", 23)))
+  },
+  {
+    key: "wistia",
+    name: "Wistia",
+    canPlay: import_patterns.canPlay.wistia,
+    lazyPlayer: (0, import_utils.lazy)(() => __webpack_require__.e(/*! import() | reactPlayerWistia */ "reactPlayerWistia").then(__webpack_require__.t.bind(__webpack_require__, /*! ./Wistia */ "./node_modules/react-player/lib/players/Wistia.js", 23)))
+  },
+  {
+    key: "twitch",
+    name: "Twitch",
+    canPlay: import_patterns.canPlay.twitch,
+    lazyPlayer: (0, import_utils.lazy)(() => __webpack_require__.e(/*! import() | reactPlayerTwitch */ "reactPlayerTwitch").then(__webpack_require__.t.bind(__webpack_require__, /*! ./Twitch */ "./node_modules/react-player/lib/players/Twitch.js", 23)))
+  },
+  {
+    key: "dailymotion",
+    name: "DailyMotion",
+    canPlay: import_patterns.canPlay.dailymotion,
+    lazyPlayer: (0, import_utils.lazy)(() => __webpack_require__.e(/*! import() | reactPlayerDailyMotion */ "reactPlayerDailyMotion").then(__webpack_require__.t.bind(__webpack_require__, /*! ./DailyMotion */ "./node_modules/react-player/lib/players/DailyMotion.js", 23)))
+  },
+  {
+    key: "mixcloud",
+    name: "Mixcloud",
+    canPlay: import_patterns.canPlay.mixcloud,
+    lazyPlayer: (0, import_utils.lazy)(() => __webpack_require__.e(/*! import() | reactPlayerMixcloud */ "reactPlayerMixcloud").then(__webpack_require__.t.bind(__webpack_require__, /*! ./Mixcloud */ "./node_modules/react-player/lib/players/Mixcloud.js", 23)))
+  },
+  {
+    key: "vidyard",
+    name: "Vidyard",
+    canPlay: import_patterns.canPlay.vidyard,
+    lazyPlayer: (0, import_utils.lazy)(() => __webpack_require__.e(/*! import() | reactPlayerVidyard */ "reactPlayerVidyard").then(__webpack_require__.t.bind(__webpack_require__, /*! ./Vidyard */ "./node_modules/react-player/lib/players/Vidyard.js", 23)))
+  },
+  {
+    key: "kaltura",
+    name: "Kaltura",
+    canPlay: import_patterns.canPlay.kaltura,
+    lazyPlayer: (0, import_utils.lazy)(() => __webpack_require__.e(/*! import() | reactPlayerKaltura */ "reactPlayerKaltura").then(__webpack_require__.t.bind(__webpack_require__, /*! ./Kaltura */ "./node_modules/react-player/lib/players/Kaltura.js", 23)))
+  },
+  {
+    key: "file",
+    name: "FilePlayer",
+    canPlay: import_patterns.canPlay.file,
+    canEnablePIP: (url) => {
+      return import_patterns.canPlay.file(url) && (document.pictureInPictureEnabled || (0, import_utils.supportsWebKitPresentationMode)()) && !import_patterns.AUDIO_EXTENSIONS.test(url);
+    },
+    lazyPlayer: (0, import_utils.lazy)(() => __webpack_require__.e(/*! import() | reactPlayerFilePlayer */ "reactPlayerFilePlayer").then(__webpack_require__.t.bind(__webpack_require__, /*! ./FilePlayer */ "./node_modules/react-player/lib/players/FilePlayer.js", 23)))
+  }
+];
+
+
+/***/ }),
+
+/***/ "./node_modules/react-player/lib/props.js":
+/*!************************************************!*\
+  !*** ./node_modules/react-player/lib/props.js ***!
+  \************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var props_exports = {};
+__export(props_exports, {
+  defaultProps: () => defaultProps,
+  propTypes: () => propTypes
+});
+module.exports = __toCommonJS(props_exports);
+var import_prop_types = __toESM(__webpack_require__(/*! prop-types */ "./node_modules/prop-types/index.js"));
+const { string, bool, number, array, oneOfType, shape, object, func, node } = import_prop_types.default;
+const propTypes = {
+  url: oneOfType([string, array, object]),
+  playing: bool,
+  loop: bool,
+  controls: bool,
+  volume: number,
+  muted: bool,
+  playbackRate: number,
+  width: oneOfType([string, number]),
+  height: oneOfType([string, number]),
+  style: object,
+  progressInterval: number,
+  playsinline: bool,
+  pip: bool,
+  stopOnUnmount: bool,
+  light: oneOfType([bool, string, object]),
+  playIcon: node,
+  previewTabIndex: number,
+  previewAriaLabel: string,
+  fallback: node,
+  oEmbedUrl: string,
+  wrapper: oneOfType([
+    string,
+    func,
+    shape({ render: func.isRequired })
+  ]),
+  config: shape({
+    soundcloud: shape({
+      options: object
+    }),
+    youtube: shape({
+      playerVars: object,
+      embedOptions: object,
+      onUnstarted: func
+    }),
+    facebook: shape({
+      appId: string,
+      version: string,
+      playerId: string,
+      attributes: object
+    }),
+    dailymotion: shape({
+      params: object
+    }),
+    vimeo: shape({
+      playerOptions: object,
+      title: string
+    }),
+    mux: shape({
+      attributes: object,
+      version: string
+    }),
+    file: shape({
+      attributes: object,
+      tracks: array,
+      forceVideo: bool,
+      forceAudio: bool,
+      forceHLS: bool,
+      forceSafariHLS: bool,
+      forceDisableHls: bool,
+      forceDASH: bool,
+      forceFLV: bool,
+      hlsOptions: object,
+      hlsVersion: string,
+      dashVersion: string,
+      flvVersion: string
+    }),
+    wistia: shape({
+      options: object,
+      playerId: string,
+      customControls: array
+    }),
+    mixcloud: shape({
+      options: object
+    }),
+    twitch: shape({
+      options: object,
+      playerId: string
+    }),
+    vidyard: shape({
+      options: object
+    })
+  }),
+  onReady: func,
+  onStart: func,
+  onPlay: func,
+  onPause: func,
+  onBuffer: func,
+  onBufferEnd: func,
+  onEnded: func,
+  onError: func,
+  onDuration: func,
+  onSeek: func,
+  onPlaybackRateChange: func,
+  onPlaybackQualityChange: func,
+  onProgress: func,
+  onClickPreview: func,
+  onEnablePIP: func,
+  onDisablePIP: func
+};
+const noop = () => {
+};
+const defaultProps = {
+  playing: false,
+  loop: false,
+  controls: false,
+  volume: null,
+  muted: false,
+  playbackRate: 1,
+  width: "640px",
+  height: "360px",
+  style: {},
+  progressInterval: 1e3,
+  playsinline: false,
+  pip: false,
+  stopOnUnmount: true,
+  light: false,
+  fallback: null,
+  wrapper: "div",
+  previewTabIndex: 0,
+  previewAriaLabel: "",
+  oEmbedUrl: "https://noembed.com/embed?url={url}",
+  config: {
+    soundcloud: {
+      options: {
+        visual: true,
+        // Undocumented, but makes player fill container and look better
+        buying: false,
+        liking: false,
+        download: false,
+        sharing: false,
+        show_comments: false,
+        show_playcount: false
+      }
+    },
+    youtube: {
+      playerVars: {
+        playsinline: 1,
+        showinfo: 0,
+        rel: 0,
+        iv_load_policy: 3,
+        modestbranding: 1
+      },
+      embedOptions: {},
+      onUnstarted: noop
+    },
+    facebook: {
+      appId: "1309697205772819",
+      version: "v3.3",
+      playerId: null,
+      attributes: {}
+    },
+    dailymotion: {
+      params: {
+        api: 1,
+        "endscreen-enable": false
+      }
+    },
+    vimeo: {
+      playerOptions: {
+        autopause: false,
+        byline: false,
+        portrait: false,
+        title: false
+      },
+      title: null
+    },
+    mux: {
+      attributes: {},
+      version: "2"
+    },
+    file: {
+      attributes: {},
+      tracks: [],
+      forceVideo: false,
+      forceAudio: false,
+      forceHLS: false,
+      forceDASH: false,
+      forceFLV: false,
+      hlsOptions: {},
+      hlsVersion: "1.1.4",
+      dashVersion: "3.1.3",
+      flvVersion: "1.5.0",
+      forceDisableHls: false
+    },
+    wistia: {
+      options: {},
+      playerId: null,
+      customControls: null
+    },
+    mixcloud: {
+      options: {
+        hide_cover: 1
+      }
+    },
+    twitch: {
+      options: {},
+      playerId: null
+    },
+    vidyard: {
+      options: {}
+    }
+  },
+  onReady: noop,
+  onStart: noop,
+  onPlay: noop,
+  onPause: noop,
+  onBuffer: noop,
+  onBufferEnd: noop,
+  onEnded: noop,
+  onError: noop,
+  onDuration: noop,
+  onSeek: noop,
+  onPlaybackRateChange: noop,
+  onPlaybackQualityChange: noop,
+  onProgress: noop,
+  onClickPreview: noop,
+  onEnablePIP: noop,
+  onDisablePIP: noop
+};
+
+
+/***/ }),
+
+/***/ "./node_modules/react-player/lib/utils.js":
+/*!************************************************!*\
+  !*** ./node_modules/react-player/lib/utils.js ***!
+  \************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var utils_exports = {};
+__export(utils_exports, {
+  callPlayer: () => callPlayer,
+  getConfig: () => getConfig,
+  getSDK: () => getSDK,
+  isBlobUrl: () => isBlobUrl,
+  isMediaStream: () => isMediaStream,
+  lazy: () => lazy,
+  omit: () => omit,
+  parseEndTime: () => parseEndTime,
+  parseStartTime: () => parseStartTime,
+  queryString: () => queryString,
+  randomString: () => randomString,
+  supportsWebKitPresentationMode: () => supportsWebKitPresentationMode
+});
+module.exports = __toCommonJS(utils_exports);
+var import_react = __toESM(__webpack_require__(/*! react */ "react"));
+var import_load_script = __toESM(__webpack_require__(/*! load-script */ "./node_modules/load-script/index.js"));
+var import_deepmerge = __toESM(__webpack_require__(/*! deepmerge */ "./node_modules/deepmerge/dist/cjs.js"));
+const lazy = (componentImportFn) => import_react.default.lazy(async () => {
+  const obj = await componentImportFn();
+  return typeof obj.default === "function" ? obj : obj.default;
+});
+const MATCH_START_QUERY = /[?&#](?:start|t)=([0-9hms]+)/;
+const MATCH_END_QUERY = /[?&#]end=([0-9hms]+)/;
+const MATCH_START_STAMP = /(\d+)(h|m|s)/g;
+const MATCH_NUMERIC = /^\d+$/;
+function parseTimeParam(url, pattern) {
+  if (url instanceof Array) {
+    return void 0;
+  }
+  const match = url.match(pattern);
+  if (match) {
+    const stamp = match[1];
+    if (stamp.match(MATCH_START_STAMP)) {
+      return parseTimeString(stamp);
+    }
+    if (MATCH_NUMERIC.test(stamp)) {
+      return parseInt(stamp);
+    }
+  }
+  return void 0;
+}
+function parseTimeString(stamp) {
+  let seconds = 0;
+  let array = MATCH_START_STAMP.exec(stamp);
+  while (array !== null) {
+    const [, count, period] = array;
+    if (period === "h")
+      seconds += parseInt(count, 10) * 60 * 60;
+    if (period === "m")
+      seconds += parseInt(count, 10) * 60;
+    if (period === "s")
+      seconds += parseInt(count, 10);
+    array = MATCH_START_STAMP.exec(stamp);
+  }
+  return seconds;
+}
+function parseStartTime(url) {
+  return parseTimeParam(url, MATCH_START_QUERY);
+}
+function parseEndTime(url) {
+  return parseTimeParam(url, MATCH_END_QUERY);
+}
+function randomString() {
+  return Math.random().toString(36).substr(2, 5);
+}
+function queryString(object) {
+  return Object.keys(object).map((key) => `${key}=${object[key]}`).join("&");
+}
+function getGlobal(key) {
+  if (window[key]) {
+    return window[key];
+  }
+  if (window.exports && window.exports[key]) {
+    return window.exports[key];
+  }
+  if (window.module && window.module.exports && window.module.exports[key]) {
+    return window.module.exports[key];
+  }
+  return null;
+}
+const requests = {};
+const getSDK = enableStubOn(function getSDK2(url, sdkGlobal, sdkReady = null, isLoaded = () => true, fetchScript = import_load_script.default) {
+  const existingGlobal = getGlobal(sdkGlobal);
+  if (existingGlobal && isLoaded(existingGlobal)) {
+    return Promise.resolve(existingGlobal);
+  }
+  return new Promise((resolve, reject) => {
+    if (requests[url]) {
+      requests[url].push({ resolve, reject });
+      return;
+    }
+    requests[url] = [{ resolve, reject }];
+    const onLoaded = (sdk) => {
+      requests[url].forEach((request) => request.resolve(sdk));
+    };
+    if (sdkReady) {
+      const previousOnReady = window[sdkReady];
+      window[sdkReady] = function() {
+        if (previousOnReady)
+          previousOnReady();
+        onLoaded(getGlobal(sdkGlobal));
+      };
+    }
+    fetchScript(url, (err) => {
+      if (err) {
+        requests[url].forEach((request) => request.reject(err));
+        requests[url] = null;
+      } else if (!sdkReady) {
+        onLoaded(getGlobal(sdkGlobal));
+      }
+    });
+  });
+});
+function getConfig(props, defaultProps) {
+  return (0, import_deepmerge.default)(defaultProps.config, props.config);
+}
+function omit(object, ...arrays) {
+  const omitKeys = [].concat(...arrays);
+  const output = {};
+  const keys = Object.keys(object);
+  for (const key of keys) {
+    if (omitKeys.indexOf(key) === -1) {
+      output[key] = object[key];
+    }
+  }
+  return output;
+}
+function callPlayer(method, ...args) {
+  if (!this.player || !this.player[method]) {
+    let message = `ReactPlayer: ${this.constructor.displayName} player could not call %c${method}%c \u2013 `;
+    if (!this.player) {
+      message += "The player was not available";
+    } else if (!this.player[method]) {
+      message += "The method was not available";
+    }
+    console.warn(message, "font-weight: bold", "");
+    return null;
+  }
+  return this.player[method](...args);
+}
+function isMediaStream(url) {
+  return typeof window !== "undefined" && typeof window.MediaStream !== "undefined" && url instanceof window.MediaStream;
+}
+function isBlobUrl(url) {
+  return /^blob:/.test(url);
+}
+function supportsWebKitPresentationMode(video = document.createElement("video")) {
+  const notMobile = /iPhone|iPod/.test(navigator.userAgent) === false;
+  return video.webkitSupportsPresentationMode && typeof video.webkitSetPresentationMode === "function" && notMobile;
+}
+function enableStubOn(fn) {
+  if (false) // removed by dead control flow
+{}
+  return fn;
+}
+
+
+/***/ }),
+
+/***/ "./node_modules/react-terminal-ui/build/index.es.js":
+/*!**********************************************************!*\
+  !*** ./node_modules/react-terminal-ui/build/index.es.js ***!
+  \**********************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   ColorMode: () => (/* binding */ o),
+/* harmony export */   TerminalInput: () => (/* binding */ i),
+/* harmony export */   TerminalOutput: () => (/* binding */ l),
+/* harmony export */   "default": () => (/* binding */ d)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+function a(n,e){var t="function"==typeof Symbol&&n[Symbol.iterator];if(!t)return n;var r,a,i=t.call(n),l=[];try{for(;(void 0===e||e-- >0)&&!(r=i.next()).done;)l.push(r.value)}catch(n){a={error:n}}finally{try{r&&!r.done&&(t=i.return)&&t.call(i)}finally{if(a)throw a.error}}return l}"function"==typeof SuppressedError&&SuppressedError;var i=function(e){var t=e.children,r=e.prompt;return react__WEBPACK_IMPORTED_MODULE_0___default().createElement("div",{className:"react-terminal-line react-terminal-input","data-terminal-prompt":r||"$"},t)},l=function(e){var t=e.children;return react__WEBPACK_IMPORTED_MODULE_0___default().createElement("div",{className:"react-terminal-line"},t)};!function(n,e){void 0===e&&(e={});var t=e.insertAt;if(n&&"undefined"!=typeof document){var r=document.head||document.getElementsByTagName("head")[0],a=document.createElement("style");a.type="text/css","top"===t&&r.firstChild?r.insertBefore(a,r.firstChild):r.appendChild(a),a.styleSheet?a.styleSheet.cssText=n:a.appendChild(document.createTextNode(n))}}("/**\n * Modfied version of [termynal.js](https://github.com/ines/termynal/blob/master/termynal.css).\n *\n * @author Ines Montani <ines@ines.io>\n * @version 0.0.1\n * @license MIT\n */\n .react-terminal-wrapper {\n  width: 100%;\n  background: #252a33;\n  color: #eee;\n  font-size: 18px;\n  font-family: 'Fira Mono', Consolas, Menlo, Monaco, 'Courier New', Courier, monospace;\n  border-radius: 4px;\n  padding: 75px 45px 35px;\n  position: relative;\n  -webkit-box-sizing: border-box;\n          box-sizing: border-box;\n }\n\n.react-terminal {\n  overflow: auto;\n  display: flex;\n  flex-direction: column;\n}\n\n.react-terminal-wrapper.react-terminal-light {\n  background: #ddd;\n  color: #1a1e24;\n}\n\n.react-terminal-window-buttons {\n  position: absolute;\n  top: 15px;\n  left: 15px;\n  display: flex;\n  flex-direction: row;\n  gap: 10px;\n}\n\n.react-terminal-window-buttons button {\n  width: 15px;\n  height: 15px;\n  border-radius: 50%;\n  border: 0;\n}\n\n.react-terminal-window-buttons button.clickable {\n  cursor: pointer;\n}\n\n.react-terminal-window-buttons button.red-btn {\n  background: #d9515d;\n}\n\n.react-terminal-window-buttons button.yellow-btn {\n  background: #f4c025;\n}\n\n.react-terminal-window-buttons button.green-btn {\n  background: #3ec930;\n}\n\n.react-terminal-wrapper:after {\n  content: attr(data-terminal-name);\n  position: absolute;\n  color: #a2a2a2;\n  top: 5px;\n  left: 0;\n  width: 100%;\n  text-align: center;\n  pointer-events: none;\n}\n\n.react-terminal-wrapper.react-terminal-light:after {\n  color: #D76D77;\n}\n\n.react-terminal-line {\n  white-space: pre;\n}\n\n.react-terminal-line:before {\n  /* Set up defaults and ensure empty lines are displayed. */\n  content: '';\n  display: inline-block;\n  vertical-align: middle;\n  color: #a2a2a2;\n}\n\n.react-terminal-light .react-terminal-line:before {\n  color: #D76D77;\n}\n\n.react-terminal-input:before {\n  margin-right: 0.75em;\n  content: '$';\n}\n\n.react-terminal-input[data-terminal-prompt]:before {\n  content: attr(data-terminal-prompt);\n}\n\n.react-terminal-wrapper:focus-within .react-terminal-active-input .cursor {\n  position: relative;\n  display: inline-block;\n  width: 0.55em;\n  height: 1em;\n  top: 0.225em;\n  background: #fff;\n  -webkit-animation: blink 1s infinite;\n          animation: blink 1s infinite;\n}\n\n/* Cursor animation */\n\n@-webkit-keyframes blink {\n  50% {\n      opacity: 0;\n  }\n}\n\n@keyframes blink {\n  50% {\n      opacity: 0;\n  }\n}\n\n.terminal-hidden-input {\n    position: fixed;\n    left: -1000px;\n}\n\n/* .react-terminal-progress {\n  display: flex;\n  margin: .5rem 0;\n}\n\n.react-terminal-progress-bar {\n  background-color: #fff;\n  border-radius: .25rem;\n  width: 25%;\n}\n\n.react-terminal-wrapper.react-terminal-light .react-terminal-progress-bar {\n  background-color: #000;\n} */\n");var o,c=function(e){var t=e.redBtnCallback,r=e.yellowBtnCallback,a=e.greenBtnCallback;return react__WEBPACK_IMPORTED_MODULE_0___default().createElement("div",{className:"react-terminal-window-buttons"},react__WEBPACK_IMPORTED_MODULE_0___default().createElement("button",{className:"".concat(r?"clickable":""," red-btn"),disabled:!t,onClick:t}),react__WEBPACK_IMPORTED_MODULE_0___default().createElement("button",{className:"".concat(r?"clickable":""," yellow-btn"),disabled:!r,onClick:r}),react__WEBPACK_IMPORTED_MODULE_0___default().createElement("button",{className:"".concat(a?"clickable":""," green-btn"),disabled:!a,onClick:a}))};!function(n){n[n.Light=0]="Light",n[n.Dark=1]="Dark"}(o||(o={}));var d=function(i){var l=i.name,d=i.prompt,s=i.height,m=void 0===s?"600px":s,u=i.colorMode,p=i.onInput,f=i.children,b=i.startingInputValue,y=void 0===b?"":b,h=i.redBtnCallback,v=i.yellowBtnCallback,w=i.greenBtnCallback,g=i.TopButtonsPanel,k=void 0===g?c:g,x=a((0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(""),2),C=x[0],E=x[1],S=a((0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(0),2),N=S[0],B=S[1],D=(0,react__WEBPACK_IMPORTED_MODULE_0__.useRef)(null);(0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)((function(){E(y.trim())}),[y]),(0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)((function(){var n,e;if(null!=p){var t=[],r=function(n){var e=function(){var e;return null===(e=null==n?void 0:n.querySelector(".terminal-hidden-input"))||void 0===e?void 0:e.focus()};null==n||n.addEventListener("click",e),t.push({terminalEl:n,listener:e})};try{for(var a=function(n){var e="function"==typeof Symbol&&Symbol.iterator,t=e&&n[e],r=0;if(t)return t.call(n);if(n&&"number"==typeof n.length)return{next:function(){return n&&r>=n.length&&(n=void 0),{value:n&&n[r++],done:!n}}};throw new TypeError(e?"Object is not iterable.":"Symbol.iterator is not defined.")}(document.getElementsByClassName("react-terminal-wrapper")),i=a.next();!i.done;i=a.next()){r(i.value)}}catch(e){n={error:e}}finally{try{i&&!i.done&&(e=a.return)&&e.call(a)}finally{if(n)throw n.error}}return function(){t.forEach((function(n){n.terminalEl.removeEventListener("click",n.listener)}))}}}),[p]);var T=["react-terminal-wrapper"];return u===o.Light&&T.push("react-terminal-light"),react__WEBPACK_IMPORTED_MODULE_0___default().createElement("div",{className:T.join(" "),"data-terminal-name":l},react__WEBPACK_IMPORTED_MODULE_0___default().createElement(k,{redBtnCallback:h,yellowBtnCallback:v,greenBtnCallback:w}),react__WEBPACK_IMPORTED_MODULE_0___default().createElement("div",{className:"react-terminal",style:{height:m}},f,"function"==typeof p&&react__WEBPACK_IMPORTED_MODULE_0___default().createElement("div",{className:"react-terminal-line react-terminal-input react-terminal-active-input","data-terminal-prompt":d||"$",key:"terminal-line-prompt"},C,react__WEBPACK_IMPORTED_MODULE_0___default().createElement("span",{className:"cursor",style:{left:"".concat(N+1,"px")}})),react__WEBPACK_IMPORTED_MODULE_0___default().createElement("div",{ref:D})),react__WEBPACK_IMPORTED_MODULE_0___default().createElement("input",{className:"terminal-hidden-input",placeholder:"Terminal Hidden Input",value:C,autoFocus:null!=p,onChange:function(n){E(n.target.value)},onKeyDown:function(n){var e,t,r;if(p)if("Enter"===n.key)p(C),B(0),E(""),setTimeout((function(){var n;return null===(n=null==D?void 0:D.current)||void 0===n?void 0:n.scrollIntoView({behavior:"auto",block:"nearest"})}),500);else if(["ArrowLeft","ArrowRight","ArrowDown","ArrowUp","Delete"].includes(n.key)){var a=n.currentTarget,i="",l=C.length-(a.selectionStart||0);e=l,t=0,r=C.length,l=e>r?r:e<t?t:e,"ArrowLeft"===n.key?(l>C.length-1&&l--,i=C.slice(C.length-1-l)):"ArrowRight"===n.key||"Delete"===n.key?i=C.slice(C.length-l+1):"ArrowUp"===n.key&&(i=C.slice(0));var o=function(n,e){var t=document.createElement("span");t.style.visibility="hidden",t.style.position="absolute",t.style.fontSize=window.getComputedStyle(n).fontSize,t.style.fontFamily=window.getComputedStyle(n).fontFamily,t.innerText=e,document.body.appendChild(t);var r=t.getBoundingClientRect().width;return document.body.removeChild(t),-r}(a,i);B(o)}}}))};
+//# sourceMappingURL=index.es.js.map
+
+
+/***/ }),
+
+/***/ "./node_modules/shallowequal/index.js":
+/*!********************************************!*\
+  !*** ./node_modules/shallowequal/index.js ***!
+  \********************************************/
+/***/ ((module) => {
+
+//
+
+module.exports = function shallowEqual(objA, objB, compare, compareContext) {
+  var ret = compare ? compare.call(compareContext, objA, objB) : void 0;
+
+  if (ret !== void 0) {
+    return !!ret;
+  }
+
+  if (objA === objB) {
+    return true;
+  }
+
+  if (typeof objA !== "object" || !objA || typeof objB !== "object" || !objB) {
+    return false;
+  }
+
+  var keysA = Object.keys(objA);
+  var keysB = Object.keys(objB);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  var bHasOwnProperty = Object.prototype.hasOwnProperty.bind(objB);
+
+  // Test for A's keys different from B.
+  for (var idx = 0; idx < keysA.length; idx++) {
+    var key = keysA[idx];
+
+    if (!bHasOwnProperty(key)) {
+      return false;
+    }
+
+    var valueA = objA[key];
+    var valueB = objB[key];
+
+    ret = compare ? compare.call(compareContext, valueA, valueB, key) : void 0;
+
+    if (ret === false || (ret === void 0 && valueA !== valueB)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/dist/styled-components.browser.esm.js":
+/*!******************************************************************************!*\
+  !*** ./node_modules/styled-components/dist/styled-components.browser.esm.js ***!
+  \******************************************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   ServerStyleSheet: () => (/* binding */ vt),
+/* harmony export */   StyleSheetConsumer: () => (/* binding */ Be),
+/* harmony export */   StyleSheetContext: () => (/* binding */ $e),
+/* harmony export */   StyleSheetManager: () => (/* binding */ Ye),
+/* harmony export */   ThemeConsumer: () => (/* binding */ tt),
+/* harmony export */   ThemeContext: () => (/* binding */ et),
+/* harmony export */   ThemeProvider: () => (/* binding */ ot),
+/* harmony export */   __PRIVATE__: () => (/* binding */ gt),
+/* harmony export */   createGlobalStyle: () => (/* binding */ ft),
+/* harmony export */   css: () => (/* binding */ lt),
+/* harmony export */   "default": () => (/* binding */ dt),
+/* harmony export */   isStyledComponent: () => (/* binding */ se),
+/* harmony export */   keyframes: () => (/* binding */ mt),
+/* harmony export */   styled: () => (/* binding */ dt),
+/* harmony export */   useTheme: () => (/* binding */ nt),
+/* harmony export */   version: () => (/* binding */ v),
+/* harmony export */   withTheme: () => (/* binding */ yt)
+/* harmony export */ });
+/* harmony import */ var tslib__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! tslib */ "./node_modules/styled-components/node_modules/tslib/tslib.es6.mjs");
+/* harmony import */ var _emotion_is_prop_valid__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @emotion/is-prop-valid */ "./node_modules/styled-components/node_modules/@emotion/is-prop-valid/dist/emotion-is-prop-valid.esm.js");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var shallowequal__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! shallowequal */ "./node_modules/shallowequal/index.js");
+/* harmony import */ var shallowequal__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(shallowequal__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var stylis__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! stylis */ "./node_modules/styled-components/node_modules/stylis/src/Enum.js");
+/* harmony import */ var stylis__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! stylis */ "./node_modules/styled-components/node_modules/stylis/src/Parser.js");
+/* harmony import */ var stylis__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! stylis */ "./node_modules/styled-components/node_modules/stylis/src/Serializer.js");
+/* harmony import */ var stylis__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(/*! stylis */ "./node_modules/styled-components/node_modules/stylis/src/Middleware.js");
+/* harmony import */ var _emotion_unitless__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(/*! @emotion/unitless */ "./node_modules/styled-components/node_modules/@emotion/unitless/dist/emotion-unitless.esm.js");
+var f="undefined"!=typeof process&&void 0!==process.env&&(process.env.REACT_APP_SC_ATTR||process.env.SC_ATTR)||"data-styled",m="active",y="data-styled-version",v="6.1.19",g="/*!sc*/\n",S="undefined"!=typeof window&&"undefined"!=typeof document,w=Boolean("boolean"==typeof SC_DISABLE_SPEEDY?SC_DISABLE_SPEEDY:"undefined"!=typeof process&&void 0!==process.env&&void 0!==process.env.REACT_APP_SC_DISABLE_SPEEDY&&""!==process.env.REACT_APP_SC_DISABLE_SPEEDY?"false"!==process.env.REACT_APP_SC_DISABLE_SPEEDY&&process.env.REACT_APP_SC_DISABLE_SPEEDY:"undefined"!=typeof process&&void 0!==process.env&&void 0!==process.env.SC_DISABLE_SPEEDY&&""!==process.env.SC_DISABLE_SPEEDY?"false"!==process.env.SC_DISABLE_SPEEDY&&process.env.SC_DISABLE_SPEEDY:"production"!=="development"),b={},E=/invalid hook call/i,N=new Set,P=function(t,n){if(true){var o=n?' with the id of "'.concat(n,'"'):"",s="The component ".concat(t).concat(o," has been created dynamically.\n")+"You may see this warning because you've called styled inside another component.\nTo resolve this only create new StyledComponents outside of any render method and function component.\nSee https://styled-components.com/docs/basics#define-styled-components-outside-of-the-render-method for more info.\n",i=console.error;try{var a=!0;console.error=function(t){for(var n=[],o=1;o<arguments.length;o++)n[o-1]=arguments[o];E.test(t)?(a=!1,N.delete(s)):i.apply(void 0,(0,tslib__WEBPACK_IMPORTED_MODULE_0__.__spreadArray)([t],n,!1))},(0,react__WEBPACK_IMPORTED_MODULE_2__.useRef)(),a&&!N.has(s)&&(console.warn(s),N.add(s))}catch(e){E.test(e.message)&&N.delete(s)}finally{console.error=i}}},_=Object.freeze([]),C=Object.freeze({});function I(e,t,n){return void 0===n&&(n=C),e.theme!==n.theme&&e.theme||t||n.theme}var A=new Set(["a","abbr","address","area","article","aside","audio","b","base","bdi","bdo","big","blockquote","body","br","button","canvas","caption","cite","code","col","colgroup","data","datalist","dd","del","details","dfn","dialog","div","dl","dt","em","embed","fieldset","figcaption","figure","footer","form","h1","h2","h3","h4","h5","h6","header","hgroup","hr","html","i","iframe","img","input","ins","kbd","keygen","label","legend","li","link","main","map","mark","menu","menuitem","meta","meter","nav","noscript","object","ol","optgroup","option","output","p","param","picture","pre","progress","q","rp","rt","ruby","s","samp","script","section","select","small","source","span","strong","style","sub","summary","sup","table","tbody","td","textarea","tfoot","th","thead","time","tr","track","u","ul","use","var","video","wbr","circle","clipPath","defs","ellipse","foreignObject","g","image","line","linearGradient","marker","mask","path","pattern","polygon","polyline","radialGradient","rect","stop","svg","text","tspan"]),O=/[!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~-]+/g,D=/(^-|-$)/g;function R(e){return e.replace(O,"-").replace(D,"")}var T=/(a)(d)/gi,k=52,j=function(e){return String.fromCharCode(e+(e>25?39:97))};function x(e){var t,n="";for(t=Math.abs(e);t>k;t=t/k|0)n=j(t%k)+n;return(j(t%k)+n).replace(T,"$1-$2")}var V,F=5381,M=function(e,t){for(var n=t.length;n;)e=33*e^t.charCodeAt(--n);return e},z=function(e){return M(F,e)};function $(e){return x(z(e)>>>0)}function B(e){return true&&"string"==typeof e&&e||e.displayName||e.name||"Component"}function L(e){return"string"==typeof e&&( false||e.charAt(0)===e.charAt(0).toLowerCase())}var G="function"==typeof Symbol&&Symbol.for,Y=G?Symbol.for("react.memo"):60115,W=G?Symbol.for("react.forward_ref"):60112,q={childContextTypes:!0,contextType:!0,contextTypes:!0,defaultProps:!0,displayName:!0,getDefaultProps:!0,getDerivedStateFromError:!0,getDerivedStateFromProps:!0,mixins:!0,propTypes:!0,type:!0},H={name:!0,length:!0,prototype:!0,caller:!0,callee:!0,arguments:!0,arity:!0},U={$$typeof:!0,compare:!0,defaultProps:!0,displayName:!0,propTypes:!0,type:!0},J=((V={})[W]={$$typeof:!0,render:!0,defaultProps:!0,displayName:!0,propTypes:!0},V[Y]=U,V);function X(e){return("type"in(t=e)&&t.type.$$typeof)===Y?U:"$$typeof"in e?J[e.$$typeof]:q;// removed by dead control flow
+ var t; }var Z=Object.defineProperty,K=Object.getOwnPropertyNames,Q=Object.getOwnPropertySymbols,ee=Object.getOwnPropertyDescriptor,te=Object.getPrototypeOf,ne=Object.prototype;function oe(e,t,n){if("string"!=typeof t){if(ne){var o=te(t);o&&o!==ne&&oe(e,o,n)}var r=K(t);Q&&(r=r.concat(Q(t)));for(var s=X(e),i=X(t),a=0;a<r.length;++a){var c=r[a];if(!(c in H||n&&n[c]||i&&c in i||s&&c in s)){var l=ee(t,c);try{Z(e,c,l)}catch(e){}}}}return e}function re(e){return"function"==typeof e}function se(e){return"object"==typeof e&&"styledComponentId"in e}function ie(e,t){return e&&t?"".concat(e," ").concat(t):e||t||""}function ae(e,t){if(0===e.length)return"";for(var n=e[0],o=1;o<e.length;o++)n+=t?t+e[o]:e[o];return n}function ce(e){return null!==e&&"object"==typeof e&&e.constructor.name===Object.name&&!("props"in e&&e.$$typeof)}function le(e,t,n){if(void 0===n&&(n=!1),!n&&!ce(e)&&!Array.isArray(e))return t;if(Array.isArray(t))for(var o=0;o<t.length;o++)e[o]=le(e[o],t[o]);else if(ce(t))for(var o in t)e[o]=le(e[o],t[o]);return e}function ue(e,t){Object.defineProperty(e,"toString",{value:t})}var pe= true?{1:"Cannot create styled-component for component: %s.\n\n",2:"Can't collect styles once you've consumed a `ServerStyleSheet`'s styles! `ServerStyleSheet` is a one off instance for each server-side render cycle.\n\n- Are you trying to reuse it across renders?\n- Are you accidentally calling collectStyles twice?\n\n",3:"Streaming SSR is only supported in a Node.js environment; Please do not try to call this method in the browser.\n\n",4:"The `StyleSheetManager` expects a valid target or sheet prop!\n\n- Does this error occur on the client and is your target falsy?\n- Does this error occur on the server and is the sheet falsy?\n\n",5:"The clone method cannot be used on the client!\n\n- Are you running in a client-like environment on the server?\n- Are you trying to run SSR on the client?\n\n",6:"Trying to insert a new style tag, but the given Node is unmounted!\n\n- Are you using a custom target that isn't mounted?\n- Does your document not have a valid head element?\n- Have you accidentally removed a style tag manually?\n\n",7:'ThemeProvider: Please return an object from your "theme" prop function, e.g.\n\n```js\ntheme={() => ({})}\n```\n\n',8:'ThemeProvider: Please make your "theme" prop an object.\n\n',9:"Missing document `<head>`\n\n",10:"Cannot find a StyleSheet instance. Usually this happens if there are multiple copies of styled-components loaded at once. Check out this issue for how to troubleshoot and fix the common cases where this situation can happen: https://github.com/styled-components/styled-components/issues/1941#issuecomment-417862021\n\n",11:"_This error was replaced with a dev-time warning, it will be deleted for v4 final._ [createGlobalStyle] received children which will not be rendered. Please use the component without passing children elements.\n\n",12:"It seems you are interpolating a keyframe declaration (%s) into an untagged string. This was supported in styled-components v3, but is not longer supported in v4 as keyframes are now injected on-demand. Please wrap your string in the css\\`\\` helper which ensures the styles are injected correctly. See https://www.styled-components.com/docs/api#css\n\n",13:"%s is not a styled component and cannot be referred to via component selector. See https://www.styled-components.com/docs/advanced#referring-to-other-components for more details.\n\n",14:'ThemeProvider: "theme" prop is required.\n\n',15:"A stylis plugin has been supplied that is not named. We need a name for each plugin to be able to prevent styling collisions between different stylis configurations within the same app. Before you pass your plugin to `<StyleSheetManager stylisPlugins={[]}>`, please make sure each plugin is uniquely-named, e.g.\n\n```js\nObject.defineProperty(importedPlugin, 'name', { value: 'some-unique-name' });\n```\n\n",16:"Reached the limit of how many styled components may be created at group %s.\nYou may only create up to 1,073,741,824 components. If you're creating components dynamically,\nas for instance in your render method then you may be running into this limitation.\n\n",17:"CSSStyleSheet could not be found on HTMLStyleElement.\nHas styled-components' style tag been unmounted or altered by another script?\n",18:"ThemeProvider: Please make sure your useTheme hook is within a `<ThemeProvider>`"}:0;function de(){for(var e=[],t=0;t<arguments.length;t++)e[t]=arguments[t];for(var n=e[0],o=[],r=1,s=e.length;r<s;r+=1)o.push(e[r]);return o.forEach(function(e){n=n.replace(/%[a-z]/,e)}),n}function he(t){for(var n=[],o=1;o<arguments.length;o++)n[o-1]=arguments[o];return false?0:new Error(de.apply(void 0,(0,tslib__WEBPACK_IMPORTED_MODULE_0__.__spreadArray)([pe[t]],n,!1)).trim())}var fe=function(){function e(e){this.groupSizes=new Uint32Array(512),this.length=512,this.tag=e}return e.prototype.indexOfGroup=function(e){for(var t=0,n=0;n<e;n++)t+=this.groupSizes[n];return t},e.prototype.insertRules=function(e,t){if(e>=this.groupSizes.length){for(var n=this.groupSizes,o=n.length,r=o;e>=r;)if((r<<=1)<0)throw he(16,"".concat(e));this.groupSizes=new Uint32Array(r),this.groupSizes.set(n),this.length=r;for(var s=o;s<r;s++)this.groupSizes[s]=0}for(var i=this.indexOfGroup(e+1),a=(s=0,t.length);s<a;s++)this.tag.insertRule(i,t[s])&&(this.groupSizes[e]++,i++)},e.prototype.clearGroup=function(e){if(e<this.length){var t=this.groupSizes[e],n=this.indexOfGroup(e),o=n+t;this.groupSizes[e]=0;for(var r=n;r<o;r++)this.tag.deleteRule(n)}},e.prototype.getGroup=function(e){var t="";if(e>=this.length||0===this.groupSizes[e])return t;for(var n=this.groupSizes[e],o=this.indexOfGroup(e),r=o+n,s=o;s<r;s++)t+="".concat(this.tag.getRule(s)).concat(g);return t},e}(),me=1<<30,ye=new Map,ve=new Map,ge=1,Se=function(e){if(ye.has(e))return ye.get(e);for(;ve.has(ge);)ge++;var t=ge++;if( true&&((0|t)<0||t>me))throw he(16,"".concat(t));return ye.set(e,t),ve.set(t,e),t},we=function(e,t){ge=t+1,ye.set(e,t),ve.set(t,e)},be="style[".concat(f,"][").concat(y,'="').concat(v,'"]'),Ee=new RegExp("^".concat(f,'\\.g(\\d+)\\[id="([\\w\\d-]+)"\\].*?"([^"]*)')),Ne=function(e,t,n){for(var o,r=n.split(","),s=0,i=r.length;s<i;s++)(o=r[s])&&e.registerName(t,o)},Pe=function(e,t){for(var n,o=(null!==(n=t.textContent)&&void 0!==n?n:"").split(g),r=[],s=0,i=o.length;s<i;s++){var a=o[s].trim();if(a){var c=a.match(Ee);if(c){var l=0|parseInt(c[1],10),u=c[2];0!==l&&(we(u,l),Ne(e,u,c[3]),e.getTag().insertRules(l,r)),r.length=0}else r.push(a)}}},_e=function(e){for(var t=document.querySelectorAll(be),n=0,o=t.length;n<o;n++){var r=t[n];r&&r.getAttribute(f)!==m&&(Pe(e,r),r.parentNode&&r.parentNode.removeChild(r))}};function Ce(){return true?__webpack_require__.nc:0}var Ie=function(e){var t=document.head,n=e||t,o=document.createElement("style"),r=function(e){var t=Array.from(e.querySelectorAll("style[".concat(f,"]")));return t[t.length-1]}(n),s=void 0!==r?r.nextSibling:null;o.setAttribute(f,m),o.setAttribute(y,v);var i=Ce();return i&&o.setAttribute("nonce",i),n.insertBefore(o,s),o},Ae=function(){function e(e){this.element=Ie(e),this.element.appendChild(document.createTextNode("")),this.sheet=function(e){if(e.sheet)return e.sheet;for(var t=document.styleSheets,n=0,o=t.length;n<o;n++){var r=t[n];if(r.ownerNode===e)return r}throw he(17)}(this.element),this.length=0}return e.prototype.insertRule=function(e,t){try{return this.sheet.insertRule(t,e),this.length++,!0}catch(e){return!1}},e.prototype.deleteRule=function(e){this.sheet.deleteRule(e),this.length--},e.prototype.getRule=function(e){var t=this.sheet.cssRules[e];return t&&t.cssText?t.cssText:""},e}(),Oe=function(){function e(e){this.element=Ie(e),this.nodes=this.element.childNodes,this.length=0}return e.prototype.insertRule=function(e,t){if(e<=this.length&&e>=0){var n=document.createTextNode(t);return this.element.insertBefore(n,this.nodes[e]||null),this.length++,!0}return!1},e.prototype.deleteRule=function(e){this.element.removeChild(this.nodes[e]),this.length--},e.prototype.getRule=function(e){return e<this.length?this.nodes[e].textContent:""},e}(),De=function(){function e(e){this.rules=[],this.length=0}return e.prototype.insertRule=function(e,t){return e<=this.length&&(this.rules.splice(e,0,t),this.length++,!0)},e.prototype.deleteRule=function(e){this.rules.splice(e,1),this.length--},e.prototype.getRule=function(e){return e<this.length?this.rules[e]:""},e}(),Re=S,Te={isServer:!S,useCSSOMInjection:!w},ke=function(){function e(e,n,o){void 0===e&&(e=C),void 0===n&&(n={});var r=this;this.options=(0,tslib__WEBPACK_IMPORTED_MODULE_0__.__assign)((0,tslib__WEBPACK_IMPORTED_MODULE_0__.__assign)({},Te),e),this.gs=n,this.names=new Map(o),this.server=!!e.isServer,!this.server&&S&&Re&&(Re=!1,_e(this)),ue(this,function(){return function(e){for(var t=e.getTag(),n=t.length,o="",r=function(n){var r=function(e){return ve.get(e)}(n);if(void 0===r)return"continue";var s=e.names.get(r),i=t.getGroup(n);if(void 0===s||!s.size||0===i.length)return"continue";var a="".concat(f,".g").concat(n,'[id="').concat(r,'"]'),c="";void 0!==s&&s.forEach(function(e){e.length>0&&(c+="".concat(e,","))}),o+="".concat(i).concat(a,'{content:"').concat(c,'"}').concat(g)},s=0;s<n;s++)r(s);return o}(r)})}return e.registerId=function(e){return Se(e)},e.prototype.rehydrate=function(){!this.server&&S&&_e(this)},e.prototype.reconstructWithOptions=function(n,o){return void 0===o&&(o=!0),new e((0,tslib__WEBPACK_IMPORTED_MODULE_0__.__assign)((0,tslib__WEBPACK_IMPORTED_MODULE_0__.__assign)({},this.options),n),this.gs,o&&this.names||void 0)},e.prototype.allocateGSInstance=function(e){return this.gs[e]=(this.gs[e]||0)+1},e.prototype.getTag=function(){return this.tag||(this.tag=(e=function(e){var t=e.useCSSOMInjection,n=e.target;return e.isServer?new De(n):t?new Ae(n):new Oe(n)}(this.options),new fe(e)));// removed by dead control flow
+ var e; },e.prototype.hasNameForId=function(e,t){return this.names.has(e)&&this.names.get(e).has(t)},e.prototype.registerName=function(e,t){if(Se(e),this.names.has(e))this.names.get(e).add(t);else{var n=new Set;n.add(t),this.names.set(e,n)}},e.prototype.insertRules=function(e,t,n){this.registerName(e,t),this.getTag().insertRules(Se(e),n)},e.prototype.clearNames=function(e){this.names.has(e)&&this.names.get(e).clear()},e.prototype.clearRules=function(e){this.getTag().clearGroup(Se(e)),this.clearNames(e)},e.prototype.clearTag=function(){this.tag=void 0},e}(),je=/&/g,xe=/^\s*\/\/.*$/gm;function Ve(e,t){return e.map(function(e){return"rule"===e.type&&(e.value="".concat(t," ").concat(e.value),e.value=e.value.replaceAll(",",",".concat(t," ")),e.props=e.props.map(function(e){return"".concat(t," ").concat(e)})),Array.isArray(e.children)&&"@keyframes"!==e.type&&(e.children=Ve(e.children,t)),e})}function Fe(e){var t,n,o,r=void 0===e?C:e,s=r.options,i=void 0===s?C:s,a=r.plugins,c=void 0===a?_:a,l=function(e,o,r){return r.startsWith(n)&&r.endsWith(n)&&r.replaceAll(n,"").length>0?".".concat(t):e},u=c.slice();u.push(function(e){e.type===stylis__WEBPACK_IMPORTED_MODULE_4__.RULESET&&e.value.includes("&")&&(e.props[0]=e.props[0].replace(je,n).replace(o,l))}),i.prefix&&u.push(stylis__WEBPACK_IMPORTED_MODULE_7__.prefixer),u.push(stylis__WEBPACK_IMPORTED_MODULE_6__.stringify);var p=function(e,r,s,a){void 0===r&&(r=""),void 0===s&&(s=""),void 0===a&&(a="&"),t=a,n=r,o=new RegExp("\\".concat(n,"\\b"),"g");var c=e.replace(xe,""),l=stylis__WEBPACK_IMPORTED_MODULE_5__.compile(s||r?"".concat(s," ").concat(r," { ").concat(c," }"):c);i.namespace&&(l=Ve(l,i.namespace));var p=[];return stylis__WEBPACK_IMPORTED_MODULE_6__.serialize(l,stylis__WEBPACK_IMPORTED_MODULE_7__.middleware(u.concat(stylis__WEBPACK_IMPORTED_MODULE_7__.rulesheet(function(e){return p.push(e)})))),p};return p.hash=c.length?c.reduce(function(e,t){return t.name||he(15),M(e,t.name)},F).toString():"",p}var Me=new ke,ze=Fe(),$e=react__WEBPACK_IMPORTED_MODULE_2___default().createContext({shouldForwardProp:void 0,styleSheet:Me,stylis:ze}),Be=$e.Consumer,Le=react__WEBPACK_IMPORTED_MODULE_2___default().createContext(void 0);function Ge(){return (0,react__WEBPACK_IMPORTED_MODULE_2__.useContext)($e)}function Ye(e){var t=(0,react__WEBPACK_IMPORTED_MODULE_2__.useState)(e.stylisPlugins),n=t[0],r=t[1],c=Ge().styleSheet,l=(0,react__WEBPACK_IMPORTED_MODULE_2__.useMemo)(function(){var t=c;return e.sheet?t=e.sheet:e.target&&(t=t.reconstructWithOptions({target:e.target},!1)),e.disableCSSOMInjection&&(t=t.reconstructWithOptions({useCSSOMInjection:!1})),t},[e.disableCSSOMInjection,e.sheet,e.target,c]),u=(0,react__WEBPACK_IMPORTED_MODULE_2__.useMemo)(function(){return Fe({options:{namespace:e.namespace,prefix:e.enableVendorPrefixes},plugins:n})},[e.enableVendorPrefixes,e.namespace,n]);(0,react__WEBPACK_IMPORTED_MODULE_2__.useEffect)(function(){shallowequal__WEBPACK_IMPORTED_MODULE_3___default()(n,e.stylisPlugins)||r(e.stylisPlugins)},[e.stylisPlugins]);var d=(0,react__WEBPACK_IMPORTED_MODULE_2__.useMemo)(function(){return{shouldForwardProp:e.shouldForwardProp,styleSheet:l,stylis:u}},[e.shouldForwardProp,l,u]);return react__WEBPACK_IMPORTED_MODULE_2___default().createElement($e.Provider,{value:d},react__WEBPACK_IMPORTED_MODULE_2___default().createElement(Le.Provider,{value:u},e.children))}var We=function(){function e(e,t){var n=this;this.inject=function(e,t){void 0===t&&(t=ze);var o=n.name+t.hash;e.hasNameForId(n.id,o)||e.insertRules(n.id,o,t(n.rules,o,"@keyframes"))},this.name=e,this.id="sc-keyframes-".concat(e),this.rules=t,ue(this,function(){throw he(12,String(n.name))})}return e.prototype.getName=function(e){return void 0===e&&(e=ze),this.name+e.hash},e}(),qe=function(e){return e>="A"&&e<="Z"};function He(e){for(var t="",n=0;n<e.length;n++){var o=e[n];if(1===n&&"-"===o&&"-"===e[0])return e;qe(o)?t+="-"+o.toLowerCase():t+=o}return t.startsWith("ms-")?"-"+t:t}var Ue=function(e){return null==e||!1===e||""===e},Je=function(t){var n,o,r=[];for(var s in t){var i=t[s];t.hasOwnProperty(s)&&!Ue(i)&&(Array.isArray(i)&&i.isCss||re(i)?r.push("".concat(He(s),":"),i,";"):ce(i)?r.push.apply(r,(0,tslib__WEBPACK_IMPORTED_MODULE_0__.__spreadArray)((0,tslib__WEBPACK_IMPORTED_MODULE_0__.__spreadArray)(["".concat(s," {")],Je(i),!1),["}"],!1)):r.push("".concat(He(s),": ").concat((n=s,null==(o=i)||"boolean"==typeof o||""===o?"":"number"!=typeof o||0===o||n in _emotion_unitless__WEBPACK_IMPORTED_MODULE_8__["default"]||n.startsWith("--")?String(o).trim():"".concat(o,"px")),";")))}return r};function Xe(e,t,n,o){if(Ue(e))return[];if(se(e))return[".".concat(e.styledComponentId)];if(re(e)){if(!re(s=e)||s.prototype&&s.prototype.isReactComponent||!t)return[e];var r=e(t);return false||"object"!=typeof r||Array.isArray(r)||r instanceof We||ce(r)||null===r||console.error("".concat(B(e)," is not a styled component and cannot be referred to via component selector. See https://www.styled-components.com/docs/advanced#referring-to-other-components for more details.")),Xe(r,t,n,o)}var s;return e instanceof We?n?(e.inject(n,o),[e.getName(o)]):[e]:ce(e)?Je(e):Array.isArray(e)?Array.prototype.concat.apply(_,e.map(function(e){return Xe(e,t,n,o)})):[e.toString()]}function Ze(e){for(var t=0;t<e.length;t+=1){var n=e[t];if(re(n)&&!se(n))return!1}return!0}var Ke=z(v),Qe=function(){function e(e,t,n){this.rules=e,this.staticRulesId="",this.isStatic= false&&0,this.componentId=t,this.baseHash=M(Ke,t),this.baseStyle=n,ke.registerId(t)}return e.prototype.generateAndInjectStyles=function(e,t,n){var o=this.baseStyle?this.baseStyle.generateAndInjectStyles(e,t,n):"";if(this.isStatic&&!n.hash)if(this.staticRulesId&&t.hasNameForId(this.componentId,this.staticRulesId))o=ie(o,this.staticRulesId);else{var r=ae(Xe(this.rules,e,t,n)),s=x(M(this.baseHash,r)>>>0);if(!t.hasNameForId(this.componentId,s)){var i=n(r,".".concat(s),void 0,this.componentId);t.insertRules(this.componentId,s,i)}o=ie(o,s),this.staticRulesId=s}else{for(var a=M(this.baseHash,n.hash),c="",l=0;l<this.rules.length;l++){var u=this.rules[l];if("string"==typeof u)c+=u, true&&(a=M(a,u));else if(u){var p=ae(Xe(u,e,t,n));a=M(a,p+l),c+=p}}if(c){var d=x(a>>>0);t.hasNameForId(this.componentId,d)||t.insertRules(this.componentId,d,n(c,".".concat(d),void 0,this.componentId)),o=ie(o,d)}}return o},e}(),et=react__WEBPACK_IMPORTED_MODULE_2___default().createContext(void 0),tt=et.Consumer;function nt(){var e=(0,react__WEBPACK_IMPORTED_MODULE_2__.useContext)(et);if(!e)throw he(18);return e}function ot(e){var n=react__WEBPACK_IMPORTED_MODULE_2___default().useContext(et),r=(0,react__WEBPACK_IMPORTED_MODULE_2__.useMemo)(function(){return function(e,n){if(!e)throw he(14);if(re(e)){var o=e(n);if( true&&(null===o||Array.isArray(o)||"object"!=typeof o))throw he(7);return o}if(Array.isArray(e)||"object"!=typeof e)throw he(8);return n?(0,tslib__WEBPACK_IMPORTED_MODULE_0__.__assign)((0,tslib__WEBPACK_IMPORTED_MODULE_0__.__assign)({},n),e):e}(e.theme,n)},[e.theme,n]);return e.children?react__WEBPACK_IMPORTED_MODULE_2___default().createElement(et.Provider,{value:r},e.children):null}var rt={},st=new Set;function it(e,r,s){var i=se(e),a=e,c=!L(e),p=r.attrs,d=void 0===p?_:p,h=r.componentId,f=void 0===h?function(e,t){var n="string"!=typeof e?"sc":R(e);rt[n]=(rt[n]||0)+1;var o="".concat(n,"-").concat($(v+n+rt[n]));return t?"".concat(t,"-").concat(o):o}(r.displayName,r.parentComponentId):h,m=r.displayName,y=void 0===m?function(e){return L(e)?"styled.".concat(e):"Styled(".concat(B(e),")")}(e):m,g=r.displayName&&r.componentId?"".concat(R(r.displayName),"-").concat(r.componentId):r.componentId||f,S=i&&a.attrs?a.attrs.concat(d).filter(Boolean):d,w=r.shouldForwardProp;if(i&&a.shouldForwardProp){var b=a.shouldForwardProp;if(r.shouldForwardProp){var E=r.shouldForwardProp;w=function(e,t){return b(e,t)&&E(e,t)}}else w=b}var N=new Qe(s,g,i?a.componentStyle:void 0);function O(e,r){return function(e,r,s){var i=e.attrs,a=e.componentStyle,c=e.defaultProps,p=e.foldedComponentIds,d=e.styledComponentId,h=e.target,f=react__WEBPACK_IMPORTED_MODULE_2___default().useContext(et),m=Ge(),y=e.shouldForwardProp||m.shouldForwardProp; true&&(0,react__WEBPACK_IMPORTED_MODULE_2__.useDebugValue)(d);var v=I(r,f,c)||C,g=function(e,n,o){for(var r,s=(0,tslib__WEBPACK_IMPORTED_MODULE_0__.__assign)((0,tslib__WEBPACK_IMPORTED_MODULE_0__.__assign)({},n),{className:void 0,theme:o}),i=0;i<e.length;i+=1){var a=re(r=e[i])?r(s):r;for(var c in a)s[c]="className"===c?ie(s[c],a[c]):"style"===c?(0,tslib__WEBPACK_IMPORTED_MODULE_0__.__assign)((0,tslib__WEBPACK_IMPORTED_MODULE_0__.__assign)({},s[c]),a[c]):a[c]}return n.className&&(s.className=ie(s.className,n.className)),s}(i,r,v),S=g.as||h,w={};for(var b in g)void 0===g[b]||"$"===b[0]||"as"===b||"theme"===b&&g.theme===v||("forwardedAs"===b?w.as=g.forwardedAs:y&&!y(b,S)||(w[b]=g[b],y||"development"!=="development"||(0,_emotion_is_prop_valid__WEBPACK_IMPORTED_MODULE_1__["default"])(b)||st.has(b)||!A.has(S)||(st.add(b),console.warn('styled-components: it looks like an unknown prop "'.concat(b,'" is being sent through to the DOM, which will likely trigger a React console error. If you would like automatic filtering of unknown props, you can opt-into that behavior via `<StyleSheetManager shouldForwardProp={...}>` (connect an API like `@emotion/is-prop-valid`) or consider using transient props (`$` prefix for automatic filtering.)')))));var E=function(e,t){var n=Ge(),o=e.generateAndInjectStyles(t,n.styleSheet,n.stylis);return true&&(0,react__WEBPACK_IMPORTED_MODULE_2__.useDebugValue)(o),o}(a,g); true&&e.warnTooManyClasses&&e.warnTooManyClasses(E);var N=ie(p,d);return E&&(N+=" "+E),g.className&&(N+=" "+g.className),w[L(S)&&!A.has(S)?"class":"className"]=N,s&&(w.ref=s),(0,react__WEBPACK_IMPORTED_MODULE_2__.createElement)(S,w)}(D,e,r)}O.displayName=y;var D=react__WEBPACK_IMPORTED_MODULE_2___default().forwardRef(O);return D.attrs=S,D.componentStyle=N,D.displayName=y,D.shouldForwardProp=w,D.foldedComponentIds=i?ie(a.foldedComponentIds,a.styledComponentId):"",D.styledComponentId=g,D.target=i?a.target:e,Object.defineProperty(D,"defaultProps",{get:function(){return this._foldedDefaultProps},set:function(e){this._foldedDefaultProps=i?function(e){for(var t=[],n=1;n<arguments.length;n++)t[n-1]=arguments[n];for(var o=0,r=t;o<r.length;o++)le(e,r[o],!0);return e}({},a.defaultProps,e):e}}), true&&(P(y,g),D.warnTooManyClasses=function(e,t){var n={},o=!1;return function(r){if(!o&&(n[r]=!0,Object.keys(n).length>=200)){var s=t?' with the id of "'.concat(t,'"'):"";console.warn("Over ".concat(200," classes were generated for component ").concat(e).concat(s,".\n")+"Consider using the attrs method, together with a style object for frequently changed styles.\nExample:\n  const Component = styled.div.attrs(props => ({\n    style: {\n      background: props.background,\n    },\n  }))`width: 100%;`\n\n  <Component />"),o=!0,n={}}}}(y,g)),ue(D,function(){return".".concat(D.styledComponentId)}),c&&oe(D,e,{attrs:!0,componentStyle:!0,displayName:!0,foldedComponentIds:!0,shouldForwardProp:!0,styledComponentId:!0,target:!0}),D}function at(e,t){for(var n=[e[0]],o=0,r=t.length;o<r;o+=1)n.push(t[o],e[o+1]);return n}var ct=function(e){return Object.assign(e,{isCss:!0})};function lt(t){for(var n=[],o=1;o<arguments.length;o++)n[o-1]=arguments[o];if(re(t)||ce(t))return ct(Xe(at(_,(0,tslib__WEBPACK_IMPORTED_MODULE_0__.__spreadArray)([t],n,!0))));var r=t;return 0===n.length&&1===r.length&&"string"==typeof r[0]?Xe(r):ct(Xe(at(r,n)))}function ut(n,o,r){if(void 0===r&&(r=C),!o)throw he(1,o);var s=function(t){for(var s=[],i=1;i<arguments.length;i++)s[i-1]=arguments[i];return n(o,r,lt.apply(void 0,(0,tslib__WEBPACK_IMPORTED_MODULE_0__.__spreadArray)([t],s,!1)))};return s.attrs=function(e){return ut(n,o,(0,tslib__WEBPACK_IMPORTED_MODULE_0__.__assign)((0,tslib__WEBPACK_IMPORTED_MODULE_0__.__assign)({},r),{attrs:Array.prototype.concat(r.attrs,e).filter(Boolean)}))},s.withConfig=function(e){return ut(n,o,(0,tslib__WEBPACK_IMPORTED_MODULE_0__.__assign)((0,tslib__WEBPACK_IMPORTED_MODULE_0__.__assign)({},r),e))},s}var pt=function(e){return ut(it,e)},dt=pt;A.forEach(function(e){dt[e]=pt(e)});var ht=function(){function e(e,t){this.rules=e,this.componentId=t,this.isStatic=Ze(e),ke.registerId(this.componentId+1)}return e.prototype.createStyles=function(e,t,n,o){var r=o(ae(Xe(this.rules,t,n,o)),""),s=this.componentId+e;n.insertRules(s,s,r)},e.prototype.removeStyles=function(e,t){t.clearRules(this.componentId+e)},e.prototype.renderStyles=function(e,t,n,o){e>2&&ke.registerId(this.componentId+e),this.removeStyles(e,n),this.createStyles(e,t,n,o)},e}();function ft(n){for(var r=[],s=1;s<arguments.length;s++)r[s-1]=arguments[s];var i=lt.apply(void 0,(0,tslib__WEBPACK_IMPORTED_MODULE_0__.__spreadArray)([n],r,!1)),a="sc-global-".concat($(JSON.stringify(i))),c=new ht(i,a); true&&P(a);var l=function(e){var t=Ge(),n=react__WEBPACK_IMPORTED_MODULE_2___default().useContext(et),r=react__WEBPACK_IMPORTED_MODULE_2___default().useRef(t.styleSheet.allocateGSInstance(a)).current;return true&&react__WEBPACK_IMPORTED_MODULE_2___default().Children.count(e.children)&&console.warn("The global style component ".concat(a," was given child JSX. createGlobalStyle does not render children.")), true&&i.some(function(e){return"string"==typeof e&&-1!==e.indexOf("@import")})&&console.warn("Please do not use @import CSS syntax in createGlobalStyle at this time, as the CSSOM APIs we use in production do not handle it well. Instead, we recommend using a library such as react-helmet to inject a typical <link> meta tag to the stylesheet, or simply embedding it manually in your index.html <head> section for a simpler app."),t.styleSheet.server&&u(r,e,t.styleSheet,n,t.stylis),react__WEBPACK_IMPORTED_MODULE_2___default().useLayoutEffect(function(){if(!t.styleSheet.server)return u(r,e,t.styleSheet,n,t.stylis),function(){return c.removeStyles(r,t.styleSheet)}},[r,e,t.styleSheet,n,t.stylis]),null};function u(e,n,o,r,s){if(c.isStatic)c.renderStyles(e,b,o,s);else{var i=(0,tslib__WEBPACK_IMPORTED_MODULE_0__.__assign)((0,tslib__WEBPACK_IMPORTED_MODULE_0__.__assign)({},n),{theme:I(n,r,l.defaultProps)});c.renderStyles(e,i,o,s)}}return react__WEBPACK_IMPORTED_MODULE_2___default().memo(l)}function mt(t){for(var n=[],o=1;o<arguments.length;o++)n[o-1]=arguments[o]; true&&"undefined"!=typeof navigator&&"ReactNative"===navigator.product&&console.warn("`keyframes` cannot be used on ReactNative, only on the web. To do animation in ReactNative please use Animated.");var r=ae(lt.apply(void 0,(0,tslib__WEBPACK_IMPORTED_MODULE_0__.__spreadArray)([t],n,!1))),s=$(r);return new We(s,r)}function yt(e){var n=react__WEBPACK_IMPORTED_MODULE_2___default().forwardRef(function(n,r){var s=I(n,react__WEBPACK_IMPORTED_MODULE_2___default().useContext(et),e.defaultProps);return true&&void 0===s&&console.warn('[withTheme] You are not using a ThemeProvider nor passing a theme prop or a theme in defaultProps in component class "'.concat(B(e),'"')),react__WEBPACK_IMPORTED_MODULE_2___default().createElement(e,(0,tslib__WEBPACK_IMPORTED_MODULE_0__.__assign)({},n,{theme:s,ref:r}))});return n.displayName="WithTheme(".concat(B(e),")"),oe(n,e)}var vt=function(){function e(){var e=this;this._emitSheetCSS=function(){var t=e.instance.toString();if(!t)return"";var n=Ce(),o=ae([n&&'nonce="'.concat(n,'"'),"".concat(f,'="true"'),"".concat(y,'="').concat(v,'"')].filter(Boolean)," ");return"<style ".concat(o,">").concat(t,"</style>")},this.getStyleTags=function(){if(e.sealed)throw he(2);return e._emitSheetCSS()},this.getStyleElement=function(){var n;if(e.sealed)throw he(2);var r=e.instance.toString();if(!r)return[];var s=((n={})[f]="",n[y]=v,n.dangerouslySetInnerHTML={__html:r},n),i=Ce();return i&&(s.nonce=i),[react__WEBPACK_IMPORTED_MODULE_2___default().createElement("style",(0,tslib__WEBPACK_IMPORTED_MODULE_0__.__assign)({},s,{key:"sc-0-0"}))]},this.seal=function(){e.sealed=!0},this.instance=new ke({isServer:!0}),this.sealed=!1}return e.prototype.collectStyles=function(e){if(this.sealed)throw he(2);return react__WEBPACK_IMPORTED_MODULE_2___default().createElement(Ye,{sheet:this.instance},e)},e.prototype.interleaveWithNodeStream=function(e){throw he(3)},e}(),gt={StyleSheet:ke,mainSheet:Me}; true&&"undefined"!=typeof navigator&&"ReactNative"===navigator.product&&console.warn("It looks like you've imported 'styled-components' on React Native.\nPerhaps you're looking to import 'styled-components/native'?\nRead more about this at https://www.styled-components.com/docs/basics#react-native");var St="__sc-".concat(f,"__"); true&&"undefined"!=typeof window&&(window[St]||(window[St]=0),1===window[St]&&console.warn("It looks like there are several instances of 'styled-components' initialized in this application. This may cause dynamic styles to not render properly, errors during the rehydration process, a missing theme prop, and makes your application bigger without good reason.\n\nSee https://s-c.sh/2BAXzed for more info."),window[St]+=1);
+//# sourceMappingURL=styled-components.browser.esm.js.map
+
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/node_modules/@emotion/is-prop-valid/dist/emotion-is-prop-valid.esm.js":
+/*!**************************************************************************************************************!*\
+  !*** ./node_modules/styled-components/node_modules/@emotion/is-prop-valid/dist/emotion-is-prop-valid.esm.js ***!
+  \**************************************************************************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (/* binding */ isPropValid)
+/* harmony export */ });
+/* harmony import */ var _emotion_memoize__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @emotion/memoize */ "./node_modules/styled-components/node_modules/@emotion/memoize/dist/emotion-memoize.esm.js");
+
+
+var reactPropsRegex = /^((children|dangerouslySetInnerHTML|key|ref|autoFocus|defaultValue|defaultChecked|innerHTML|suppressContentEditableWarning|suppressHydrationWarning|valueLink|abbr|accept|acceptCharset|accessKey|action|allow|allowUserMedia|allowPaymentRequest|allowFullScreen|allowTransparency|alt|async|autoComplete|autoPlay|capture|cellPadding|cellSpacing|challenge|charSet|checked|cite|classID|className|cols|colSpan|content|contentEditable|contextMenu|controls|controlsList|coords|crossOrigin|data|dateTime|decoding|default|defer|dir|disabled|disablePictureInPicture|disableRemotePlayback|download|draggable|encType|enterKeyHint|form|formAction|formEncType|formMethod|formNoValidate|formTarget|frameBorder|headers|height|hidden|high|href|hrefLang|htmlFor|httpEquiv|id|inputMode|integrity|is|keyParams|keyType|kind|label|lang|list|loading|loop|low|marginHeight|marginWidth|max|maxLength|media|mediaGroup|method|min|minLength|multiple|muted|name|nonce|noValidate|open|optimum|pattern|placeholder|playsInline|poster|preload|profile|radioGroup|readOnly|referrerPolicy|rel|required|reversed|role|rows|rowSpan|sandbox|scope|scoped|scrolling|seamless|selected|shape|size|sizes|slot|span|spellCheck|src|srcDoc|srcLang|srcSet|start|step|style|summary|tabIndex|target|title|translate|type|useMap|value|width|wmode|wrap|about|datatype|inlist|prefix|property|resource|typeof|vocab|autoCapitalize|autoCorrect|autoSave|color|incremental|fallback|inert|itemProp|itemScope|itemType|itemID|itemRef|on|option|results|security|unselectable|accentHeight|accumulate|additive|alignmentBaseline|allowReorder|alphabetic|amplitude|arabicForm|ascent|attributeName|attributeType|autoReverse|azimuth|baseFrequency|baselineShift|baseProfile|bbox|begin|bias|by|calcMode|capHeight|clip|clipPathUnits|clipPath|clipRule|colorInterpolation|colorInterpolationFilters|colorProfile|colorRendering|contentScriptType|contentStyleType|cursor|cx|cy|d|decelerate|descent|diffuseConstant|direction|display|divisor|dominantBaseline|dur|dx|dy|edgeMode|elevation|enableBackground|end|exponent|externalResourcesRequired|fill|fillOpacity|fillRule|filter|filterRes|filterUnits|floodColor|floodOpacity|focusable|fontFamily|fontSize|fontSizeAdjust|fontStretch|fontStyle|fontVariant|fontWeight|format|from|fr|fx|fy|g1|g2|glyphName|glyphOrientationHorizontal|glyphOrientationVertical|glyphRef|gradientTransform|gradientUnits|hanging|horizAdvX|horizOriginX|ideographic|imageRendering|in|in2|intercept|k|k1|k2|k3|k4|kernelMatrix|kernelUnitLength|kerning|keyPoints|keySplines|keyTimes|lengthAdjust|letterSpacing|lightingColor|limitingConeAngle|local|markerEnd|markerMid|markerStart|markerHeight|markerUnits|markerWidth|mask|maskContentUnits|maskUnits|mathematical|mode|numOctaves|offset|opacity|operator|order|orient|orientation|origin|overflow|overlinePosition|overlineThickness|panose1|paintOrder|pathLength|patternContentUnits|patternTransform|patternUnits|pointerEvents|points|pointsAtX|pointsAtY|pointsAtZ|preserveAlpha|preserveAspectRatio|primitiveUnits|r|radius|refX|refY|renderingIntent|repeatCount|repeatDur|requiredExtensions|requiredFeatures|restart|result|rotate|rx|ry|scale|seed|shapeRendering|slope|spacing|specularConstant|specularExponent|speed|spreadMethod|startOffset|stdDeviation|stemh|stemv|stitchTiles|stopColor|stopOpacity|strikethroughPosition|strikethroughThickness|string|stroke|strokeDasharray|strokeDashoffset|strokeLinecap|strokeLinejoin|strokeMiterlimit|strokeOpacity|strokeWidth|surfaceScale|systemLanguage|tableValues|targetX|targetY|textAnchor|textDecoration|textRendering|textLength|to|transform|u1|u2|underlinePosition|underlineThickness|unicode|unicodeBidi|unicodeRange|unitsPerEm|vAlphabetic|vHanging|vIdeographic|vMathematical|values|vectorEffect|version|vertAdvY|vertOriginX|vertOriginY|viewBox|viewTarget|visibility|widths|wordSpacing|writingMode|x|xHeight|x1|x2|xChannelSelector|xlinkActuate|xlinkArcrole|xlinkHref|xlinkRole|xlinkShow|xlinkTitle|xlinkType|xmlBase|xmlns|xmlnsXlink|xmlLang|xmlSpace|y|y1|y2|yChannelSelector|z|zoomAndPan|for|class|autofocus)|(([Dd][Aa][Tt][Aa]|[Aa][Rr][Ii][Aa]|x)-.*))$/; // https://esbench.com/bench/5bfee68a4cd7e6009ef61d23
+
+var isPropValid = /* #__PURE__ */(0,_emotion_memoize__WEBPACK_IMPORTED_MODULE_0__["default"])(function (prop) {
+  return reactPropsRegex.test(prop) || prop.charCodeAt(0) === 111
+  /* o */
+  && prop.charCodeAt(1) === 110
+  /* n */
+  && prop.charCodeAt(2) < 91;
+}
+/* Z+1 */
+);
+
+
+
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/node_modules/@emotion/memoize/dist/emotion-memoize.esm.js":
+/*!**************************************************************************************************!*\
+  !*** ./node_modules/styled-components/node_modules/@emotion/memoize/dist/emotion-memoize.esm.js ***!
+  \**************************************************************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (/* binding */ memoize)
+/* harmony export */ });
+function memoize(fn) {
+  var cache = Object.create(null);
+  return function (arg) {
+    if (cache[arg] === undefined) cache[arg] = fn(arg);
+    return cache[arg];
+  };
+}
+
+
+
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/node_modules/@emotion/unitless/dist/emotion-unitless.esm.js":
+/*!****************************************************************************************************!*\
+  !*** ./node_modules/styled-components/node_modules/@emotion/unitless/dist/emotion-unitless.esm.js ***!
+  \****************************************************************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (/* binding */ unitlessKeys)
+/* harmony export */ });
+var unitlessKeys = {
+  animationIterationCount: 1,
+  aspectRatio: 1,
+  borderImageOutset: 1,
+  borderImageSlice: 1,
+  borderImageWidth: 1,
+  boxFlex: 1,
+  boxFlexGroup: 1,
+  boxOrdinalGroup: 1,
+  columnCount: 1,
+  columns: 1,
+  flex: 1,
+  flexGrow: 1,
+  flexPositive: 1,
+  flexShrink: 1,
+  flexNegative: 1,
+  flexOrder: 1,
+  gridRow: 1,
+  gridRowEnd: 1,
+  gridRowSpan: 1,
+  gridRowStart: 1,
+  gridColumn: 1,
+  gridColumnEnd: 1,
+  gridColumnSpan: 1,
+  gridColumnStart: 1,
+  msGridRow: 1,
+  msGridRowSpan: 1,
+  msGridColumn: 1,
+  msGridColumnSpan: 1,
+  fontWeight: 1,
+  lineHeight: 1,
+  opacity: 1,
+  order: 1,
+  orphans: 1,
+  tabSize: 1,
+  widows: 1,
+  zIndex: 1,
+  zoom: 1,
+  WebkitLineClamp: 1,
+  // SVG-related properties
+  fillOpacity: 1,
+  floodOpacity: 1,
+  stopOpacity: 1,
+  strokeDasharray: 1,
+  strokeDashoffset: 1,
+  strokeMiterlimit: 1,
+  strokeOpacity: 1,
+  strokeWidth: 1
+};
+
+
+
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/node_modules/stylis/src/Enum.js":
+/*!************************************************************************!*\
+  !*** ./node_modules/styled-components/node_modules/stylis/src/Enum.js ***!
+  \************************************************************************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   CHARSET: () => (/* binding */ CHARSET),
+/* harmony export */   COMMENT: () => (/* binding */ COMMENT),
+/* harmony export */   COUNTER_STYLE: () => (/* binding */ COUNTER_STYLE),
+/* harmony export */   DECLARATION: () => (/* binding */ DECLARATION),
+/* harmony export */   DOCUMENT: () => (/* binding */ DOCUMENT),
+/* harmony export */   FONT_FACE: () => (/* binding */ FONT_FACE),
+/* harmony export */   FONT_FEATURE_VALUES: () => (/* binding */ FONT_FEATURE_VALUES),
+/* harmony export */   IMPORT: () => (/* binding */ IMPORT),
+/* harmony export */   KEYFRAMES: () => (/* binding */ KEYFRAMES),
+/* harmony export */   LAYER: () => (/* binding */ LAYER),
+/* harmony export */   MEDIA: () => (/* binding */ MEDIA),
+/* harmony export */   MOZ: () => (/* binding */ MOZ),
+/* harmony export */   MS: () => (/* binding */ MS),
+/* harmony export */   NAMESPACE: () => (/* binding */ NAMESPACE),
+/* harmony export */   PAGE: () => (/* binding */ PAGE),
+/* harmony export */   RULESET: () => (/* binding */ RULESET),
+/* harmony export */   SCOPE: () => (/* binding */ SCOPE),
+/* harmony export */   SUPPORTS: () => (/* binding */ SUPPORTS),
+/* harmony export */   VIEWPORT: () => (/* binding */ VIEWPORT),
+/* harmony export */   WEBKIT: () => (/* binding */ WEBKIT)
+/* harmony export */ });
+var MS = '-ms-'
+var MOZ = '-moz-'
+var WEBKIT = '-webkit-'
+
+var COMMENT = 'comm'
+var RULESET = 'rule'
+var DECLARATION = 'decl'
+
+var PAGE = '@page'
+var MEDIA = '@media'
+var IMPORT = '@import'
+var CHARSET = '@charset'
+var VIEWPORT = '@viewport'
+var SUPPORTS = '@supports'
+var DOCUMENT = '@document'
+var NAMESPACE = '@namespace'
+var KEYFRAMES = '@keyframes'
+var FONT_FACE = '@font-face'
+var COUNTER_STYLE = '@counter-style'
+var FONT_FEATURE_VALUES = '@font-feature-values'
+var LAYER = '@layer'
+var SCOPE = '@scope'
+
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/node_modules/stylis/src/Middleware.js":
+/*!******************************************************************************!*\
+  !*** ./node_modules/styled-components/node_modules/stylis/src/Middleware.js ***!
+  \******************************************************************************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   middleware: () => (/* binding */ middleware),
+/* harmony export */   namespace: () => (/* binding */ namespace),
+/* harmony export */   prefixer: () => (/* binding */ prefixer),
+/* harmony export */   rulesheet: () => (/* binding */ rulesheet)
+/* harmony export */ });
+/* harmony import */ var _Enum_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./Enum.js */ "./node_modules/styled-components/node_modules/stylis/src/Enum.js");
+/* harmony import */ var _Utility_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./Utility.js */ "./node_modules/styled-components/node_modules/stylis/src/Utility.js");
+/* harmony import */ var _Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./Tokenizer.js */ "./node_modules/styled-components/node_modules/stylis/src/Tokenizer.js");
+/* harmony import */ var _Serializer_js__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./Serializer.js */ "./node_modules/styled-components/node_modules/stylis/src/Serializer.js");
+/* harmony import */ var _Prefixer_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./Prefixer.js */ "./node_modules/styled-components/node_modules/stylis/src/Prefixer.js");
+
+
+
+
+
+
+/**
+ * @param {function[]} collection
+ * @return {function}
+ */
+function middleware (collection) {
+	var length = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.sizeof)(collection)
+
+	return function (element, index, children, callback) {
+		var output = ''
+
+		for (var i = 0; i < length; i++)
+			output += collection[i](element, index, children, callback) || ''
+
+		return output
+	}
+}
+
+/**
+ * @param {function} callback
+ * @return {function}
+ */
+function rulesheet (callback) {
+	return function (element) {
+		if (!element.root)
+			if (element = element.return)
+				callback(element)
+	}
+}
+
+/**
+ * @param {object} element
+ * @param {number} index
+ * @param {object[]} children
+ * @param {function} callback
+ */
+function prefixer (element, index, children, callback) {
+	if (element.length > -1)
+		if (!element.return)
+			switch (element.type) {
+				case _Enum_js__WEBPACK_IMPORTED_MODULE_0__.DECLARATION: element.return = (0,_Prefixer_js__WEBPACK_IMPORTED_MODULE_4__.prefix)(element.value, element.length, children)
+					return
+				case _Enum_js__WEBPACK_IMPORTED_MODULE_0__.KEYFRAMES:
+					return (0,_Serializer_js__WEBPACK_IMPORTED_MODULE_3__.serialize)([(0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.copy)(element, {value: (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(element.value, '@', '@' + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT)})], callback)
+				case _Enum_js__WEBPACK_IMPORTED_MODULE_0__.RULESET:
+					if (element.length)
+						return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.combine)(children = element.props, function (value) {
+							switch ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.match)(value, callback = /(::plac\w+|:read-\w+)/)) {
+								// :read-(only|write)
+								case ':read-only': case ':read-write':
+									(0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.lift)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.copy)(element, {props: [(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, /:(read-\w+)/, ':' + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MOZ + '$1')]}))
+									;(0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.lift)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.copy)(element, {props: [value]}))
+									;(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.assign)(element, {props: (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.filter)(children, callback)})
+									break
+								// :placeholder
+								case '::placeholder':
+									;(0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.lift)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.copy)(element, {props: [(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, /:(plac\w+)/, ':' + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + 'input-$1')]}))
+									;(0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.lift)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.copy)(element, {props: [(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, /:(plac\w+)/, ':' + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MOZ + '$1')]}))
+									;(0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.lift)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.copy)(element, {props: [(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, /:(plac\w+)/, _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + 'input-$1')]}))
+									;(0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.lift)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.copy)(element, {props: [value]}))
+									;(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.assign)(element, {props: (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.filter)(children, callback)})
+									break
+							}
+
+							return ''
+						})
+			}
+}
+
+/**
+ * @param {object} element
+ * @param {number} index
+ * @param {object[]} children
+ */
+function namespace (element) {
+	switch (element.type) {
+		case _Enum_js__WEBPACK_IMPORTED_MODULE_0__.RULESET:
+			element.props = element.props.map(function (value) {
+				return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.combine)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.tokenize)(value), function (value, index, children) {
+					switch ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.charat)(value, 0)) {
+						// \f
+						case 12:
+							return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.substr)(value, 1, (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.strlen)(value))
+						// \0 ( + > ~
+						case 0: case 40: case 43: case 62: case 126:
+							return value
+						// :
+						case 58:
+							if (children[++index] === 'global')
+								children[index] = '', children[++index] = '\f' + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.substr)(children[index], index = 1, -1)
+						// \s
+						case 32:
+							return index === 1 ? '' : value
+						default:
+							switch (index) {
+								case 0: element = value
+									return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.sizeof)(children) > 1 ? '' : value
+								case index = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.sizeof)(children) - 1: case 2:
+									return index === 2 ? value + element + element : value + element
+								default:
+									return value
+							}
+					}
+				})
+			})
+	}
+}
+
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/node_modules/stylis/src/Parser.js":
+/*!**************************************************************************!*\
+  !*** ./node_modules/styled-components/node_modules/stylis/src/Parser.js ***!
+  \**************************************************************************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   comment: () => (/* binding */ comment),
+/* harmony export */   compile: () => (/* binding */ compile),
+/* harmony export */   declaration: () => (/* binding */ declaration),
+/* harmony export */   parse: () => (/* binding */ parse),
+/* harmony export */   ruleset: () => (/* binding */ ruleset)
+/* harmony export */ });
+/* harmony import */ var _Enum_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./Enum.js */ "./node_modules/styled-components/node_modules/stylis/src/Enum.js");
+/* harmony import */ var _Utility_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./Utility.js */ "./node_modules/styled-components/node_modules/stylis/src/Utility.js");
+/* harmony import */ var _Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./Tokenizer.js */ "./node_modules/styled-components/node_modules/stylis/src/Tokenizer.js");
+
+
+
+
+/**
+ * @param {string} value
+ * @return {object[]}
+ */
+function compile (value) {
+	return (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.dealloc)(parse('', null, null, null, [''], value = (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.alloc)(value), 0, [0], value))
+}
+
+/**
+ * @param {string} value
+ * @param {object} root
+ * @param {object?} parent
+ * @param {string[]} rule
+ * @param {string[]} rules
+ * @param {string[]} rulesets
+ * @param {number[]} pseudo
+ * @param {number[]} points
+ * @param {string[]} declarations
+ * @return {object}
+ */
+function parse (value, root, parent, rule, rules, rulesets, pseudo, points, declarations) {
+	var index = 0
+	var offset = 0
+	var length = pseudo
+	var atrule = 0
+	var property = 0
+	var previous = 0
+	var variable = 1
+	var scanning = 1
+	var ampersand = 1
+	var character = 0
+	var type = ''
+	var props = rules
+	var children = rulesets
+	var reference = rule
+	var characters = type
+
+	while (scanning)
+		switch (previous = character, character = (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.next)()) {
+			// (
+			case 40:
+				if (previous != 108 && (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.charat)(characters, length - 1) == 58) {
+					if ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.indexof)(characters += (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.delimit)(character), '&', '&\f'), '&\f', (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.abs)(index ? points[index - 1] : 0)) != -1)
+						ampersand = -1
+					break
+				}
+			// " ' [
+			case 34: case 39: case 91:
+				characters += (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.delimit)(character)
+				break
+			// \t \n \r \s
+			case 9: case 10: case 13: case 32:
+				characters += (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.whitespace)(previous)
+				break
+			// \
+			case 92:
+				characters += (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.escaping)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.caret)() - 1, 7)
+				continue
+			// /
+			case 47:
+				switch ((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.peek)()) {
+					case 42: case 47:
+						;(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.append)(comment((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.commenter)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.next)(), (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.caret)()), root, parent, declarations), declarations)
+						break
+					default:
+						characters += '/'
+				}
+				break
+			// {
+			case 123 * variable:
+				points[index++] = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.strlen)(characters) * ampersand
+			// } ; \0
+			case 125 * variable: case 59: case 0:
+				switch (character) {
+					// \0 }
+					case 0: case 125: scanning = 0
+					// ;
+					case 59 + offset: if (ampersand == -1) characters = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(characters, /\f/g, '')
+						if (property > 0 && ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.strlen)(characters) - length))
+							(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.append)(property > 32 ? declaration(characters + ';', rule, parent, length - 1, declarations) : declaration((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(characters, ' ', '') + ';', rule, parent, length - 2, declarations), declarations)
+						break
+					// @ ;
+					case 59: characters += ';'
+					// { rule/at-rule
+					default:
+						;(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.append)(reference = ruleset(characters, root, parent, index, offset, rules, points, type, props = [], children = [], length, rulesets), rulesets)
+
+						if (character === 123)
+							if (offset === 0)
+								parse(characters, root, reference, reference, props, rulesets, length, points, children)
+							else
+								switch (atrule === 99 && (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.charat)(characters, 3) === 110 ? 100 : atrule) {
+									// d l m s
+									case 100: case 108: case 109: case 115:
+										parse(value, reference, reference, rule && (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.append)(ruleset(value, reference, reference, 0, 0, rules, points, type, rules, props = [], length, children), children), rules, children, length, points, rule ? props : children)
+										break
+									default:
+										parse(characters, reference, reference, reference, [''], children, 0, points, children)
+								}
+				}
+
+				index = offset = property = 0, variable = ampersand = 1, type = characters = '', length = pseudo
+				break
+			// :
+			case 58:
+				length = 1 + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.strlen)(characters), property = previous
+			default:
+				if (variable < 1)
+					if (character == 123)
+						--variable
+					else if (character == 125 && variable++ == 0 && (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.prev)() == 125)
+						continue
+
+				switch (characters += (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.from)(character), character * variable) {
+					// &
+					case 38:
+						ampersand = offset > 0 ? 1 : (characters += '\f', -1)
+						break
+					// ,
+					case 44:
+						points[index++] = ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.strlen)(characters) - 1) * ampersand, ampersand = 1
+						break
+					// @
+					case 64:
+						// -
+						if ((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.peek)() === 45)
+							characters += (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.delimit)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.next)())
+
+						atrule = (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.peek)(), offset = length = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.strlen)(type = characters += (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.identifier)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.caret)())), character++
+						break
+					// -
+					case 45:
+						if (previous === 45 && (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.strlen)(characters) == 2)
+							variable = 0
+				}
+		}
+
+	return rulesets
+}
+
+/**
+ * @param {string} value
+ * @param {object} root
+ * @param {object?} parent
+ * @param {number} index
+ * @param {number} offset
+ * @param {string[]} rules
+ * @param {number[]} points
+ * @param {string} type
+ * @param {string[]} props
+ * @param {string[]} children
+ * @param {number} length
+ * @param {object[]} siblings
+ * @return {object}
+ */
+function ruleset (value, root, parent, index, offset, rules, points, type, props, children, length, siblings) {
+	var post = offset - 1
+	var rule = offset === 0 ? rules : ['']
+	var size = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.sizeof)(rule)
+
+	for (var i = 0, j = 0, k = 0; i < index; ++i)
+		for (var x = 0, y = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.substr)(value, post + 1, post = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.abs)(j = points[i])), z = value; x < size; ++x)
+			if (z = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.trim)(j > 0 ? rule[x] + ' ' + y : (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(y, /&\f/g, rule[x])))
+				props[k++] = z
+
+	return (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.node)(value, root, parent, offset === 0 ? _Enum_js__WEBPACK_IMPORTED_MODULE_0__.RULESET : type, props, children, length, siblings)
+}
+
+/**
+ * @param {number} value
+ * @param {object} root
+ * @param {object?} parent
+ * @param {object[]} siblings
+ * @return {object}
+ */
+function comment (value, root, parent, siblings) {
+	return (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.node)(value, root, parent, _Enum_js__WEBPACK_IMPORTED_MODULE_0__.COMMENT, (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.from)((0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.char)()), (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.substr)(value, 2, -2), 0, siblings)
+}
+
+/**
+ * @param {string} value
+ * @param {object} root
+ * @param {object?} parent
+ * @param {number} length
+ * @param {object[]} siblings
+ * @return {object}
+ */
+function declaration (value, root, parent, length, siblings) {
+	return (0,_Tokenizer_js__WEBPACK_IMPORTED_MODULE_2__.node)(value, root, parent, _Enum_js__WEBPACK_IMPORTED_MODULE_0__.DECLARATION, (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.substr)(value, 0, length), (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.substr)(value, length + 1, -1), length, siblings)
+}
+
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/node_modules/stylis/src/Prefixer.js":
+/*!****************************************************************************!*\
+  !*** ./node_modules/styled-components/node_modules/stylis/src/Prefixer.js ***!
+  \****************************************************************************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   prefix: () => (/* binding */ prefix)
+/* harmony export */ });
+/* harmony import */ var _Enum_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./Enum.js */ "./node_modules/styled-components/node_modules/stylis/src/Enum.js");
+/* harmony import */ var _Utility_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./Utility.js */ "./node_modules/styled-components/node_modules/stylis/src/Utility.js");
+
+
+
+/**
+ * @param {string} value
+ * @param {number} length
+ * @param {object[]} children
+ * @return {string}
+ */
+function prefix (value, length, children) {
+	switch ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.hash)(value, length)) {
+		// color-adjust
+		case 5103:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + 'print-' + value + value
+		// animation, animation-(delay|direction|duration|fill-mode|iteration-count|name|play-state|timing-function)
+		case 5737: case 4201: case 3177: case 3433: case 1641: case 4457: case 2921:
+		// text-decoration, filter, clip-path, backface-visibility, column, box-decoration-break
+		case 5572: case 6356: case 5844: case 3191: case 6645: case 3005:
+		// mask, mask-image, mask-(mode|clip|size), mask-(repeat|origin), mask-position, mask-composite,
+		case 6391: case 5879: case 5623: case 6135: case 4599: case 4855:
+		// background-clip, columns, column-(count|fill|gap|rule|rule-color|rule-style|rule-width|span|width)
+		case 4215: case 6389: case 5109: case 5365: case 5621: case 3829:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + value + value
+		// tab-size
+		case 4789:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MOZ + value + value
+		// appearance, user-select, transform, hyphens, text-size-adjust
+		case 5349: case 4246: case 4810: case 6968: case 2756:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MOZ + value + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + value + value
+		// writing-mode
+		case 5936:
+			switch ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.charat)(value, length + 11)) {
+				// vertical-l(r)
+				case 114:
+					return _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, /[svh]\w+-[tblr]{2}/, 'tb') + value
+				// vertical-r(l)
+				case 108:
+					return _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, /[svh]\w+-[tblr]{2}/, 'tb-rl') + value
+				// horizontal(-)tb
+				case 45:
+					return _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, /[svh]\w+-[tblr]{2}/, 'lr') + value
+				// default: fallthrough to below
+			}
+		// flex, flex-direction, scroll-snap-type, writing-mode
+		case 6828: case 4268: case 2903:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + value + value
+		// order
+		case 6165:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + 'flex-' + value + value
+		// align-items
+		case 5187:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + value + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, /(\w+).+(:[^]+)/, _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + 'box-$1$2' + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + 'flex-$1$2') + value
+		// align-self
+		case 5443:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + 'flex-item-' + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, /flex-|-self/g, '') + (!(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.match)(value, /flex-|baseline/) ? _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + 'grid-row-' + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, /flex-|-self/g, '') : '') + value
+		// align-content
+		case 4675:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + 'flex-line-pack' + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, /align-content|flex-|-self/g, '') + value
+		// flex-shrink
+		case 5548:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, 'shrink', 'negative') + value
+		// flex-basis
+		case 5292:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, 'basis', 'preferred-size') + value
+		// flex-grow
+		case 6060:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + 'box-' + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, '-grow', '') + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + value + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, 'grow', 'positive') + value
+		// transition
+		case 4554:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, /([^-])(transform)/g, '$1' + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + '$2') + value
+		// cursor
+		case 6187:
+			return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, /(zoom-|grab)/, _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + '$1'), /(image-set)/, _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + '$1'), value, '') + value
+		// background, background-image
+		case 5495: case 3959:
+			return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, /(image-set\([^]*)/, _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + '$1' + '$`$1')
+		// justify-content
+		case 4968:
+			return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, /(.+:)(flex-)?(.*)/, _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + 'box-pack:$3' + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + 'flex-pack:$3'), /s.+-b[^;]+/, 'justify') + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + value + value
+		// justify-self
+		case 4200:
+			if (!(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.match)(value, /flex-|baseline/)) return _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + 'grid-column-align' + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.substr)(value, length) + value
+			break
+		// grid-template-(columns|rows)
+		case 2592: case 3360:
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, 'template-', '') + value
+		// grid-(row|column)-start
+		case 4384: case 3616:
+			if (children && children.some(function (element, index) { return length = index, (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.match)(element.props, /grid-\w+-end/) })) {
+				return ~(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.indexof)(value + (children = children[length].value), 'span', 0) ? value : (_Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, '-start', '') + value + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + 'grid-row-span:' + (~(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.indexof)(children, 'span', 0) ? (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.match)(children, /\d+/) : +(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.match)(children, /\d+/) - +(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.match)(value, /\d+/)) + ';')
+			}
+			return _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, '-start', '') + value
+		// grid-(row|column)-end
+		case 4896: case 4128:
+			return (children && children.some(function (element) { return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.match)(element.props, /grid-\w+-start/) })) ? value : _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, '-end', '-span'), 'span ', '') + value
+		// (margin|padding)-inline-(start|end)
+		case 4095: case 3583: case 4068: case 2532:
+			return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, /(.+)-inline(.+)/, _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + '$1$2') + value
+		// (min|max)?(width|height|inline-size|block-size)
+		case 8116: case 7059: case 5753: case 5535:
+		case 5445: case 5701: case 4933: case 4677:
+		case 5533: case 5789: case 5021: case 4765:
+			// stretch, max-content, min-content, fill-available
+			if ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.strlen)(value) - 1 - length > 6)
+				switch ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.charat)(value, length + 1)) {
+					// (m)ax-content, (m)in-content
+					case 109:
+						// -
+						if ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.charat)(value, length + 4) !== 45)
+							break
+					// (f)ill-available, (f)it-content
+					case 102:
+						return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, /(.+:)(.+)-([^]+)/, '$1' + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + '$2-$3' + '$1' + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MOZ + ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.charat)(value, length + 3) == 108 ? '$3' : '$2-$3')) + value
+					// (s)tretch
+					case 115:
+						return ~(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.indexof)(value, 'stretch', 0) ? prefix((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, 'stretch', 'fill-available'), length, children) + value : value
+				}
+			break
+		// grid-(column|row)
+		case 5152: case 5920:
+			return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, /(.+?):(\d+)(\s*\/\s*(span)?\s*(\d+))?(.*)/, function (_, a, b, c, d, e, f) { return (_Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + a + ':' + b + f) + (c ? (_Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + a + '-span:' + (d ? e : +e - +b)) + f : '') + value })
+		// position: sticky
+		case 4949:
+			// stick(y)?
+			if ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.charat)(value, length + 6) === 121)
+				return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, ':', ':' + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT) + value
+			break
+		// display: (flex|inline-flex|grid|inline-grid)
+		case 6444:
+			switch ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.charat)(value, (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.charat)(value, 14) === 45 ? 18 : 11)) {
+				// (inline-)?fle(x)
+				case 120:
+					return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, /(.+:)([^;\s!]+)(;|(\s+)?!.+)?/, '$1' + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + ((0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.charat)(value, 14) === 45 ? 'inline-' : '') + 'box$3' + '$1' + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.WEBKIT + '$2$3' + '$1' + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS + '$2box$3') + value
+				// (inline-)?gri(d)
+				case 100:
+					return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, ':', ':' + _Enum_js__WEBPACK_IMPORTED_MODULE_0__.MS) + value
+			}
+			break
+		// scroll-margin, scroll-margin-(top|right|bottom|left)
+		case 5719: case 2647: case 2135: case 3927: case 2391:
+			return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.replace)(value, 'scroll-', 'scroll-snap-') + value
+	}
+
+	return value
+}
+
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/node_modules/stylis/src/Serializer.js":
+/*!******************************************************************************!*\
+  !*** ./node_modules/styled-components/node_modules/stylis/src/Serializer.js ***!
+  \******************************************************************************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   serialize: () => (/* binding */ serialize),
+/* harmony export */   stringify: () => (/* binding */ stringify)
+/* harmony export */ });
+/* harmony import */ var _Enum_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./Enum.js */ "./node_modules/styled-components/node_modules/stylis/src/Enum.js");
+/* harmony import */ var _Utility_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./Utility.js */ "./node_modules/styled-components/node_modules/stylis/src/Utility.js");
+
+
+
+/**
+ * @param {object[]} children
+ * @param {function} callback
+ * @return {string}
+ */
+function serialize (children, callback) {
+	var output = ''
+
+	for (var i = 0; i < children.length; i++)
+		output += callback(children[i], i, children, callback) || ''
+
+	return output
+}
+
+/**
+ * @param {object} element
+ * @param {number} index
+ * @param {object[]} children
+ * @param {function} callback
+ * @return {string}
+ */
+function stringify (element, index, children, callback) {
+	switch (element.type) {
+		case _Enum_js__WEBPACK_IMPORTED_MODULE_0__.LAYER: if (element.children.length) break
+		case _Enum_js__WEBPACK_IMPORTED_MODULE_0__.IMPORT: case _Enum_js__WEBPACK_IMPORTED_MODULE_0__.DECLARATION: return element.return = element.return || element.value
+		case _Enum_js__WEBPACK_IMPORTED_MODULE_0__.COMMENT: return ''
+		case _Enum_js__WEBPACK_IMPORTED_MODULE_0__.KEYFRAMES: return element.return = element.value + '{' + serialize(element.children, callback) + '}'
+		case _Enum_js__WEBPACK_IMPORTED_MODULE_0__.RULESET: if (!(0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.strlen)(element.value = element.props.join(','))) return ''
+	}
+
+	return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_1__.strlen)(children = serialize(element.children, callback)) ? element.return = element.value + '{' + children + '}' : ''
+}
+
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/node_modules/stylis/src/Tokenizer.js":
+/*!*****************************************************************************!*\
+  !*** ./node_modules/styled-components/node_modules/stylis/src/Tokenizer.js ***!
+  \*****************************************************************************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   alloc: () => (/* binding */ alloc),
+/* harmony export */   caret: () => (/* binding */ caret),
+/* harmony export */   char: () => (/* binding */ char),
+/* harmony export */   character: () => (/* binding */ character),
+/* harmony export */   characters: () => (/* binding */ characters),
+/* harmony export */   column: () => (/* binding */ column),
+/* harmony export */   commenter: () => (/* binding */ commenter),
+/* harmony export */   copy: () => (/* binding */ copy),
+/* harmony export */   dealloc: () => (/* binding */ dealloc),
+/* harmony export */   delimit: () => (/* binding */ delimit),
+/* harmony export */   delimiter: () => (/* binding */ delimiter),
+/* harmony export */   escaping: () => (/* binding */ escaping),
+/* harmony export */   identifier: () => (/* binding */ identifier),
+/* harmony export */   length: () => (/* binding */ length),
+/* harmony export */   lift: () => (/* binding */ lift),
+/* harmony export */   line: () => (/* binding */ line),
+/* harmony export */   next: () => (/* binding */ next),
+/* harmony export */   node: () => (/* binding */ node),
+/* harmony export */   peek: () => (/* binding */ peek),
+/* harmony export */   position: () => (/* binding */ position),
+/* harmony export */   prev: () => (/* binding */ prev),
+/* harmony export */   slice: () => (/* binding */ slice),
+/* harmony export */   token: () => (/* binding */ token),
+/* harmony export */   tokenize: () => (/* binding */ tokenize),
+/* harmony export */   tokenizer: () => (/* binding */ tokenizer),
+/* harmony export */   whitespace: () => (/* binding */ whitespace)
+/* harmony export */ });
+/* harmony import */ var _Utility_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./Utility.js */ "./node_modules/styled-components/node_modules/stylis/src/Utility.js");
+
+
+var line = 1
+var column = 1
+var length = 0
+var position = 0
+var character = 0
+var characters = ''
+
+/**
+ * @param {string} value
+ * @param {object | null} root
+ * @param {object | null} parent
+ * @param {string} type
+ * @param {string[] | string} props
+ * @param {object[] | string} children
+ * @param {object[]} siblings
+ * @param {number} length
+ */
+function node (value, root, parent, type, props, children, length, siblings) {
+	return {value: value, root: root, parent: parent, type: type, props: props, children: children, line: line, column: column, length: length, return: '', siblings: siblings}
+}
+
+/**
+ * @param {object} root
+ * @param {object} props
+ * @return {object}
+ */
+function copy (root, props) {
+	return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.assign)(node('', null, null, '', null, null, 0, root.siblings), root, {length: -root.length}, props)
+}
+
+/**
+ * @param {object} root
+ */
+function lift (root) {
+	while (root.root)
+		root = copy(root.root, {children: [root]})
+
+	;(0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.append)(root, root.siblings)
+}
+
+/**
+ * @return {number}
+ */
+function char () {
+	return character
+}
+
+/**
+ * @return {number}
+ */
+function prev () {
+	character = position > 0 ? (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.charat)(characters, --position) : 0
+
+	if (column--, character === 10)
+		column = 1, line--
+
+	return character
+}
+
+/**
+ * @return {number}
+ */
+function next () {
+	character = position < length ? (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.charat)(characters, position++) : 0
+
+	if (column++, character === 10)
+		column = 1, line++
+
+	return character
+}
+
+/**
+ * @return {number}
+ */
+function peek () {
+	return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.charat)(characters, position)
+}
+
+/**
+ * @return {number}
+ */
+function caret () {
+	return position
+}
+
+/**
+ * @param {number} begin
+ * @param {number} end
+ * @return {string}
+ */
+function slice (begin, end) {
+	return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.substr)(characters, begin, end)
+}
+
+/**
+ * @param {number} type
+ * @return {number}
+ */
+function token (type) {
+	switch (type) {
+		// \0 \t \n \r \s whitespace token
+		case 0: case 9: case 10: case 13: case 32:
+			return 5
+		// ! + , / > @ ~ isolate token
+		case 33: case 43: case 44: case 47: case 62: case 64: case 126:
+		// ; { } breakpoint token
+		case 59: case 123: case 125:
+			return 4
+		// : accompanied token
+		case 58:
+			return 3
+		// " ' ( [ opening delimit token
+		case 34: case 39: case 40: case 91:
+			return 2
+		// ) ] closing delimit token
+		case 41: case 93:
+			return 1
+	}
+
+	return 0
+}
+
+/**
+ * @param {string} value
+ * @return {any[]}
+ */
+function alloc (value) {
+	return line = column = 1, length = (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.strlen)(characters = value), position = 0, []
+}
+
+/**
+ * @param {any} value
+ * @return {any}
+ */
+function dealloc (value) {
+	return characters = '', value
+}
+
+/**
+ * @param {number} type
+ * @return {string}
+ */
+function delimit (type) {
+	return (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.trim)(slice(position - 1, delimiter(type === 91 ? type + 2 : type === 40 ? type + 1 : type)))
+}
+
+/**
+ * @param {string} value
+ * @return {string[]}
+ */
+function tokenize (value) {
+	return dealloc(tokenizer(alloc(value)))
+}
+
+/**
+ * @param {number} type
+ * @return {string}
+ */
+function whitespace (type) {
+	while (character = peek())
+		if (character < 33)
+			next()
+		else
+			break
+
+	return token(type) > 2 || token(character) > 3 ? '' : ' '
+}
+
+/**
+ * @param {string[]} children
+ * @return {string[]}
+ */
+function tokenizer (children) {
+	while (next())
+		switch (token(character)) {
+			case 0: (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.append)(identifier(position - 1), children)
+				break
+			case 2: ;(0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.append)(delimit(character), children)
+				break
+			default: ;(0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.append)((0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.from)(character), children)
+		}
+
+	return children
+}
+
+/**
+ * @param {number} index
+ * @param {number} count
+ * @return {string}
+ */
+function escaping (index, count) {
+	while (--count && next())
+		// not 0-9 A-F a-f
+		if (character < 48 || character > 102 || (character > 57 && character < 65) || (character > 70 && character < 97))
+			break
+
+	return slice(index, caret() + (count < 6 && peek() == 32 && next() == 32))
+}
+
+/**
+ * @param {number} type
+ * @return {number}
+ */
+function delimiter (type) {
+	while (next())
+		switch (character) {
+			// ] ) " '
+			case type:
+				return position
+			// " '
+			case 34: case 39:
+				if (type !== 34 && type !== 39)
+					delimiter(character)
+				break
+			// (
+			case 40:
+				if (type === 41)
+					delimiter(type)
+				break
+			// \
+			case 92:
+				next()
+				break
+		}
+
+	return position
+}
+
+/**
+ * @param {number} type
+ * @param {number} index
+ * @return {number}
+ */
+function commenter (type, index) {
+	while (next())
+		// //
+		if (type + character === 47 + 10)
+			break
+		// /*
+		else if (type + character === 42 + 42 && peek() === 47)
+			break
+
+	return '/*' + slice(index, position - 1) + '*' + (0,_Utility_js__WEBPACK_IMPORTED_MODULE_0__.from)(type === 47 ? type : next())
+}
+
+/**
+ * @param {number} index
+ * @return {string}
+ */
+function identifier (index) {
+	while (!token(peek()))
+		next()
+
+	return slice(index, position)
+}
+
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/node_modules/stylis/src/Utility.js":
+/*!***************************************************************************!*\
+  !*** ./node_modules/styled-components/node_modules/stylis/src/Utility.js ***!
+  \***************************************************************************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   abs: () => (/* binding */ abs),
+/* harmony export */   append: () => (/* binding */ append),
+/* harmony export */   assign: () => (/* binding */ assign),
+/* harmony export */   charat: () => (/* binding */ charat),
+/* harmony export */   combine: () => (/* binding */ combine),
+/* harmony export */   filter: () => (/* binding */ filter),
+/* harmony export */   from: () => (/* binding */ from),
+/* harmony export */   hash: () => (/* binding */ hash),
+/* harmony export */   indexof: () => (/* binding */ indexof),
+/* harmony export */   match: () => (/* binding */ match),
+/* harmony export */   replace: () => (/* binding */ replace),
+/* harmony export */   sizeof: () => (/* binding */ sizeof),
+/* harmony export */   strlen: () => (/* binding */ strlen),
+/* harmony export */   substr: () => (/* binding */ substr),
+/* harmony export */   trim: () => (/* binding */ trim)
+/* harmony export */ });
+/**
+ * @param {number}
+ * @return {number}
+ */
+var abs = Math.abs
+
+/**
+ * @param {number}
+ * @return {string}
+ */
+var from = String.fromCharCode
+
+/**
+ * @param {object}
+ * @return {object}
+ */
+var assign = Object.assign
+
+/**
+ * @param {string} value
+ * @param {number} length
+ * @return {number}
+ */
+function hash (value, length) {
+	return charat(value, 0) ^ 45 ? (((((((length << 2) ^ charat(value, 0)) << 2) ^ charat(value, 1)) << 2) ^ charat(value, 2)) << 2) ^ charat(value, 3) : 0
+}
+
+/**
+ * @param {string} value
+ * @return {string}
+ */
+function trim (value) {
+	return value.trim()
+}
+
+/**
+ * @param {string} value
+ * @param {RegExp} pattern
+ * @return {string?}
+ */
+function match (value, pattern) {
+	return (value = pattern.exec(value)) ? value[0] : value
+}
+
+/**
+ * @param {string} value
+ * @param {(string|RegExp)} pattern
+ * @param {string} replacement
+ * @return {string}
+ */
+function replace (value, pattern, replacement) {
+	return value.replace(pattern, replacement)
+}
+
+/**
+ * @param {string} value
+ * @param {string} search
+ * @param {number} position
+ * @return {number}
+ */
+function indexof (value, search, position) {
+	return value.indexOf(search, position)
+}
+
+/**
+ * @param {string} value
+ * @param {number} index
+ * @return {number}
+ */
+function charat (value, index) {
+	return value.charCodeAt(index) | 0
+}
+
+/**
+ * @param {string} value
+ * @param {number} begin
+ * @param {number} end
+ * @return {string}
+ */
+function substr (value, begin, end) {
+	return value.slice(begin, end)
+}
+
+/**
+ * @param {string} value
+ * @return {number}
+ */
+function strlen (value) {
+	return value.length
+}
+
+/**
+ * @param {any[]} value
+ * @return {number}
+ */
+function sizeof (value) {
+	return value.length
+}
+
+/**
+ * @param {any} value
+ * @param {any[]} array
+ * @return {any}
+ */
+function append (value, array) {
+	return array.push(value), value
+}
+
+/**
+ * @param {string[]} array
+ * @param {function} callback
+ * @return {string}
+ */
+function combine (array, callback) {
+	return array.map(callback).join('')
+}
+
+/**
+ * @param {string[]} array
+ * @param {RegExp} pattern
+ * @return {string[]}
+ */
+function filter (array, pattern) {
+	return array.filter(function (value) { return !match(value, pattern) })
+}
+
+
+/***/ }),
+
+/***/ "./node_modules/styled-components/node_modules/tslib/tslib.es6.mjs":
+/*!*************************************************************************!*\
+  !*** ./node_modules/styled-components/node_modules/tslib/tslib.es6.mjs ***!
+  \*************************************************************************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   __addDisposableResource: () => (/* binding */ __addDisposableResource),
+/* harmony export */   __assign: () => (/* binding */ __assign),
+/* harmony export */   __asyncDelegator: () => (/* binding */ __asyncDelegator),
+/* harmony export */   __asyncGenerator: () => (/* binding */ __asyncGenerator),
+/* harmony export */   __asyncValues: () => (/* binding */ __asyncValues),
+/* harmony export */   __await: () => (/* binding */ __await),
+/* harmony export */   __awaiter: () => (/* binding */ __awaiter),
+/* harmony export */   __classPrivateFieldGet: () => (/* binding */ __classPrivateFieldGet),
+/* harmony export */   __classPrivateFieldIn: () => (/* binding */ __classPrivateFieldIn),
+/* harmony export */   __classPrivateFieldSet: () => (/* binding */ __classPrivateFieldSet),
+/* harmony export */   __createBinding: () => (/* binding */ __createBinding),
+/* harmony export */   __decorate: () => (/* binding */ __decorate),
+/* harmony export */   __disposeResources: () => (/* binding */ __disposeResources),
+/* harmony export */   __esDecorate: () => (/* binding */ __esDecorate),
+/* harmony export */   __exportStar: () => (/* binding */ __exportStar),
+/* harmony export */   __extends: () => (/* binding */ __extends),
+/* harmony export */   __generator: () => (/* binding */ __generator),
+/* harmony export */   __importDefault: () => (/* binding */ __importDefault),
+/* harmony export */   __importStar: () => (/* binding */ __importStar),
+/* harmony export */   __makeTemplateObject: () => (/* binding */ __makeTemplateObject),
+/* harmony export */   __metadata: () => (/* binding */ __metadata),
+/* harmony export */   __param: () => (/* binding */ __param),
+/* harmony export */   __propKey: () => (/* binding */ __propKey),
+/* harmony export */   __read: () => (/* binding */ __read),
+/* harmony export */   __rest: () => (/* binding */ __rest),
+/* harmony export */   __runInitializers: () => (/* binding */ __runInitializers),
+/* harmony export */   __setFunctionName: () => (/* binding */ __setFunctionName),
+/* harmony export */   __spread: () => (/* binding */ __spread),
+/* harmony export */   __spreadArray: () => (/* binding */ __spreadArray),
+/* harmony export */   __spreadArrays: () => (/* binding */ __spreadArrays),
+/* harmony export */   __values: () => (/* binding */ __values),
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/******************************************************************************
+Copyright (c) Microsoft Corporation.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+***************************************************************************** */
+/* global Reflect, Promise, SuppressedError, Symbol */
+
+var extendStatics = function(d, b) {
+  extendStatics = Object.setPrototypeOf ||
+      ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+      function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+  return extendStatics(d, b);
+};
+
+function __extends(d, b) {
+  if (typeof b !== "function" && b !== null)
+      throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+  extendStatics(d, b);
+  function __() { this.constructor = d; }
+  d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+}
+
+var __assign = function() {
+  __assign = Object.assign || function __assign(t) {
+      for (var s, i = 1, n = arguments.length; i < n; i++) {
+          s = arguments[i];
+          for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+      }
+      return t;
+  }
+  return __assign.apply(this, arguments);
+}
+
+function __rest(s, e) {
+  var t = {};
+  for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+      t[p] = s[p];
+  if (s != null && typeof Object.getOwnPropertySymbols === "function")
+      for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+          if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+              t[p[i]] = s[p[i]];
+      }
+  return t;
+}
+
+function __decorate(decorators, target, key, desc) {
+  var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+  if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+  else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+  return c > 3 && r && Object.defineProperty(target, key, r), r;
+}
+
+function __param(paramIndex, decorator) {
+  return function (target, key) { decorator(target, key, paramIndex); }
+}
+
+function __esDecorate(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+      var context = {};
+      for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+      for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+      context.addInitializer = function (f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+      var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+      if (kind === "accessor") {
+          if (result === void 0) continue;
+          if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+          if (_ = accept(result.get)) descriptor.get = _;
+          if (_ = accept(result.set)) descriptor.set = _;
+          if (_ = accept(result.init)) initializers.unshift(_);
+      }
+      else if (_ = accept(result)) {
+          if (kind === "field") initializers.unshift(_);
+          else descriptor[key] = _;
+      }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+
+function __runInitializers(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+      value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+
+function __propKey(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+
+function __setFunctionName(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+
+function __metadata(metadataKey, metadataValue) {
+  if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(metadataKey, metadataValue);
+}
+
+function __awaiter(thisArg, _arguments, P, generator) {
+  function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+  return new (P || (P = Promise))(function (resolve, reject) {
+      function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+      function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+      function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+  });
+}
+
+function __generator(thisArg, body) {
+  var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+  return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+  function verb(n) { return function (v) { return step([n, v]); }; }
+  function step(op) {
+      if (f) throw new TypeError("Generator is already executing.");
+      while (g && (g = 0, op[0] && (_ = 0)), _) try {
+          if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+          if (y = 0, t) op = [op[0] & 2, t.value];
+          switch (op[0]) {
+              case 0: case 1: t = op; break;
+              case 4: _.label++; return { value: op[1], done: false };
+              case 5: _.label++; y = op[1]; op = [0]; continue;
+              case 7: op = _.ops.pop(); _.trys.pop(); continue;
+              default:
+                  if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                  if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                  if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                  if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                  if (t[2]) _.ops.pop();
+                  _.trys.pop(); continue;
+          }
+          op = body.call(thisArg, _);
+      } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+      if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+  }
+}
+
+var __createBinding = Object.create ? (function(o, m, k, k2) {
+  if (k2 === undefined) k2 = k;
+  var desc = Object.getOwnPropertyDescriptor(m, k);
+  if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+  }
+  Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+  if (k2 === undefined) k2 = k;
+  o[k2] = m[k];
+});
+
+function __exportStar(m, o) {
+  for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(o, p)) __createBinding(o, m, p);
+}
+
+function __values(o) {
+  var s = typeof Symbol === "function" && Symbol.iterator, m = s && o[s], i = 0;
+  if (m) return m.call(o);
+  if (o && typeof o.length === "number") return {
+      next: function () {
+          if (o && i >= o.length) o = void 0;
+          return { value: o && o[i++], done: !o };
+      }
+  };
+  throw new TypeError(s ? "Object is not iterable." : "Symbol.iterator is not defined.");
+}
+
+function __read(o, n) {
+  var m = typeof Symbol === "function" && o[Symbol.iterator];
+  if (!m) return o;
+  var i = m.call(o), r, ar = [], e;
+  try {
+      while ((n === void 0 || n-- > 0) && !(r = i.next()).done) ar.push(r.value);
+  }
+  catch (error) { e = { error: error }; }
+  finally {
+      try {
+          if (r && !r.done && (m = i["return"])) m.call(i);
+      }
+      finally { if (e) throw e.error; }
+  }
+  return ar;
+}
+
+/** @deprecated */
+function __spread() {
+  for (var ar = [], i = 0; i < arguments.length; i++)
+      ar = ar.concat(__read(arguments[i]));
+  return ar;
+}
+
+/** @deprecated */
+function __spreadArrays() {
+  for (var s = 0, i = 0, il = arguments.length; i < il; i++) s += arguments[i].length;
+  for (var r = Array(s), k = 0, i = 0; i < il; i++)
+      for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
+          r[k] = a[j];
+  return r;
+}
+
+function __spreadArray(to, from, pack) {
+  if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+      if (ar || !(i in from)) {
+          if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+          ar[i] = from[i];
+      }
+  }
+  return to.concat(ar || Array.prototype.slice.call(from));
+}
+
+function __await(v) {
+  return this instanceof __await ? (this.v = v, this) : new __await(v);
+}
+
+function __asyncGenerator(thisArg, _arguments, generator) {
+  if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+  var g = generator.apply(thisArg, _arguments || []), i, q = [];
+  return i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i;
+  function verb(n) { if (g[n]) i[n] = function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]) > 1 || resume(n, v); }); }; }
+  function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(q[0][3], e); } }
+  function step(r) { r.value instanceof __await ? Promise.resolve(r.value.v).then(fulfill, reject) : settle(q[0][2], r); }
+  function fulfill(value) { resume("next", value); }
+  function reject(value) { resume("throw", value); }
+  function settle(f, v) { if (f(v), q.shift(), q.length) resume(q[0][0], q[0][1]); }
+}
+
+function __asyncDelegator(o) {
+  var i, p;
+  return i = {}, verb("next"), verb("throw", function (e) { throw e; }), verb("return"), i[Symbol.iterator] = function () { return this; }, i;
+  function verb(n, f) { i[n] = o[n] ? function (v) { return (p = !p) ? { value: __await(o[n](v)), done: false } : f ? f(v) : v; } : f; }
+}
+
+function __asyncValues(o) {
+  if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+  var m = o[Symbol.asyncIterator], i;
+  return m ? m.call(o) : (o = typeof __values === "function" ? __values(o) : o[Symbol.iterator](), i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i);
+  function verb(n) { i[n] = o[n] && function (v) { return new Promise(function (resolve, reject) { v = o[n](v), settle(resolve, reject, v.done, v.value); }); }; }
+  function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
+}
+
+function __makeTemplateObject(cooked, raw) {
+  if (Object.defineProperty) { Object.defineProperty(cooked, "raw", { value: raw }); } else { cooked.raw = raw; }
+  return cooked;
+};
+
+var __setModuleDefault = Object.create ? (function(o, v) {
+  Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+  o["default"] = v;
+};
+
+function __importStar(mod) {
+  if (mod && mod.__esModule) return mod;
+  var result = {};
+  if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+  __setModuleDefault(result, mod);
+  return result;
+}
+
+function __importDefault(mod) {
+  return (mod && mod.__esModule) ? mod : { default: mod };
+}
+
+function __classPrivateFieldGet(receiver, state, kind, f) {
+  if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+  if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+  return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+}
+
+function __classPrivateFieldSet(receiver, state, value, kind, f) {
+  if (kind === "m") throw new TypeError("Private method is not writable");
+  if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+  if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+  return (kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value)), value;
+}
+
+function __classPrivateFieldIn(state, receiver) {
+  if (receiver === null || (typeof receiver !== "object" && typeof receiver !== "function")) throw new TypeError("Cannot use 'in' operator on non-object");
+  return typeof state === "function" ? receiver === state : state.has(receiver);
+}
+
+function __addDisposableResource(env, value, async) {
+  if (value !== null && value !== void 0) {
+    if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
+    var dispose;
+    if (async) {
+        if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+        dispose = value[Symbol.asyncDispose];
+    }
+    if (dispose === void 0) {
+        if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+        dispose = value[Symbol.dispose];
+    }
+    if (typeof dispose !== "function") throw new TypeError("Object not disposable.");
+    env.stack.push({ value: value, dispose: dispose, async: async });
+  }
+  else if (async) {
+    env.stack.push({ async: true });
+  }
+  return value;
+}
+
+var _SuppressedError = typeof SuppressedError === "function" ? SuppressedError : function (error, suppressed, message) {
+  var e = new Error(message);
+  return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
+};
+
+function __disposeResources(env) {
+  function fail(e) {
+    env.error = env.hasError ? new _SuppressedError(e, env.error, "An error was suppressed during disposal.") : e;
+    env.hasError = true;
+  }
+  function next() {
+    while (env.stack.length) {
+      var rec = env.stack.pop();
+      try {
+        var result = rec.dispose && rec.dispose.call(rec.value);
+        if (rec.async) return Promise.resolve(result).then(next, function(e) { fail(e); return next(); });
+      }
+      catch (e) {
+          fail(e);
+      }
+    }
+    if (env.hasError) throw env.error;
+  }
+  return next();
+}
+
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({
+  __extends,
+  __assign,
+  __rest,
+  __decorate,
+  __param,
+  __metadata,
+  __awaiter,
+  __generator,
+  __createBinding,
+  __exportStar,
+  __values,
+  __read,
+  __spread,
+  __spreadArrays,
+  __spreadArray,
+  __await,
+  __asyncGenerator,
+  __asyncDelegator,
+  __asyncValues,
+  __makeTemplateObject,
+  __importStar,
+  __importDefault,
+  __classPrivateFieldGet,
+  __classPrivateFieldSet,
+  __classPrivateFieldIn,
+  __addDisposableResource,
+  __disposeResources,
+});
+
+
+/***/ }),
+
+/***/ "./src/hooks/useInterval.js":
+/*!**********************************!*\
+  !*** ./src/hooks/useInterval.js ***!
+  \**********************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (/* binding */ useInterval)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+
+function useInterval(callback, delay) {
+  const savedCallback = (0,react__WEBPACK_IMPORTED_MODULE_0__.useRef)();
+
+  // Remember the latest callback.
+  (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  // Set up the interval.
+  (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(() => {
+    function tick() {
+      savedCallback.current();
+    }
+    if (delay !== null) {
+      let id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+  }, [delay]);
+}
+
+/***/ }),
+
+/***/ "./src/settings/Settings.js":
+/*!**********************************!*\
+  !*** ./src/settings/Settings.js ***!
+  \**********************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _components_SettingsPage__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./components/SettingsPage */ "./src/settings/components/SettingsPage.jsx");
+/* harmony import */ var _settings_scss__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./settings.scss */ "./src/settings/settings.scss");
+
+
+
+
+function Settings() {
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_1__["default"], null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_SettingsPage__WEBPACK_IMPORTED_MODULE_2__["default"], null)));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (Settings);
+
+/***/ }),
+
+/***/ "./src/settings/components/ActivityLog.jsx":
+/*!*************************************************!*\
+  !*** ./src/settings/components/ActivityLog.jsx ***!
+  \*************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var react_terminal_ui__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! react-terminal-ui */ "./node_modules/react-terminal-ui/build/index.es.js");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_4__);
+/* harmony import */ var _hooks_useInterval__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ../../hooks/useInterval */ "./src/hooks/useInterval.js");
+
+
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function ActivityLog() {
+  const {
+    isRunning,
+    isResumed,
+    isPaused,
+    blogId
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__.SettingsContext);
+  const [terminalLineData, setTerminalLineData] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)([(0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react_terminal_ui__WEBPACK_IMPORTED_MODULE_3__.TerminalOutput, null, "Waiting for new export..")]);
+  function refreshActivityLog() {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_4___default()({
+      path: '/simplystatic/v1/activity-log?blog_id=' + blogId + '&is_network_admin=' + options.is_network,
+      method: 'GET'
+    }).then(resp => {
+      var json = JSON.parse(resp);
+      var terminal = [];
+      for (var message in json.data) {
+        var date = json.data[message].datetime;
+        var text = json.data[message].message;
+        var error = message.includes('pause') || message.includes('cancel');
+        var success = message.includes('resume');
+        terminal.push((0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react_terminal_ui__WEBPACK_IMPORTED_MODULE_3__.TerminalOutput, null, "[", date, "] ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("span", {
+          className: `${error ? 'is-error' : ''} ${success ? 'is-success' : ''}`,
+          dangerouslySetInnerHTML: {
+            __html: text
+          }
+        })));
+      }
+      setTerminalLineData(terminal);
+    });
+  }
+  (0,_hooks_useInterval__WEBPACK_IMPORTED_MODULE_5__["default"])(() => {
+    refreshActivityLog();
+  }, isRunning ? 2500 : null);
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useEffect)(() => {
+    if (isRunning && !isResumed) {
+      setTerminalLineData([(0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react_terminal_ui__WEBPACK_IMPORTED_MODULE_3__.TerminalOutput, null, "Waiting for new export..")]);
+    }
+    if (isRunning && isResumed) {
+      setTerminalLineData([(0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react_terminal_ui__WEBPACK_IMPORTED_MODULE_3__.TerminalOutput, null, "Resuming the export..")]);
+    }
+    refreshActivityLog();
+  }, [isRunning]);
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react_terminal_ui__WEBPACK_IMPORTED_MODULE_3__["default"], {
+    name: __('Activity Log', 'simply-static'),
+    height: "250px",
+    colorMode: react_terminal_ui__WEBPACK_IMPORTED_MODULE_3__.ColorMode.Dark
+  }, terminalLineData);
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (ActivityLog);
+
+/***/ }),
+
+/***/ "./src/settings/components/EnvironmentSidebar.jsx":
+/*!********************************************************!*\
+  !*** ./src/settings/components/EnvironmentSidebar.jsx ***!
+  \********************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (/* binding */ EnvironmentSidebar)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _Environments_EnvironmentForm__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./Environments/EnvironmentForm */ "./src/settings/components/Environments/EnvironmentForm.jsx");
+/* harmony import */ var _Environments_EnvironmentsDropdown__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./Environments/EnvironmentsDropdown */ "./src/settings/components/Environments/EnvironmentsDropdown.jsx");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_5___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_5__);
+
+
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function EnvironmentSidebar({
+  getSettings,
+  isRunning
+}) {
+  const [selectedEnvironment, setSelectedEnvironment] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('');
+  const [selectableEnvironments, setSelectableEnvironments] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)([]);
+  const [showingEnvironmentForm, setShowingEnvironmentForm] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [changingEnvironment, setChangingEnvironment] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useEffect)(() => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_5___default()({
+      path: '/simplystatic/v1/environment',
+      method: 'GET'
+    }).then(resp => {
+      let environments = Object.keys(resp.environments).map(function (version) {
+        return {
+          label: resp.environments[version],
+          value: version
+        };
+      });
+      setSelectableEnvironments(environments);
+      setSelectedEnvironment(resp.current_environment);
+    });
+  }, []);
+  const deleteCurrentVersion = () => {
+    setChangingEnvironment(true);
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_5___default()({
+      path: '/simplystatic/v1/environment',
+      method: 'DELETE',
+      data: {
+        version: selectedEnvironment
+      }
+    }).then(resp => {
+      getSettings();
+      let environments = Object.keys(resp.environments).map(function (version) {
+        return {
+          label: resp.environments[version],
+          value: version
+        };
+      });
+      setSelectableEnvironments(environments);
+      setSelectedEnvironment(resp.current_environment);
+    }).catch(resp => alert(resp.message)).finally(() => {
+      setChangingEnvironment(false);
+    });
+  };
+  const updateCurrentVersion = version => {
+    setChangingEnvironment(true);
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_5___default()({
+      path: '/simplystatic/v1/environment',
+      method: 'PUT',
+      data: {
+        version: version
+      }
+    }).then(() => {
+      getSettings();
+      setSelectedEnvironment(version);
+    }).catch(resp => alert(resp.message)).finally(() => {
+      setChangingEnvironment(false);
+    });
+  };
+  const currentVersion = () => {
+    if (changingEnvironment) {
+      return __('Changing ...', 'simply-static');
+    }
+    return selectableEnvironments.filter(item => {
+      return item.value === selectedEnvironment;
+    }).pop().label;
+  };
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "environment-container"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("h4", {
+    className: "settings-headline"
+  }, " ", __('Environment', 'simply-static')), !showingEnvironmentForm && selectedEnvironment && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, "Current: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("strong", null, currentVersion())), !showingEnvironmentForm && selectableEnvironments.length > 0 && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_Environments_EnvironmentsDropdown__WEBPACK_IMPORTED_MODULE_4__["default"], {
+    onChange: updateCurrentVersion,
+    environments: selectableEnvironments,
+    onDelete: deleteCurrentVersion,
+    current: selectedEnvironment,
+    disabled: isRunning || changingEnvironment
+  }), !showingEnvironmentForm && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    disabled: isRunning || changingEnvironment,
+    variant: "primary",
+    size: "large",
+    onClick: () => setShowingEnvironmentForm(true)
+  }, "Create an Environment"), showingEnvironmentForm && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_Environments_EnvironmentForm__WEBPACK_IMPORTED_MODULE_3__["default"], {
+    onClose: () => setShowingEnvironmentForm(false),
+    setSelectedEnvironment: setSelectedEnvironment,
+    setSelectableEnvironments: setSelectableEnvironments
+  }));
+}
+
+/***/ }),
+
+/***/ "./src/settings/components/Environments/EnvironmentForm.jsx":
+/*!******************************************************************!*\
+  !*** ./src/settings/components/Environments/EnvironmentForm.jsx ***!
+  \******************************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (/* binding */ EnvironmentForm)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3__);
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function EnvironmentForm({
+  onClose,
+  setSelectableEnvironments,
+  setSelectedEnvironment
+}) {
+  const [name, setName] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('');
+  const [creating, setCreating] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const createNew = () => {
+    setCreating(true);
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3___default()({
+      path: '/simplystatic/v1/environment',
+      method: 'POST',
+      data: {
+        title: name
+      }
+    }).then(resp => {
+      let environments = Object.keys(resp.environments).map(function (version) {
+        return {
+          label: resp.environments[version],
+          value: version
+        };
+      });
+      setSelectableEnvironments(environments);
+      setSelectedEnvironment(resp.current_environment);
+      onClose();
+    }).catch(resp => {
+      alert(resp.message);
+    }).finally(() => setCreating(false));
+  };
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: 'ss-environment-form'
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: "Name",
+    onChange: val => setName(val),
+    value: name
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('A new environment will be created with the current configuration.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexBlock, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    variant: 'primary',
+    onClick: createNew,
+    isBusy: creating
+  }, creating ? __('Creating...', 'simply-static') : __('Create', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexBlock, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    variant: 'secondary',
+    onClick: onClose
+  }, __('Cancel', 'simply-static')))));
+}
+
+/***/ }),
+
+/***/ "./src/settings/components/Environments/EnvironmentsDropdown.jsx":
+/*!***********************************************************************!*\
+  !*** ./src/settings/components/Environments/EnvironmentsDropdown.jsx ***!
+  \***********************************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (/* binding */ EnvironmentDropdown)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+
+
+const {
+  __
+} = wp.i18n;
+function EnvironmentDropdown({
+  onChange,
+  current,
+  environments,
+  disabled,
+  onDelete
+}) {
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, {
+    style: {
+      minWidth: "80%"
+    }
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    disabled: disabled,
+    value: current,
+    options: environments,
+    help: __('Choose an environment or create a new one to configure settings.', 'simply-static'),
+    onChange: onChange
+  })), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    className: 'environment-delete-button',
+    variant: 'tertiary',
+    label: __('Delete selected environment', 'simply-static'),
+    showToolTip: true,
+    size: 'small',
+    icon: 'trash',
+    disabled: disabled,
+    onClick: onDelete
+  })));
+}
+
+/***/ }),
+
+/***/ "./src/settings/components/ExportLog.jsx":
+/*!***********************************************!*\
+  !*** ./src/settings/components/ExportLog.jsx ***!
+  \***********************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var _hooks_useInterval__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ../../hooks/useInterval */ "./src/hooks/useInterval.js");
+/* harmony import */ var react_data_table_component__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! react-data-table-component */ "./node_modules/react-data-table-component/dist/index.cjs.js");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_6___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_6__);
+
+
+
+
+
+
+
+function ExportLog() {
+  const {
+    isRunning,
+    blogId,
+    isPro,
+    settings
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_2__.SettingsContext);
+  const [exportLog, setExportLog] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)([]);
+  const [loadingExportLog, setLoadingExportLog] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)(false);
+  const [perPageExportLog, setPerPageExportLog] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)(25);
+  const [exportPage, setExportPage] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)(0);
+  const [filterText, setFilterText] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)('');
+  const [allData, setAllData] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)([]);
+  const [loadingAllData, setLoadingAllData] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)(false);
+  const [totalPages, setTotalPages] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)(0);
+  const [exportType, setExportType] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)('export');
+  const [exportTypeId, setExportTypeId] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)(null);
+
+  // Determine export type based on available information
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useEffect)(() => {
+    // If delivery method is 'zip', always use 'export' type
+    if (settings && settings.delivery_method === 'zip') {
+      setExportType('export');
+      return;
+    }
+
+    // Use the new export-type endpoint to get the export type information
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3___default()({
+      path: '/simplystatic/v1/export-type',
+      method: 'GET'
+    }).then(response => {
+      const json = JSON.parse(response);
+      if (json.status === 200 && json.data) {
+        // If delivery method is 'zip', override with 'export' type
+        if (settings && settings.delivery_method === 'zip') {
+          setExportType('export');
+        } else {
+          setExportType(json.data.export_type);
+          setExportTypeId(json.data.export_type_id);
+        }
+      }
+    }).catch(error => {
+      console.error('Error fetching export type:', error);
+      // Fallback to using options.last_export_end
+      if (settings && settings.delivery_method === 'zip') {
+        setExportType('export');
+      } else if (options.last_export_end) {
+        setExportType('Update');
+      } else {
+        setExportType('export');
+      }
+    });
+  }, [settings]);
+
+  // Define base columns
+  const baseColumns = [{
+    name: 'Code',
+    selector: row => row.code,
+    sortable: true,
+    maxWidth: '100px'
+  }, {
+    name: 'URL',
+    selector: row => {
+      // Display a safe path without throwing on invalid URLs
+      const raw = row && typeof row.url === 'string' ? row.url : '';
+      if (!raw) {
+        return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("span", null, "-");
+      }
+      // Default to the raw value
+      let pathOnly = raw;
+      // If it's a relative path, just show it as-is
+      if (raw.startsWith('/')) {
+        pathOnly = raw;
+      } else {
+        // Try to parse absolute URLs safely
+        try {
+          const parsed = new URL(raw);
+          pathOnly = parsed.pathname + parsed.search + parsed.hash;
+        } catch (e) {
+          // Parsing failed (e.g., protocol-relative or malformed). Keep raw.
+        }
+      }
+      return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("a", {
+        target: '_blank',
+        href: raw
+      }, pathOnly);
+    },
+    sortable: true,
+    sortFunction: (rowA, rowB) => rowA.url.localeCompare(rowB.url)
+  }];
+
+  // Define Export-Type column (only included if Pro is activated)
+  const exportTypeColumn = {
+    name: 'Export-Type',
+    selector: row => {
+      // Display the export type and ID if it's a Build or Single export
+      if (exportType === 'Build' || exportType === 'Single') {
+        return `${exportType} (ID: ${exportTypeId})`;
+      }
+      return exportType;
+    },
+    sortable: true,
+    maxWidth: '200px'
+  };
+
+  // Define Notes column
+  const notesColumn = {
+    name: 'Notes',
+    wrap: true,
+    selector: row => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("span", {
+      dangerouslySetInnerHTML: {
+        __html: row.notes
+      }
+    }),
+    sortable: true,
+    sortFunction: (rowA, rowB) => {
+      // Remove HTML tags for sorting
+      const notesA = rowA.notes.replace(/<[^>]*>/g, '');
+      const notesB = rowB.notes.replace(/<[^>]*>/g, '');
+      return notesA.localeCompare(notesB);
+    }
+  };
+
+  // Combine columns based on whether Pro is activated
+  const columns = isPro() ? [...baseColumns, exportTypeColumn, notesColumn] : [...baseColumns, notesColumn];
+  const handlePageChange = page => {
+    getExportLog(page);
+  };
+  const handlePerRowsChange = (newPerPage, page) => {
+    setPerPageExportLog(newPerPage);
+    getExportLog(page, true);
+  };
+  const handleSearch = async e => {
+    const searchTerm = e.target.value;
+    setFilterText(searchTerm);
+
+    // If search term is not empty and we don't have all data yet, fetch all data
+    // But only if we're not running a Build or Single export
+    if (searchTerm && allData.length === 0 && exportType !== 'Build' && exportType !== 'Single') {
+      await fetchAllData();
+      setLastAllDataFetch(Date.now()); // Update the timestamp after fetching
+    }
+  };
+  function getExportLog(page, force = false) {
+    page = page !== null && page !== void 0 ? page : 1;
+    if (page !== exportPage || force) {
+      setLoadingExportLog(true);
+    }
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3___default()({
+      path: `/simplystatic/v1/export-log?page=${page}&per_page=${perPageExportLog}&blog_id=${blogId}&is_network_admin=${options.is_network}`,
+      method: 'GET'
+    }).then(resp => {
+      var json = JSON.parse(resp);
+      if (page !== exportPage || force) {
+        setExportLog(json.data);
+        setLoadingExportLog(false);
+
+        // Calculate total pages
+        const total = json.data.total_static_pages || 0;
+        const calculatedTotalPages = Math.ceil(total / perPageExportLog);
+        setTotalPages(calculatedTotalPages);
+      } else {
+        exportLog.total_static_pages = json.data.total_static_pages;
+        setExportLog(exportLog);
+      }
+      setExportPage(page);
+    });
+  }
+
+  // Function to fetch all data for search
+  async function fetchAllData() {
+    setLoadingAllData(true);
+    try {
+      // First, get the first page to determine total pages
+      const firstPageResponse = await _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3___default()({
+        path: `/simplystatic/v1/export-log?page=1&per_page=${perPageExportLog}&blog_id=${blogId}&is_network_admin=${options.is_network}`,
+        method: 'GET'
+      });
+      const firstPageJson = JSON.parse(firstPageResponse);
+      const totalItems = firstPageJson.data.total_static_pages || 0;
+      let calculatedTotalPages = Math.ceil(totalItems / perPageExportLog);
+
+      // For very large sites, limit the number of pages we fetch to avoid timeouts
+      const MAX_PAGES_TO_FETCH = 20; // This will fetch up to 500 items with default perPage of 25
+      if (calculatedTotalPages > MAX_PAGES_TO_FETCH) {
+        console.log(`Site has ${calculatedTotalPages} pages of data, limiting to ${MAX_PAGES_TO_FETCH} pages to prevent timeouts`);
+        calculatedTotalPages = MAX_PAGES_TO_FETCH;
+      }
+
+      // Instead of fetching all pages at once, fetch them in batches
+      const BATCH_SIZE = 5; // Process 5 pages at a time
+      let allPages = [];
+
+      // Add the first page data we already fetched
+      if (firstPageJson.data && firstPageJson.data.static_pages) {
+        allPages = [...firstPageJson.data.static_pages];
+      }
+
+      // Process remaining pages in batches
+      for (let batchStart = 2; batchStart <= calculatedTotalPages; batchStart += BATCH_SIZE) {
+        const batchEnd = Math.min(batchStart + BATCH_SIZE - 1, calculatedTotalPages);
+        console.log(`Fetching batch of pages ${batchStart} to ${batchEnd}`);
+
+        // Create batch of promises
+        const batchPromises = [];
+        for (let i = batchStart; i <= batchEnd; i++) {
+          batchPromises.push(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3___default()({
+            path: `/simplystatic/v1/export-log?page=${i}&per_page=${perPageExportLog}&blog_id=${blogId}&is_network_admin=${options.is_network}`,
+            method: 'GET'
+          }));
+        }
+
+        // Execute batch of promises
+        const batchResponses = await Promise.all(batchPromises);
+
+        // Process batch responses
+        batchResponses.forEach(response => {
+          const json = JSON.parse(response);
+          if (json.data && json.data.static_pages) {
+            allPages = [...allPages, ...json.data.static_pages];
+          }
+        });
+      }
+
+      // Update state with the fetched data
+      setAllData(allPages);
+
+      // Log for debugging
+      console.log(`Fetched ${allPages.length} total items from ${calculatedTotalPages} pages (out of ${Math.ceil(totalItems / perPageExportLog)} total pages)`);
+      return allPages;
+    } catch (error) {
+      console.error('Error fetching all data:', error);
+      return [];
+    } finally {
+      setLoadingAllData(false);
+    }
+  }
+
+  // Track the last time we fetched all data
+  const [lastAllDataFetch, setLastAllDataFetch] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)(0);
+  (0,_hooks_useInterval__WEBPACK_IMPORTED_MODULE_4__["default"])(() => {
+    getExportLog();
+
+    // If we have a search term and already have all data, refresh the all data
+    // but limit how often we do this to prevent overloading the server
+    const currentTime = Date.now();
+    const ALL_DATA_REFRESH_INTERVAL = 30000; // 30 seconds between full refreshes
+
+    if (filterText && allData.length > 0 && currentTime - lastAllDataFetch > ALL_DATA_REFRESH_INTERVAL) {
+      console.log('Refreshing all data for search (30-second interval)');
+      fetchAllData();
+      setLastAllDataFetch(currentTime);
+    }
+  }, isRunning ? 5000 : null);
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useEffect)(() => {
+    getExportLog(1, true);
+
+    // Fetch the export type when isRunning changes
+    if (isRunning) {
+      _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_3___default()({
+        path: '/simplystatic/v1/export-type',
+        method: 'GET'
+      }).then(response => {
+        const json = JSON.parse(response);
+        if (json.status === 200 && json.data) {
+          setExportType(json.data.export_type);
+          setExportTypeId(json.data.export_type_id);
+        }
+      }).catch(error => {
+        console.error('Error fetching export type:', error);
+      });
+    }
+  }, [isRunning]);
+
+  // Filter data based on search term
+  // When running a Build or Single export, only search in the current export log data
+  const dataToFilter = filterText && allData.length > 0 && exportType !== 'Build' && exportType !== 'Single' ? allData : exportLog.static_pages || [];
+  const filteredData = dataToFilter.filter(item => {
+    if (!filterText) return true;
+    const searchTerm = filterText.toLowerCase();
+    return item.code && item.code.toString().toLowerCase().includes(searchTerm) || item.url && item.url.toLowerCase().includes(searchTerm) || item.notes && item.notes.toLowerCase().includes(searchTerm);
+  });
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "log-table-container"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_6__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_6__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("input", {
+    id: "export-search",
+    className: 'ss-export-log-search',
+    type: "text",
+    placeholder: "Search...",
+    value: filterText,
+    onChange: handleSearch
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react_data_table_component__WEBPACK_IMPORTED_MODULE_5__["default"], {
+    columns: columns,
+    data: filterText ? filteredData : exportLog.static_pages || [],
+    pagination: true,
+    paginationServer: !filterText,
+    paginationTotalRows: filterText ? filteredData.length : exportLog.total_static_pages,
+    paginationPerPage: 25,
+    paginationRowsPerPageOptions: [25, 50, 100, 200],
+    progressPending: loadingExportLog || loadingAllData && filterText,
+    progressComponent: (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+      style: {
+        padding: '24px',
+        textAlign: 'center'
+      }
+    }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_6__.Spinner, null), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+      style: {
+        marginTop: '8px'
+      }
+    }, loadingAllData && filterText ? 'Loading all data for search...' : 'Loading...')),
+    onChangeRowsPerPage: handlePerRowsChange,
+    onChangePage: filterText ? undefined : handlePageChange
+  }));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (ExportLog);
+
+/***/ }),
+
+/***/ "./src/settings/components/GenerateButtons.jsx":
+/*!*****************************************************!*\
+  !*** ./src/settings/components/GenerateButtons.jsx ***!
+  \*****************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+
+
+const {
+  __
+} = wp.i18n;
+function GenerateButtons(props) {
+  const {
+    canGenerate,
+    isPaused,
+    isDelayed,
+    startExport,
+    cancelExport,
+    pauseExport,
+    resumeExport
+  } = props;
+  const hasPauseFeature = typeof pauseExport === 'function';
+  const hasCancelFeature = typeof cancelExport === 'function';
+  const hasResumeFeature = typeof resumeExport === 'function';
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "generate-buttons-container"
+  }, canGenerate && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: () => {
+      startExport();
+    },
+    disabled: !canGenerate || isDelayed,
+    className: 'generate'
+  }, canGenerate && [(0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Dashicon, {
+    icon: "update"
+  }), __('Generate', 'simply-static')], canGenerate && isDelayed > 0 && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, " ", isDelayed, "s"), !canGenerate && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Dashicon, {
+    icon: "update spin"
+  })), !canGenerate && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, !isPaused && hasPauseFeature && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    label: __('Pause', 'simply-static'),
+    className: "ss-generate-media-button",
+    showToolTip: true,
+    onClick: () => pauseExport()
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Dashicon, {
+    icon: "controls-pause"
+  })), isPaused && hasResumeFeature && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    label: __('Resume', 'simply-static'),
+    className: "ss-generate-media-button",
+    showToolTip: true,
+    onClick: () => resumeExport()
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Dashicon, {
+    icon: "controls-play"
+  })), hasCancelFeature && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: () => cancelExport(),
+    label: __('Cancel', 'simply-static'),
+    className: "ss-generate-cancel-button",
+    showToolTip: true
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Dashicon, {
+    icon: 'no'
+  }))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (GenerateButtons);
+
+/***/ }),
+
+/***/ "./src/settings/components/HelperVideo.jsx":
+/*!*************************************************!*\
+  !*** ./src/settings/components/HelperVideo.jsx ***!
+  \*************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var react_player__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! react-player */ "./node_modules/react-player/lib/index.js");
+/* harmony import */ var react_player__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(react_player__WEBPACK_IMPORTED_MODULE_3__);
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function HelperVideo({
+  title,
+  videoUrl
+}) {
+  const [isVideoModalOpen, setVideoModalOpen] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const openVideoModal = () => setVideoModalOpen(true);
+  const closeVideoModal = () => setVideoModalOpen(false);
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, isVideoModalOpen && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    class: "simply-static-video-modal-background"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Modal, {
+    title: title,
+    className: 'simply-static-video-modal',
+    onRequestClose: closeVideoModal
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)((react_player__WEBPACK_IMPORTED_MODULE_3___default()), {
+    url: videoUrl,
+    controls: true,
+    width: '920px',
+    height: '560px'
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    variant: 'link',
+    className: "simply-static-video-button",
+    onClick: openVideoModal
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Dashicon, {
+    icon: 'format-video'
+  })));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (HelperVideo);
+
+/***/ }),
+
+/***/ "./src/settings/components/Integration.jsx":
+/*!*************************************************!*\
+  !*** ./src/settings/components/Integration.jsx ***!
+  \*************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _HelperVideo__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./HelperVideo */ "./src/settings/components/HelperVideo.jsx");
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_4__);
+
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function Integration({
+  integration,
+  settings,
+  toggleIntegration
+}) {
+  const {
+    isQueuedIntegration
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_4__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__.SettingsContext);
+  let isActive = integration.active;
+  const isPro = integration.pro;
+  const canRun = integration.can_run;
+  const alwaysActive = integration.always_active;
+  const isQueued = isQueuedIntegration(integration.id);
+  if (typeof settings.integrations !== 'undefined' && settings.integrations !== false) {
+    isActive = settings.integrations.indexOf(integration.id) >= 0;
+  }
+  let canUse = options.plan === 'pro' || !isPro;
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, {
+    className: 'ss-integration'
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("strong", null, integration.name || integration.id, canRun && isQueued && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("em", {
+    class: "ss-text-notice"
+  }, __('Requires saving settings', 'simply-static')), integration.id === 'redirection' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_HelperVideo__WEBPACK_IMPORTED_MODULE_2__["default"], {
+    title: __('Automated Redirects with Redirection', 'simply-static'),
+    videoUrl: 'https://youtu.be/sS4BQcZ4dN8'
+  }), integration.id === 'complianz' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_HelperVideo__WEBPACK_IMPORTED_MODULE_2__["default"], {
+    title: __('Cookie Consent with Complianz', 'simply-static'),
+    videoUrl: 'https://youtu.be/GPKYtt8A5QE'
+  })), integration.description != '' && [(0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), integration.description]), !canRun && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("span", {
+    className: 'ss-align-right ss-no-shrink'
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("em", null, "Missing Plugin"), !canUse && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    variant: "link",
+    href: "https://simplystatic.com/pricing/"
+  }, __('Requires Simply Static Pro', 'simply-static')))), canRun && canUse && !alwaysActive && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    className: 'integration-toggle',
+    checked: isActive,
+    onChange: value => {
+      toggleIntegration(integration.id, value);
+    }
+  }), canRun && canUse && alwaysActive && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("em", null, "Always Active"), canRun && !canUse && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    variant: "primary",
+    href: "https://simplystatic.com/pricing/"
+  }, __('Get the Pro version', 'simply-static'))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (Integration);
+
+/***/ }),
+
+/***/ "./src/settings/components/LogButtons.jsx":
+/*!************************************************!*\
+  !*** ./src/settings/components/LogButtons.jsx ***!
+  \************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_3__);
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function LogButtons() {
+  const [logDeleted, setLogDeleted] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)(false);
+  const deleteLog = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default()({
+      path: '/simplystatic/v1/delete-log',
+      method: 'POST'
+    });
+    setLogDeleted(true);
+    setTimeout(function () {
+      setLogDeleted(false);
+    }, 2000);
+  };
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    variant: "primary",
+    href: options.log_file,
+    download: true,
+    style: {
+      marginRight: "10px"
+    }
+  }, __('Download Log', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    variant: "secondary",
+    onClick: deleteLog
+  }, __('Clear Log', 'simply-static')), logDeleted && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Log file cleared.', 'simply-static')))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (LogButtons);
+
+/***/ }),
+
+/***/ "./src/settings/components/SettingsPage.jsx":
+/*!**************************************************!*\
+  !*** ./src/settings/components/SettingsPage.jsx ***!
+  \**************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _pages_GeneralSettings__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../pages/GeneralSettings */ "./src/settings/pages/GeneralSettings.jsx");
+/* harmony import */ var _pages_Diagnostics__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../pages/Diagnostics */ "./src/settings/pages/Diagnostics.jsx");
+/* harmony import */ var _pages_Utilities__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../pages/Utilities */ "./src/settings/pages/Utilities.jsx");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_4__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_5___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__);
+/* harmony import */ var _pages_DeploymentSettings__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! ../pages/DeploymentSettings */ "./src/settings/pages/DeploymentSettings.jsx");
+/* harmony import */ var _pages_FormSettings__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(/*! ../pages/FormSettings */ "./src/settings/pages/FormSettings.jsx");
+/* harmony import */ var _pages_SearchSettings__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(/*! ../pages/SearchSettings */ "./src/settings/pages/SearchSettings.jsx");
+/* harmony import */ var _pages_DebugSettings__WEBPACK_IMPORTED_MODULE_9__ = __webpack_require__(/*! ../pages/DebugSettings */ "./src/settings/pages/DebugSettings.jsx");
+/* harmony import */ var _pages_IntegrationsSettings__WEBPACK_IMPORTED_MODULE_10__ = __webpack_require__(/*! ../pages/IntegrationsSettings */ "./src/settings/pages/IntegrationsSettings.jsx");
+/* harmony import */ var _pages_Generate__WEBPACK_IMPORTED_MODULE_11__ = __webpack_require__(/*! ../pages/Generate */ "./src/settings/pages/Generate.jsx");
+/* harmony import */ var _pages_Optimize__WEBPACK_IMPORTED_MODULE_12__ = __webpack_require__(/*! ../pages/Optimize */ "./src/settings/pages/Optimize.jsx");
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_13__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_14__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_14___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_14__);
+/* harmony import */ var _EnvironmentSidebar__WEBPACK_IMPORTED_MODULE_15__ = __webpack_require__(/*! ./EnvironmentSidebar */ "./src/settings/components/EnvironmentSidebar.jsx");
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function SettingsPage() {
+  const {
+    isRunning,
+    setIsRunning,
+    isResumed,
+    setIsResumed,
+    isPaused,
+    setIsPaused,
+    blogId,
+    settings,
+    updateFromNetwork,
+    getSettings,
+    passedChecks,
+    isPro,
+    isStudio,
+    canRunIntegration,
+    showMobileNav,
+    setShowMobileNav,
+    isDelayed
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_4__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_13__.SettingsContext);
+  const [activeItem, setActiveItem] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_4__.useState)({
+    activeItem: "/"
+  });
+  const [initialPage, setInitialPage] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_4__.useState)(localStorage.getItem('ss-initial-page') ? localStorage.getItem('ss-initial-page') : options.initial);
+  const [initialSet, setInitialSet] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_4__.useState)(false);
+  const [disabledButton, setDisabledButton] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_4__.useState)(false);
+  const [selectedCopySite, setSelectedCopySite] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_4__.useState)('current');
+  const [selectablesSites, setSelectableSites] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_4__.useState)([]);
+  const [isUpdatingFromNetwork, setIsUpdatingFromNetwork] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_4__.useState)(false);
+  const [selectedExportType, setSelectedExportType] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_4__.useState)('export');
+  const runUpdateFromNetwork = blogId => {
+    // Update settings from selected blog_id.
+    updateFromNetwork(blogId);
+    setIsUpdatingFromNetwork(true);
+    setTimeout(function () {
+      setIsUpdatingFromNetwork(false);
+      window.location.reload();
+    }, 2000);
+  };
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_4__.useEffect)(() => {
+    setDisabledButton(isRunning || isPaused);
+
+    // Change initial page.
+    let initialPageRedirect = localStorage.getItem('ss-initial-page');
+    if (!initialSet) {
+      setInitialSet(true);
+      if (initialPageRedirect) {
+        setActiveItem(initialPageRedirect);
+        setInitialPage(initialPageRedirect);
+        localStorage.removeItem('ss-initial-page');
+      } else {
+        setActiveItem(options.initial);
+        setInitialPage(options.initial);
+      }
+    }
+    if (options.selectable_sites && !options.is_network && options.is_multisite) {
+      let sites = options.selectable_sites.map(function (site) {
+        return {
+          label: `${site.name}`,
+          value: site.blog_id
+        };
+      });
+      sites.unshift({
+        label: __('Use current settings', 'simply-static'),
+        value: 'current'
+      });
+      setSelectableSites(sites);
+    }
+  }, [options, isRunning, isPaused]);
+
+  // Set the default export type when the component mounts or when settings change
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_4__.useEffect)(() => {
+    // Always use 'export' as the default option
+    setSelectedExportType('export');
+  }, [settings]);
+  const startExport = () => {
+    setDisabledButton(true);
+    setIsResumed(false);
+    setIsPaused(false);
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_14___default()({
+      path: '/simplystatic/v1/start-export',
+      method: 'POST',
+      data: {
+        'blog_id': blogId,
+        'type': selectedExportType
+      }
+    }).then(resp => {
+      var json = JSON.parse(resp);
+      if (json.status === 500) {
+        alert(json.message);
+        setDisabledButton(false);
+        return;
+      }
+      setIsRunning(true);
+    });
+  };
+  const cancelExport = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_14___default()({
+      path: '/simplystatic/v1/cancel-export',
+      method: 'POST',
+      data: {
+        'blog_id': blogId
+      }
+    }).then(resp => {
+      setIsResumed(false);
+      setIsPaused(false);
+      setIsRunning(false);
+      setDisabledButton(false);
+    });
+  };
+  const pauseExport = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_14___default()({
+      path: '/simplystatic/v1/pause-export',
+      method: 'POST',
+      data: {
+        'blog_id': blogId
+      }
+    }).then(resp => {
+      setIsRunning(false);
+      setIsResumed(false);
+      setIsPaused(true);
+    });
+  };
+  const resumeExport = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_14___default()({
+      path: '/simplystatic/v1/resume-export',
+      method: 'POST',
+      data: {
+        'blog_id': blogId
+      }
+    }).then(resp => {
+      setIsResumed(true);
+      setIsPaused(false);
+      setIsRunning(true);
+    });
+  };
+  let buildOptions = '';
+  if (Object.keys(options.builds).length) {
+    const builds = Object.keys(options.builds).map(id => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("option", {
+      value: id
+    }, options.builds[id]));
+
+    // Sort builds alphabetically
+    builds.sort((a, b) => {
+      return a.props.children.localeCompare(b.props.children);
+    });
+    buildOptions = (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("optgroup", {
+      label: "Builds"
+    }, builds);
+  }
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "plugin-settings-container"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorProvider, {
+    initialPath: initialPage
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("a", {
+    onClick: () => {
+      setShowMobileNav(!showMobileNav);
+    },
+    className: "show-nav"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "align-center"
+  }), " ", __('Toggle menu', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.FlexItem, {
+    className: showMobileNav ? 'toggle-nav sidebar' : 'sidebar'
+  }, options.is_network ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Card, {
+    className: "plugin-nav"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "plugin-logo"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("img", {
+    alt: "Logo",
+    src: options.logo
+  })), 'pro' === options.plan && isPro() ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", {
+    className: "version-number"
+  }, "Free: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), "Pro: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version_pro)) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", {
+    className: "version-number"
+  }, "Version: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version)), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Button, {
+    href: "https://simplystatic.com/changelogs/",
+    target: "_blank"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "editor-ul"
+  }), " ", __('Changelog', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Button, {
+    href: "https://docs.simplystatic.com",
+    target: "_blank"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "admin-links"
+  }), " ", __('Documentation', 'simply-static')), 'free' === options.plan && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Button, {
+    href: "https://simplystatic.com",
+    target: "_blank"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "admin-site-alt3"
+  }), "Simply Static Pro")) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Card, {
+    className: "plugin-nav"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "plugin-logo"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("img", {
+    alt: "Logo",
+    src: options.logo
+  })), 'pro' === options.plan && isPro() ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, isStudio() ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", {
+    className: "version-number"
+  }, "Free: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), "Pro: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version_pro), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), "Studio: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version_studio)) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", {
+    className: "version-number"
+  }, "Free: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), "Pro: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version_pro))) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", {
+    className: "version-number"
+  }, "Version: ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, options.version)), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: `generate-container ${disabledButton ? 'generating' : ''}`
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.SelectControl, {
+    className: 'generate-type',
+    value: selectedExportType,
+    disabled: disabledButton,
+    onChange: value => {
+      setSelectedExportType(value);
+    }
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("option", {
+    value: "export"
+  }, __('Export', 'simply-static')), 'zip' !== settings.delivery_method && 'tiiny' !== settings.delivery_method && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, 'pro' === options.plan && isPro() ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("option", {
+    value: "update"
+  }, __('Export Changes', 'simply-static')) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("option", {
+    disabled: true,
+    value: "update"
+  }, __('Export Changes (Requires Simply Static Pro)', 'simply-static'))), buildOptions), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "generate-buttons-container"
+  }, !disabledButton && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Button, {
+    onClick: () => {
+      startExport();
+    },
+    disabled: disabledButton || isDelayed,
+    className: activeItem === '/' ? 'is-active-item generate' : 'generate'
+  }, !disabledButton && [(0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "update"
+  }), __('Generate', 'simply-static')], !disabledButton && isDelayed > 0 && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, " ", isDelayed, "s"), disabledButton && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "update spin"
+  })), disabledButton && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, !isPaused && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Button, {
+    label: __('Pause', 'simply-static'),
+    className: "ss-generate-media-button",
+    showToolTip: true,
+    onClick: () => pauseExport()
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "controls-pause"
+  })), isPaused && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Button, {
+    label: __('Resume', 'simply-static'),
+    className: "ss-generate-media-button",
+    showToolTip: true,
+    onClick: () => resumeExport()
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "controls-play"
+  })), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Button, {
+    onClick: () => cancelExport(),
+    label: __('Cancel', 'simply-static'),
+    className: "ss-generate-cancel-button",
+    showToolTip: true
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: 'no'
+  }))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.CardBody, null, 'pro' === options.plan && isPro() && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, !options.is_network && canRunIntegration('environments') && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_EnvironmentSidebar__WEBPACK_IMPORTED_MODULE_15__["default"], {
+    isRunning: isRunning,
+    getSettings: getSettings
+  })), !options.is_network && options.is_multisite && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("h4", {
+    className: "settings-headline"
+  }, " ", __('Import', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.SelectControl, {
+    value: selectedCopySite,
+    options: selectablesSites,
+    help: __('Choose a subsite to import settings from.', 'simply-static'),
+    onChange: blog_id => {
+      setSelectedCopySite(blog_id);
+    }
+  }), selectedCopySite !== 'current' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Button, {
+    isPrimary: true,
+    onClick: () => {
+      runUpdateFromNetwork(selectedCopySite);
+    }
+  }, __('Import Settings', 'simply-static')), isUpdatingFromNetwork ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Notice, {
+    status: "success",
+    isDismissible: false,
+    className: "upgrade-network-notice"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings successfully imported.', 'simply-static')))) : ''), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("h4", {
+    className: "settings-headline"
+  }, " ", __('Tools', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorButton, {
+    onClick: () => {
+      setActiveItem('/');
+      setShowMobileNav(!showMobileNav);
+    },
+    className: activeItem === '/' ? 'is-active-item generate' : 'generate',
+    path: "/"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "update"
+  }), " ", __('Activity Log', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorButton, {
+    onClick: () => {
+      setActiveItem('/diagnostics');
+      setShowMobileNav(!showMobileNav);
+    },
+    className: activeItem === '/diagnostics' ? 'is-active-item' : '',
+    path: "/diagnostics"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "bell"
+  }), " ", __('Diagnostics', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("h4", {
+    className: "settings-headline"
+  }, " ", __('Settings', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorButton, {
+    onClick: () => {
+      setActiveItem('/general');
+      setShowMobileNav(!showMobileNav);
+    },
+    className: activeItem === '/general' ? 'is-active-item' : '',
+    path: "/general"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "admin-generic"
+  }), " ", __('General', 'simply-static')), !options.is_network && !options.hidden_settings.includes('deployment') && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorButton, {
+    onClick: () => {
+      setActiveItem('/deployment');
+      setShowMobileNav(!showMobileNav);
+    },
+    className: activeItem === '/deployment' ? 'is-active-item' : '',
+    path: "/deployment"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "migrate"
+  }), " ", __('Deploy', 'simply-static')), !options.is_network && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorButton, {
+    onClick: () => {
+      setActiveItem('/forms');
+      setShowMobileNav(!showMobileNav);
+    },
+    className: activeItem === '/forms' ? 'is-active-item' : '',
+    path: "/forms"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "align-center"
+  }), " ", __('Forms', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorButton, {
+    onClick: () => {
+      setActiveItem('/search');
+      setShowMobileNav(!showMobileNav);
+    },
+    className: activeItem === '/search' ? 'is-active-item' : '',
+    path: "/search"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "search"
+  }), " ", __('Search', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorButton, {
+    onClick: () => {
+      setActiveItem('/optimize');
+      setShowMobileNav(!showMobileNav);
+    },
+    className: activeItem === '/optimize' ? 'is-active-item' : '',
+    path: "/optimize"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "dashboard"
+  }), " ", __('Optimize', 'simply-static')))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("h4", {
+    className: "settings-headline"
+  }, " ", __('Advanced', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorButton, {
+    onClick: () => {
+      setActiveItem('/integrations');
+      setShowMobileNav(!showMobileNav);
+    },
+    className: activeItem === '/integrations' ? 'is-active-item' : '',
+    path: "/integrations"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "block-default"
+  }), " ", __('Integrations', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorButton, {
+    onClick: () => {
+      setActiveItem('/utilities');
+      setShowMobileNav(!showMobileNav);
+    },
+    className: activeItem === '/utilities' ? 'is-active-item' : '',
+    path: "/utilities"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "admin-tools"
+  }), " ", __('Utilities', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorButton, {
+    onClick: () => {
+      setActiveItem('/debug');
+      setShowMobileNav(!showMobileNav);
+    },
+    className: activeItem === '/debug' ? 'is-active-item' : '',
+    path: "/debug"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "editor-help"
+  }), " ", __('Debug', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("h4", {
+    className: "settings-headline"
+  }, "Learn"), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Button, {
+    href: "https://docs.simplystatic.com",
+    target: "_blank"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "admin-links"
+  }), " ", __('Documentation', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Button, {
+    href: "https://www.youtube.com/playlist?list=PLcpe8_rNg8U5g1gCOa0Ge6T17f50nSvmg",
+    target: "_blank"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "format-video"
+  }), " ", __('Video Course', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Button, {
+    href: "https://simplystatic.com/tutorials/",
+    target: "_blank"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "edit"
+  }), " ", __('Tutorials', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.FlexItem, {
+    isBlock: true,
+    className: !showMobileNav ? 'toggle-nav' : ''
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    class: "plugin-settings"
+  }, 'no' === passedChecks && !options.is_network ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Notice, {
+    status: "notice",
+    isDismissible: false,
+    className: activeItem == '/' ? 'diagnostics-notice diagnostics-notice-generate' : 'diagnostics-notice'
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('There are errors in diagnostics that may negatively affect your static export.', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), __('Please review them and get them fixed to avoid problems.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorButton, {
+    isSecondary: true,
+    onClick: () => {
+      setActiveItem('/diagnostics');
+      setShowMobileNav(!showMobileNav);
+    },
+    className: activeItem === '/diagnostics' ? 'is-active-item' : '',
+    path: "/diagnostics"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
+    icon: "editor-help"
+  }), " ", __('Visit Diagnostics', 'simply-static')))) : '', 'pro' === options.plan && !isPro() ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Notice, {
+    status: "error",
+    isDismissible: false,
+    className: activeItem == '/' ? 'diagnostics-notice diagnostics-notice-generate' : 'diagnostics-notice'
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('You are using the pro version without a valid license.', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), __('We have temporarily disabled all the pro features now. Please contact our support to have the problem solved.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Button, {
+    isPrimary: true,
+    href: "https://simplystatic.com/support/",
+    target: "_blank"
+  }, "Contact Support")), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalSpacer, {
+    margin: "5px"
+  }))) : '', activeItem === '/' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorScreen, {
+    path: "/"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_Generate__WEBPACK_IMPORTED_MODULE_11__["default"], null)), activeItem === '/diagnostics' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorScreen, {
+    path: "/diagnostics"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_Diagnostics__WEBPACK_IMPORTED_MODULE_2__["default"], null)), activeItem === '/general' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorScreen, {
+    path: "/general"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_GeneralSettings__WEBPACK_IMPORTED_MODULE_1__["default"], null)), activeItem === '/deployment' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorScreen, {
+    path: "/deployment"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_DeploymentSettings__WEBPACK_IMPORTED_MODULE_6__["default"], null)), activeItem === '/forms' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorScreen, {
+    path: "/forms"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_FormSettings__WEBPACK_IMPORTED_MODULE_7__["default"], null)), activeItem === '/search' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorScreen, {
+    path: "/search"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_SearchSettings__WEBPACK_IMPORTED_MODULE_8__["default"], null)), activeItem === '/optimize' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorScreen, {
+    path: "/optimize"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_Optimize__WEBPACK_IMPORTED_MODULE_12__["default"], null)), activeItem === '/utilities' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorScreen, {
+    path: "/utilities"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_Utilities__WEBPACK_IMPORTED_MODULE_3__["default"], null)), activeItem === '/debug' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorScreen, {
+    path: "/debug"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_DebugSettings__WEBPACK_IMPORTED_MODULE_9__["default"], null)), activeItem === '/integrations' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.__experimentalNavigatorScreen, {
+    path: "/integrations"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_pages_IntegrationsSettings__WEBPACK_IMPORTED_MODULE_10__["default"], null)))))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (SettingsPage);
+
+/***/ }),
+
+/***/ "./src/settings/components/Site.jsx":
+/*!******************************************!*\
+  !*** ./src/settings/components/Site.jsx ***!
+  \******************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _GenerateButtons__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./GenerateButtons */ "./src/settings/components/GenerateButtons.jsx");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_3__);
+
+
+
+
+
+function Site(props) {
+  const {
+    site,
+    setAnyRunning
+  } = props;
+  const blogId = site.id;
+  const [canGenerate, setCanGenerate] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)(!site.running && !site.paused);
+  const [isRunning, setIsRunning] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)(site.running);
+  const [isPaused, setIsPaused] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)(site.paused);
+  (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(() => {
+    if (isRunning) {
+      setAnyRunning(true);
+    }
+  }, [isRunning]);
+  const startExport = () => {
+    setCanGenerate(false);
+    setIsPaused(false);
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1___default()({
+      path: '/simplystatic/v1/start-export',
+      method: 'POST',
+      data: {
+        'blog_id': blogId,
+        'type': 'export'
+      }
+    }).then(resp => {
+      var json = JSON.parse(resp);
+      if (json.status === 500) {
+        setCanGenerate(true);
+        return;
+      }
+      setIsRunning(true);
+    });
+  };
+  const cancelExport = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1___default()({
+      path: '/simplystatic/v1/cancel-export',
+      method: 'POST',
+      data: {
+        'blog_id': blogId
+      }
+    }).then(resp => {
+      setIsPaused(false);
+      setIsRunning(false);
+      setCanGenerate(true);
+    });
+  };
+  const pauseExport = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1___default()({
+      path: '/simplystatic/v1/pause-export',
+      method: 'POST',
+      data: {
+        'blog_id': blogId
+      }
+    }).then(resp => {
+      setIsRunning(false);
+      setIsPaused(true);
+    });
+  };
+  const resumeExport = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_1___default()({
+      path: '/simplystatic/v1/resume-export',
+      method: 'POST',
+      data: {
+        'blog_id': blogId
+      }
+    }).then(resp => {
+      setIsPaused(false);
+      setIsRunning(true);
+    });
+  };
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("tr", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("td", null, site.name), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("td", null, site.url), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("td", null, isRunning ? 'Running' : 'Idle'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("td", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_GenerateButtons__WEBPACK_IMPORTED_MODULE_2__["default"], {
+    site: site,
+    canGenerate: canGenerate,
+    startExport: startExport,
+    isPaused: isPaused,
+    isRunning: isRunning,
+    cancelExport: cancelExport,
+    pauseExport: pauseExport,
+    resumeExport: resumeExport
+  })));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (Site);
+
+/***/ }),
+
+/***/ "./src/settings/components/Sites.jsx":
+/*!*******************************************!*\
+  !*** ./src/settings/components/Sites.jsx ***!
+  \*******************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var react_terminal_ui__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! react-terminal-ui */ "./node_modules/react-terminal-ui/build/index.es.js");
+/* harmony import */ var _hooks_useInterval__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ../../hooks/useInterval */ "./src/hooks/useInterval.js");
+/* harmony import */ var _Site__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! ./Site */ "./src/settings/components/Site.jsx");
+
+
+
+
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function Sites(props) {
+  const [sites, setSites] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)([]);
+  const [anyRunning, setAnyRunning] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)(false);
+  function refreshSites() {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default()({
+      path: '/simplystatic/v1/sites',
+      method: 'GET'
+    }).then(resp => {
+      console.log(resp);
+      let sitesObjects = [];
+      let haveRunningSite = false;
+      resp.data.forEach(function (site) {
+        console.log(site);
+        sitesObjects.push(site);
+        if (site.running) {
+          haveRunningSite = true;
+        }
+      });
+      setSites(sitesObjects);
+      setAnyRunning(haveRunningSite);
+    });
+  }
+  (0,_hooks_useInterval__WEBPACK_IMPORTED_MODULE_5__["default"])(() => {
+    refreshSites();
+  }, anyRunning ? 2500 : null);
+  (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(() => {
+    refreshSites();
+  }, []);
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("table", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("thead", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("tr", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("th", null, __('Name', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("th", null, __('URL', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("th", null, __('Status', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("th", null, __('Actions', 'simply-static')))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("tbody", null, sites.map(site => {
+    return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_Site__WEBPACK_IMPORTED_MODULE_6__["default"], {
+      setAnyRunning: setAnyRunning,
+      site: site,
+      key: site.blog_id
+    });
+  }))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (Sites);
+
+/***/ }),
+
+/***/ "./src/settings/context/SettingsContext.jsx":
+/*!**************************************************!*\
+  !*** ./src/settings/context/SettingsContext.jsx ***!
+  \**************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   SettingsContext: () => (/* binding */ SettingsContext),
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _hooks_useInterval__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../../hooks/useInterval */ "./src/hooks/useInterval.js");
+
+
+
+
+const {
+  __
+} = wp.i18n;
+const SettingsContext = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.createContext)();
+function SettingsContextProvider(props) {
+  const [isRunning, setIsRunning] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)(false);
+  const [isDelayed, setIsDelayed] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)(0);
+  const [isPaused, setIsPaused] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)(false);
+  const [isResumed, setIsResumed] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)(false);
+  const [settingsSaved, setSettingsSaved] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)(false);
+  const [settings, setSettings] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)({});
+  const [configs, setConfigs] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)({});
+  const [passedChecks, setPassedChecks] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)('yes');
+  const [blogId, setBlogId] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)(1);
+  const [queuedIntegrations, setQueuedIntegrations] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)([]);
+  const [showMobileNav, setShowMobileNav] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useState)(true);
+  const getSettings = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default()({
+      path: '/simplystatic/v1/settings'
+    }).then(options => {
+      setSettings(options);
+    });
+  };
+  const saveSettings = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default()({
+      path: '/simplystatic/v1/settings',
+      method: 'POST',
+      data: settings
+    }).then(resp => {
+      setQueuedIntegrations([]);
+    });
+  };
+  const resetSettings = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default()({
+      path: '/simplystatic/v1/settings/reset',
+      method: 'POST'
+    }).then(resp => {
+      // Parse the response to get the default settings
+      const response = JSON.parse(resp);
+      if (response.status === 200 && response.data) {
+        // Update the settings state with the default settings from the server
+        setSettings(response.data);
+      }
+    });
+  };
+  const resetDatabase = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default()({
+      path: '/simplystatic/v1/settings/reset-database',
+      method: 'POST'
+    });
+  };
+  const updateFromNetwork = blogId => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default()({
+      path: '/simplystatic/v1/update-from-network',
+      method: 'POST',
+      data: {
+        'blog_id': blogId
+      }
+    });
+  };
+  const checkIfRunning = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default()({
+      path: '/simplystatic/v1/is-running',
+      method: 'GET'
+    }).then(resp => {
+      var json = JSON.parse(resp);
+      setIsRunning(json.running);
+      setIsPaused(json.paused);
+      if (json.delayed) {
+        setIsDelayed(json.delayed_until);
+      }
+    });
+  };
+  const importSettings = newSettings => {
+    setSettings(newSettings);
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default()({
+      path: '/simplystatic/v1/settings',
+      method: 'POST',
+      data: newSettings
+    });
+  };
+  const migrateSettings = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default()({
+      path: '/simplystatic/v1/migrate',
+      method: 'POST',
+      migrate: true
+    });
+  };
+  const updateSetting = (key, value) => {
+    const updatedSettings = {
+      ...settings,
+      [key]: value
+    };
+    setSettings(updatedSettings);
+  };
+  const getStatus = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default()({
+      path: '/simplystatic/v1/system-status'
+    }).then(configs => {
+      setConfigs(configs);
+      getStatusPassed();
+    });
+  };
+  const getStatusPassed = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default()({
+      path: '/simplystatic/v1/system-status/passed'
+    }).then(result => {
+      let test = JSON.parse(result);
+      setPassedChecks(test.passed);
+    });
+  };
+  const resetDiagnostics = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default()({
+      path: '/simplystatic/v1/reset-diagnostics',
+      method: 'POST'
+    });
+  };
+  const isPro = () => {
+    if (options.is_multisite) {
+      return true;
+    }
+    if (options.connect) {
+      return !!options.connect.is_connected;
+    }
+    return false;
+  };
+  const isStudio = () => {
+    if (options.home.includes('static.studio') || options.home.includes('static1.studio') || options.home.includes('static2.studio')) {
+      return true;
+    }
+    return false;
+  };
+  const integrationRequiresSaving = integration => {
+    /**
+     * @todo make it defined inside integration classes when more come.
+     * @type {string[]}
+     */
+    const integrations = ['environments'];
+    return integrations.indexOf(integration) >= 0;
+  };
+  const maybeQueueIntegration = integration => {
+    if (!integrationRequiresSaving(integration)) {
+      return;
+    }
+
+    // Already queued.
+    if (isQueuedIntegration(integration)) {
+      return;
+    }
+    queuedIntegrations.push(integration);
+    setQueuedIntegrations(queuedIntegrations);
+  };
+  const maybeUnqueueIntegration = integration => {
+    if (!integrationRequiresSaving(integration)) {
+      return;
+    }
+
+    // Already queued.
+    if (!isQueuedIntegration(integration)) {
+      return;
+    }
+    const index = queuedIntegrations.indexOf(integration);
+    if (index < 0) {
+      return;
+    }
+    queuedIntegrations.splice(index, 1);
+    setQueuedIntegrations(queuedIntegrations);
+  };
+  const canRunIntegration = integration => {
+    if (!isIntegrationActive(integration)) {
+      return false;
+    }
+    if (isQueuedIntegration(integration)) {
+      return false;
+    }
+    return true;
+  };
+  const isQueuedIntegration = integration => {
+    return queuedIntegrations.indexOf(integration) >= 0;
+  };
+  const isIntegrationActive = integration => {
+    let integrations = settings.integrations;
+    if (false === integrations || !integrations || !Array.isArray(integrations)) {
+      return false;
+    }
+    if (integrations.indexOf(integration) >= 0) {
+      return true;
+    }
+    return false;
+  };
+  (0,_hooks_useInterval__WEBPACK_IMPORTED_MODULE_3__["default"])(() => {
+    setIsDelayed(isDelayed - 1);
+  }, isDelayed > 0 ? 1000 : null);
+  (0,_hooks_useInterval__WEBPACK_IMPORTED_MODULE_3__["default"])(() => {
+    checkIfRunning();
+  }, isRunning || isDelayed ? 5000 : null);
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.useEffect)(() => {
+    // If current_settings is available in the options object, use it instead of fetching from the API
+    if (options.current_settings) {
+      setSettings(options.current_settings);
+    } else {
+      // Fallback to fetching from the API if current_settings is not available
+      getSettings();
+    }
+    getStatus();
+    checkIfRunning();
+    setBlogId(options.blog_id);
+  }, []);
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(SettingsContext.Provider, {
+    value: {
+      settings,
+      configs,
+      passedChecks,
+      settingsSaved,
+      setSettingsSaved,
+      updateSetting,
+      setSettings,
+      saveSettings,
+      resetSettings,
+      resetDatabase,
+      getSettings,
+      updateFromNetwork,
+      importSettings,
+      migrateSettings,
+      resetDiagnostics,
+      isRunning,
+      setIsRunning,
+      isPaused,
+      setIsPaused,
+      setIsResumed,
+      isResumed,
+      blogId,
+      setBlogId,
+      isPro,
+      isStudio,
+      isIntegrationActive,
+      canRunIntegration,
+      maybeQueueIntegration,
+      maybeUnqueueIntegration,
+      isQueuedIntegration,
+      showMobileNav,
+      setShowMobileNav,
+      isDelayed
+    }
+  }, props.children);
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (SettingsContextProvider);
+
+/***/ }),
+
+/***/ "./src/settings/pages/DebugSettings.jsx":
+/*!**********************************************!*\
+  !*** ./src/settings/pages/DebugSettings.jsx ***!
+  \**********************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _components_HelperVideo__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ../components/HelperVideo */ "./src/settings/components/HelperVideo.jsx");
+
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function DebugSettings() {
+  const {
+    settings,
+    updateSetting,
+    saveSettings,
+    settingsSaved,
+    setSettingsSaved,
+    isPro,
+    isStudio
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__.SettingsContext);
+  const [activateDebugLog, setActivateDebugLog] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [useServerCron, setUserServerCron] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const setSavingSettings = () => {
+    saveSettings();
+    setSettingsSaved(true);
+    setTimeout(function () {
+      setSettingsSaved(false);
+    }, 2000);
+  };
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useEffect)(() => {
+    if (settings.debugging_mode) {
+      setActivateDebugLog(settings.debugging_mode);
+    }
+    if (settings.server_cron) {
+      setUserServerCron(settings.server_cron);
+    }
+  }, [settings]);
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "inner-settings"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Basic Auth', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_4__["default"], {
+    title: __('How to set up basic auth', 'simply-static'),
+    videoUrl: 'https://youtu.be/6udSR3_zSOU'
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('If you\'ve secured WordPress with HTTP Basic Auth you need to specify the username and password to use below.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Basic Auth Username', 'simply-static'),
+    autoComplete: "off",
+    type: "text",
+    value: settings.http_basic_auth_username,
+    onChange: username => {
+      updateSetting('http_basic_auth_username', username);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Basic Auth Password', 'simply-static'),
+    type: "password",
+    autoComplete: "off",
+    value: settings.http_basic_auth_password,
+    onChange: username => {
+      updateSetting('http_basic_auth_password', username);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Enable Basic Auth', 'simply-static'),
+    help: (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, 'free' === options.plan ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, __('Automatically setting up Basic Auth requires Simply Static Pro.', 'simply-static')) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, __('Once enabled we will put your entire website behind password protection.', 'simply-static'))),
+    disabled: 'free' === options.plan || !isPro(),
+    checked: settings.http_basic_auth_on,
+    onChange: value => {
+      updateSetting('http_basic_auth_on', value);
+    }
+  }), settings.http_basic_auth_on && (!settings.http_basic_auth_username || !settings.http_basic_auth_password) && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "warning",
+    isDismissible: false
+  }, __('Requires Username & Password to work', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), !isStudio() && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Temporary Files', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Temporary Files Directory', 'simply-static'),
+    type: "text",
+    placeholder: options.temp_files_dir,
+    help: __('Optionally specify the directory to save your temporary files. This directory must exist and be writeable.', 'simply-static'),
+    value: settings.temp_files_dir,
+    onChange: temp_dir => {
+      updateSetting('temp_files_dir', temp_dir);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Whitelist Plugins', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextareaControl, {
+    label: __('Whitelist plugins in diagnostics', 'simply-static'),
+    placeholder: "autoptimize\nwp-search-with-algolia\nwp-rocket",
+    help: __('If you want to exclude certain plugins from the diagnostics check add the plugin slugs here (one per line).', 'simply-static'),
+    value: settings.whitelist_plugins,
+    onChange: value => {
+      updateSetting('whitelist_plugins', value);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), !isStudio() && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Proxy Setup', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Origin URL', 'simply-static'),
+    type: "url",
+    help: __('If the URL of your WordPress installation differs from the public-facing URL (Proxy Setup), add the public URL here.', 'simply-static'),
+    placeholder: options.home,
+    autoComplete: "off",
+    value: settings.origin_url,
+    onChange: origin_url => {
+      updateSetting('origin_url', origin_url);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Debug Log', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Activate Debug Log', 'simply-static'),
+    help: __('Enable it to download the debug log from Simply Static -> Generate.', 'simply-static'),
+    checked: activateDebugLog,
+    onChange: value => {
+      setActivateDebugLog(value);
+      updateSetting('debugging_mode', value);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), !isStudio() && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Cron', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Use server-side cron job', 'simply-static'),
+    help: __('Enable this if you use a server-side cron job instead of the default WP-Cron.', 'simply-static'),
+    checked: useServerCron,
+    onChange: value => {
+      setUserServerCron(value);
+      updateSetting('server_cron', value);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), settingsSaved && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings saved successfully.', 'simply-static')))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  })), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "save-settings"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: setSavingSettings,
+    variant: "primary"
+  }, __('Save Settings', 'simply-static'))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (DebugSettings);
+
+/***/ }),
+
+/***/ "./src/settings/pages/DeploymentSettings.jsx":
+/*!***************************************************!*\
+  !*** ./src/settings/pages/DeploymentSettings.jsx ***!
+  \***************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_4__);
+/* harmony import */ var _components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ../components/HelperVideo */ "./src/settings/components/HelperVideo.jsx");
+
+
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function DeploymentSettings() {
+  var _settings$github_batc;
+  const {
+    settings,
+    updateSetting,
+    saveSettings,
+    settingsSaved,
+    setSettingsSaved,
+    isRunning,
+    isPro,
+    isStudio
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__.SettingsContext);
+  const [deliveryMethod, setDeliveryMethod] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('zip');
+  const [clearDirectory, setClearDirectory] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [githubAccountType, setGithubAccountType] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('personal');
+  const [githubVisibility, setGithubVisibility] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('private');
+  const [emptyBucketBeforeExport, setEmptyBucketBeforeExport] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [throttleGitHubRequests, setThrottleGitHubRequests] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [region, setRegion] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('us-east-2');
+  const [awsAuthMethod, setAwsAuthMethod] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('aws-iam-key');
+  const [hasCopied, setHasCopied] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [pages, setPages] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [testDisabled, setTestDisabled] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [testRunning, setTestRunning] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [deploymentOptions] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)([{
+    label: __('ZIP Archive', 'simply-static'),
+    value: 'zip'
+  }, {
+    label: __('Local Directory', 'simply-static'),
+    value: 'local'
+  }, {
+    label: __('Static Studio', 'simply-static'),
+    value: 'simply-static-studio'
+  }, {
+    label: __('SFTP', 'simply-static'),
+    value: 'sftp'
+  }, {
+    label: __('GitHub', 'simply-static'),
+    value: 'github'
+  }, {
+    label: __('AWS S3', 'simply-static'),
+    value: 'aws-s3'
+  }, {
+    label: __('Bunny CDN', 'simply-static'),
+    value: 'cdn'
+  }, {
+    label: __('Tiiny.host', 'simply-static'),
+    value: 'tiiny'
+  }]);
+  const setSavingSettings = () => {
+    saveSettings();
+    setSettingsSaved(true);
+    setTestDisabled(false);
+    setTimeout(function () {
+      setSettingsSaved(false);
+    }, 2000);
+  };
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useEffect)(() => {
+    if (settings.delivery_method) {
+      setDeliveryMethod(settings.delivery_method);
+    }
+    if (settings.clear_directory_before_export) {
+      setClearDirectory(settings.clear_directory_before_export);
+    }
+    if (settings.github_account_type) {
+      setGithubAccountType(settings.github_account_type);
+    }
+    if (settings.github_repository_visibility) {
+      setGithubVisibility(settings.github_repository_visibility);
+    }
+    if (settings.github_repository_visibility) {
+      setGithubVisibility(settings.github_repository_visibility);
+    }
+    if (settings.github_throttle_requests) {
+      setThrottleGitHubRequests(settings.github_throttle_requests);
+    }
+    if (settings.aws_empty) {
+      setEmptyBucketBeforeExport(settings.aws_empty);
+    }
+    if (settings.aws_auth_method) {
+      setAwsAuthMethod(settings.aws_auth_method);
+    }
+    if (settings.aws_region) {
+      setRegion(settings.aws_region);
+    }
+
+    // Get global page selection
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_4___default()({
+      path: '/simplystatic/v1/pages'
+    }).then(fetched_pages => {
+      let pages = fetched_pages;
+      pages.unshift({
+        label: __('No page selected', 'simply-static'),
+        value: 0
+      });
+      setPages(pages);
+    });
+  }, [settings]);
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "inner-settings"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Deployment Settings', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Choose from a variety of deployment methods. Depending on your selection we either provide a ZIP file, export to a local directory or send your files to a remote destination.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Deployment method', 'simply-static'),
+    value: deliveryMethod,
+    options: deploymentOptions,
+    onChange: method => {
+      setDeliveryMethod(method);
+      updateSetting('delivery_method', method);
+      setTestDisabled(true);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), deliveryMethod === 'simply-static-studio' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Static Studio', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('The all-in-one Static WordPress cloud-hosting platform.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Enjoy secure WordPress, the fastest exports, and the best-performing static site hosting in one package.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("a", {
+    class: "button button-primary",
+    href: "https://simplystatic.com/simply-static-studio/",
+    target: "_blank"
+  }, "Check out Static Studio")))), deliveryMethod === 'zip' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('ZIP', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+    title: __('How to export a ZIP file', 'simply-static'),
+    videoUrl: 'https://youtu.be/WHaFjDte6zI'
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Get a download link in the activity log once the static export has finished.', 'simply-static')))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), deliveryMethod === 'local' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Local Directory', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+    title: __('How to deploy to a local directory', 'simply-static'),
+    videoUrl: 'https://youtu.be/ZRdXQB5slnY'
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Path', 'simply-static'),
+    type: "text",
+    help: __("This is the directory where your static files will be saved. We will create it automatically on the first export if it doesn't exist.", 'simply-static'),
+    placeholder: options.home_path + "public_static/",
+    value: settings.local_dir,
+    onChange: path => {
+      updateSetting('local_dir', path);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ClipboardButton, {
+    variant: "secondary",
+    text: options.home_path,
+    onCopy: () => setHasCopied(true),
+    onFinishCopy: () => setHasCopied(false)
+  }, hasCopied ? __('Copied home path', 'simply-static') : __('Copy home path', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Clear Local Directory', 'simply-static'),
+    help: clearDirectory ? __('Clear local directory before running an export.', 'simply-static') : __('Don\'t clear local directory before running an export.', 'simply-static'),
+    checked: clearDirectory,
+    onChange: value => {
+      setClearDirectory(value);
+      updateSetting('clear_directory_before_export', value);
+    }
+  })))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, deliveryMethod === 'github' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('GitHub', 'simply-static'), " ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+    title: __('How to deploy to a GitHub (2/2)', 'simply-static'),
+    videoUrl: 'https://youtu.be/HqyTKwZuUAM'
+  }))), ('free' === options.plan || !isPro()) && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ExternalLink, {
+    href: "https://simplystatic.com"
+  }, " ", __('Requires Simply Static Pro', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('GitHub enables you to export your static website to one of the common static hosting providers like Netlify, Cloudflare Pages or GitHub Pages.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Account Type', 'simply-static'),
+    value: githubAccountType,
+    help: __('Depending on the account type the settings fields will change.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    options: [{
+      label: __('Personal', 'simply-static'),
+      value: 'personal'
+    }, {
+      label: __('Organization', 'simply-static'),
+      value: 'organization'
+    }],
+    onChange: type => {
+      setGithubAccountType(type);
+      updateSetting('github_account_type', type);
+    }
+  }), githubAccountType === 'organization' ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Organization', 'simply-static'),
+    type: "text",
+    help: __('Enter the name of your organization.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.github_user,
+    onChange: organization => {
+      updateSetting('github_user', organization);
+    }
+  }) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Username', 'simply-static'),
+    type: "text",
+    help: __('Enter your GitHub username.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.github_user,
+    onChange: name => {
+      updateSetting('github_user', name);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('E-Mail', 'simply-static'),
+    type: "email",
+    help: __('Enter your GitHub email address. This will be used to commit files to your repository.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.github_email,
+    onChange: email => {
+      updateSetting('github_email', email);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, __('Personal Access Token', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+      title: __('How to prepare your GitHub account', 'simply-static'),
+      videoUrl: 'https://youtu.be/fjsJJmPeKuc'
+    })),
+    type: "password",
+    help: (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, __('You need a personal access token from GitHub. Learn how to get one ', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("a", {
+      href: "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic",
+      target: "_blank"
+    }, __('here', 'simply-static'))),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.github_personal_access_token,
+    onChange: token => {
+      updateSetting('github_personal_access_token', token);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Repository', 'simply-static'),
+    type: "text",
+    help: __('Enter a name for your repository (lowercase without spaces or special characters).', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.github_repository,
+    onChange: repository => {
+      updateSetting('github_repository', repository);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "warning",
+    isDismissible: false
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Ensure to create the repository and add a readme file to it before running an export as shown in the docs ', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("a", {
+    href: "https://docs.simplystatic.com/article/33-set-up-the-github-integration/",
+    target: "_blank"
+  }, __('here', 'simply-static')))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Folder', 'simply-static'),
+    type: "text",
+    help: __('Enter a relative path to a folder if you want to push files under it. Example: for github.com/USER/REPOSITORY/folder1, enter folder1', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.github_folder_path,
+    onChange: repository => {
+      updateSetting('github_folder_path', repository);
+    }
+  }), githubAccountType === 'organization' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "warning",
+    isDismissible: false
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('You need to create the repository manually within your organization before connecting it.', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  })), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Visiblity', 'simply-static'),
+    value: githubVisibility,
+    help: __('Decide if you want to make your repository public or private.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    options: [{
+      label: __('Public', 'simply-static'),
+      value: 'public'
+    }, {
+      label: __('Private', 'simply-static'),
+      value: 'private'
+    }],
+    onChange: visibility => {
+      setGithubVisibility(visibility);
+      updateSetting('github_repository_visibility', visibility);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Branch', 'simply-static'),
+    type: settings.github_branch,
+    placeholder: "main",
+    help: __('Simply Static automatically uses "main" as branch. You may want to modify that for example to gh-pages. for GitHub Pages.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.github_branch,
+    onChange: branch => {
+      updateSetting('github_branch', branch);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Webhook URL', 'simply-static'),
+    type: "url",
+    help: __('Enter your Webhook URL here and Simply Static will send a POST request after all files are commited to GitHub.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.github_webhook_url,
+    onChange: webhook => {
+      updateSetting('github_webhook_url', webhook);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Throttle Requests', 'simply-static'),
+    help: __('Enable this option if you are experiencing issues with the GitHub API rate limit.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    checked: throttleGitHubRequests,
+    onChange: value => {
+      setThrottleGitHubRequests(value);
+      updateSetting('github_throttle_requests', value);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Batch size', 'simply-static'),
+    type: "number",
+    help: __('Enter the number of files you want to be processed in a single batch. If current export fails to deploy, lower the number.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: (_settings$github_batc = settings.github_batch_size) !== null && _settings$github_batc !== void 0 ? _settings$github_batc : 100,
+    onChange: size => {
+      updateSetting('github_batch_size', size);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), deliveryMethod === 'tiiny' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Tiiny.host', 'simply-static'), " ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+    title: __('How to deploy to Tiiny.host', 'simply-static'),
+    videoUrl: 'https://youtu.be/Y9EDaQkGl1Y'
+  }))), ('free' === options.plan || !isPro()) && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ExternalLink, {
+    href: "https://simplystatic.com"
+  }, " ", __('Requires Simply Static Pro', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Deploying to Tiiny.host is the easiest and fastest deployment option available in Simply Static Pro.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    disabled: true,
+    label: __('E-Mail', 'simply-static'),
+    type: "text",
+    help: (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, __('This field is auto-filled with the e-mail address used for activating Simply Static Pro.', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('An account will be created automatically on your first deployment.', 'simply-static'))),
+    value: options.admin_email
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Subdomain', 'simply-static'),
+    type: "text",
+    help: __('That\'s the part before your TLD. Your full URL is the combination of the subdomain plus the domain suffix.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.tiiny_subdomain,
+    onChange: subdomain => {
+      updateSetting('tiiny_subdomain', subdomain);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Domain Suffix', 'simply-static'),
+    type: "text",
+    help: __('This defaults to tiiny.site. If you have a custom domain configured in Tiiny.host, you can also use  that one.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.tiiny_domain_suffix,
+    onChange: suffix => {
+      updateSetting('tiiny_domain_suffix', suffix);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Password Protection', 'simply-static'),
+    type: "password",
+    help: __('Adding a password will activate password protection on your static site. The website is only visible with the password.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.tiiny_password,
+    onChange: password => {
+      updateSetting('tiiny_password', password);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), deliveryMethod === 'cdn' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Bunny CDN', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+    title: __('How to deploy to Bunny CDN', 'simply-static'),
+    videoUrl: 'https://youtu.be/FBRg1BI41VY'
+  }))), ('free' === options.plan || !isPro()) && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ExternalLink, {
+    href: "https://simplystatic.com"
+  }, " ", __('Requires Simply Static Pro', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Bunny CDN is a fast and reliable CDN provider that you can run your static website on.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Bunny CDN API Key', 'simply-static'),
+    type: "password",
+    help: (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, __('Enter your API Key from Bunny CDN. You can find your API-Key as described ', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("a", {
+      href: "https://support.bunny.net/hc/en-us/articles/360012168840-Where-do-I-find-my-API-key",
+      target: "_blank"
+    }, __('here', 'simply-static'))),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.cdn_api_key,
+    onChange: api_key => {
+      updateSetting('cdn_api_key', api_key);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Storage Host', 'simply-static'),
+    type: "text",
+    help: (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, __('Depending on your location, you have a different storage host. You find out which URL to use ', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("a", {
+      href: "https://docs.bunny.net/reference/storage-api#storage-endpoints",
+      target: "_blank"
+    }, __('here', 'simply-static'))),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.cdn_storage_host,
+    onChange: storage_host => {
+      updateSetting('cdn_storage_host', storage_host);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Bunny CDN Access Key', 'simply-static'),
+    type: "password",
+    help: __('Enter your Acess Key from Bunny CDN. You will find it within your storage zone setttings within FTP & API Access -> Password.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.cdn_access_key,
+    onChange: access_key => {
+      updateSetting('cdn_access_key', access_key);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Pull Zone', 'simply-static'),
+    type: "text",
+    help: __('A pull zone is the connection of your CDN to the internet. Simply Static will try to find an existing pull zone with the provided name, if there is none it creates a new pull zone.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.cdn_pull_zone,
+    onChange: pull_zone => {
+      updateSetting('cdn_pull_zone', pull_zone);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Storage Zone', 'simply-static'),
+    type: "text",
+    help: __('A storage zone contains your static files. Simply Static will try to find an existing storage zone with the provided name, if there is none it creates a new storage zone.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.cdn_storage_zone,
+    onChange: storage_zone => {
+      updateSetting('cdn_storage_zone', storage_zone);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Subdirectory', 'simply-static'),
+    type: "text",
+    placeholder: '/subdirectory/',
+    help: __('If you want to transfer the files to a specific subdirectory on your storage zone add the name of that directory here.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.cdn_directory,
+    onChange: directory => {
+      updateSetting('cdn_directory', directory);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), deliveryMethod === 'aws-s3' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Amazon AWS S3', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+    title: __('How to deploy to Amazon AWS S3', 'simply-static'),
+    videoUrl: 'https://youtu.be/rtn21J86Upc'
+  }))), ('free' === options.plan || !isPro()) && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ExternalLink, {
+    href: "https://simplystatic.com"
+  }, " ", __('Requires Simply Static Pro', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Authentication Method', 'simply-static'),
+    value: awsAuthMethod,
+    options: [{
+      label: __('AWS IAM Access Key', 'simply-static'),
+      value: 'aws-iam-key'
+    }, {
+      label: __('AWS EC2', 'simply-static'),
+      value: 'aws-ec2'
+    }],
+    disabled: 'free' === options.plan || !isPro(),
+    onChange: method => {
+      setAwsAuthMethod(method);
+      updateSetting('aws_auth_method', method);
+    }
+  }), awsAuthMethod === 'aws-iam-key' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Access Key ID', 'simply-static'),
+    type: "text",
+    help: (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, __('Enter your Access Key from AWS. Learn how to get one ', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("a", {
+      href: "https://docs.aws.amazon.com/en_en/IAM/latest/UserGuide/id_credentials_access-keys.html",
+      target: "_blank"
+    }, __('here', 'simply-static'))),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.aws_access_key,
+    onChange: access_key => {
+      updateSetting('aws_access_key', access_key);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Secret Access Key', 'simply-static'),
+    type: "password",
+    help: (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, __('Enter your Secret Key from AWS. Learn how to get one ', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("a", {
+      href: "https://docs.aws.amazon.com/en_en/IAM/latest/UserGuide/id_credentials_access-keys.html",
+      target: "_blank"
+    }, __('here', 'simply-static'))),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.aws_access_secret,
+    onChange: secret => {
+      updateSetting('aws_access_secret', secret);
+    }
+  })), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Region', 'simply-static'),
+    value: region,
+    options: [{
+      label: __('US East (Ohio)', 'simply-static'),
+      value: 'us-east-2'
+    }, {
+      label: __('US East (N. Virginia)', 'simply-static'),
+      value: 'us-east-1'
+    }, {
+      label: __('US West (N. California)', 'simply-static'),
+      value: 'us-west-1'
+    }, {
+      label: __('US West (Oregon)', 'simply-static'),
+      value: 'us-west-2'
+    }, {
+      label: __('Africa (Cape Town)', 'simply-static'),
+      value: 'af-south-1'
+    }, {
+      label: __('Asia Pacific (Hong Kong)', 'simply-static'),
+      value: 'ap-east-1'
+    }, {
+      label: __('Asia Pacific (Hyderabad)', 'simply-static'),
+      value: 'ap-south-2'
+    }, {
+      label: __('Asia Pacific (Jakarta)', 'simply-static'),
+      value: 'ap-southeast-3'
+    }, {
+      label: __('Asia Pacific (Melbourne)', 'simply-static'),
+      value: 'ap-southeast-4'
+    }, {
+      label: __('Asia Pacific (Mumbai)', 'simply-static'),
+      value: 'ap-south-1'
+    }, {
+      label: __('Asia Pacific (Osaka)', 'simply-static'),
+      value: 'ap-northeast-3'
+    }, {
+      label: __('Asia Pacific (Seoul)', 'simply-static'),
+      value: 'ap-northeast-2'
+    }, {
+      label: __('Asia Pacific (Singapore)', 'simply-static'),
+      value: 'ap-southeast-1'
+    }, {
+      label: __('Asia Pacific (Sydney)', 'simply-static'),
+      value: 'ap-southeast-2'
+    }, {
+      label: __('Asia Pacific (Tokyo)', 'simply-static'),
+      value: 'ap-northeast-1'
+    }, {
+      label: __('Canada (Central)', 'simply-static'),
+      value: 'ca-central-1'
+    }, {
+      label: __('Europe (Frankfurt)', 'simply-static'),
+      value: 'eu-central-1'
+    }, {
+      label: __('Europe (Ireland)', 'simply-static'),
+      value: 'eu-west-1'
+    }, {
+      label: __('Europe (London)', 'simply-static'),
+      value: 'eu-west-2'
+    }, {
+      label: __('Europe (Milan)', 'simply-static'),
+      value: 'eu-south-1'
+    }, {
+      label: __('Europe (Paris)', 'simply-static'),
+      value: 'eu-west-3'
+    }, {
+      label: __('Europe (Spain)', 'simply-static'),
+      value: 'eu-south-2'
+    }, {
+      label: __('Europe (Stockholm)', 'simply-static'),
+      value: 'eu-north-1'
+    }, {
+      label: __('Europe (Zurich)', 'simply-static'),
+      value: 'eu-central-2'
+    }, {
+      label: __('Middle East (Bahrain)', 'simply-static'),
+      value: 'me-south-1'
+    }, {
+      label: __('Middle East (UAE)', 'simply-static'),
+      value: 'me-central-1'
+    }, {
+      label: __('South America (São Paulo)', 'simply-static'),
+      value: 'sa-east-1'
+    }, {
+      label: __('AWS GovCloud (US-East)', 'simply-static'),
+      value: 'us-gov-east-1'
+    }, {
+      label: __('AWS GovCloud (US-West)', 'simply-static'),
+      value: 'us-gov-west-1'
+    }],
+    disabled: 'free' === options.plan || !isPro(),
+    onChange: region => {
+      setRegion(region);
+      updateSetting('aws_region', region);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Bucket', 'simply-static'),
+    type: "text",
+    help: __('Add the name of your bucket here.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.aws_bucket,
+    onChange: bucket => {
+      updateSetting('aws_bucket', bucket);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Subdirectory', 'simply-static'),
+    type: "text",
+    help: __('Add an optional subdirectory for your bucket', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.aws_subdirectory,
+    onChange: subdirectory => {
+      updateSetting('aws_subdirectory', subdirectory);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Cloudfront Distribution ID', 'simply-static'),
+    type: "text",
+    help: __('We automatically invalidate the cache after each export.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.aws_distribution_id,
+    onChange: distribution_id => {
+      updateSetting('aws_distribution_id', distribution_id);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Webhook URL', 'simply-static'),
+    type: "url",
+    help: __('Enter your Webhook URL here and Simply Static will send a POST request after all files are transferred to AWS S3.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.aws_webhook_url,
+    onChange: webhook => {
+      updateSetting('aws_webhook_url', webhook);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Empty bucket before new export?', 'simply-static'),
+    help: emptyBucketBeforeExport ? __('Clear bucket before new export.', 'simply-static') : __('Don\'t clear bucket before new export.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    checked: emptyBucketBeforeExport,
+    onChange: value => {
+      setEmptyBucketBeforeExport(value);
+      updateSetting('aws_empty', value);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), deliveryMethod === 'sftp' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('SFTP', 'simply-static'), " ", (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+    title: __('How to deploy via SFTP', 'simply-static'),
+    videoUrl: 'https://youtu.be/6-QR9wZA3VQ'
+  }))), ('free' === options.plan || !isPro()) && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ExternalLink, {
+    href: "https://simplystatic.com"
+  }, " ", __('Requires Simply Static Pro', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Host', 'simply-static'),
+    type: "text",
+    help: __('Enter your SFTP host.', 'simply-static'),
+    value: settings.sftp_host,
+    disabled: 'free' === options.plan || !isPro(),
+    onChange: host => {
+      updateSetting('sftp_host', host);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Port', 'simply-static'),
+    type: "number",
+    disabled: 'free' === options.plan || !isPro(),
+    help: __('Enter your SFTP port.', 'simply-static'),
+    value: settings.sftp_port,
+    onChange: port => {
+      updateSetting('sftp_port', port);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('SFTP username', 'simply-static'),
+    help: __('Enter your SFTP username.', 'simply-static'),
+    type: "text",
+    disabled: 'free' === options.plan || !isPro(),
+    placeholder: "username",
+    value: settings.sftp_user,
+    onChange: user => {
+      updateSetting('sftp_user', user);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('SFTP password', 'simply-static'),
+    type: "password",
+    disabled: 'free' === options.plan || !isPro(),
+    help: __('Enter your SFTP password.', 'simply-static'),
+    value: settings.sftp_pass,
+    onChange: pass => {
+      updateSetting('sftp_pass', pass);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextareaControl, {
+    label: __('SFTP private key', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    placeholder: __('OPTIONAL: This is only required if you need to authenticate via a private key to access your SFTP server.', 'simply-static'),
+    help: __('Enter your SFTP private key if you want passwordless upload and the server is configured to allow it. You can set it as a constant in wp-config.php by using define(\'SSP_SFTP_KEY\', \'YOUR_KEY\')', 'simply-static'),
+    value: settings.sftp_private_key,
+    onChange: pass => {
+      updateSetting('sftp_private_key', pass);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('SFTP folder', 'simply-static'),
+    help: __('Leave empty to upload to the default SFTP folder. Enter a folder path where you want the static files to be uploaded to (example: "uploads" will upload to uploads folder. "uploads/new-folder" will upload files to "new-folder"). ', 'simply-static'),
+    type: "text",
+    disabled: 'free' === options.plan || !isPro(),
+    placeholder: "",
+    value: settings.sftp_folder,
+    onChange: folder => {
+      updateSetting('sftp_folder', folder);
+    }
+  })))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), settingsSaved && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings saved successfully.', 'simply-static')))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  })), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "save-settings"
+  }, 'free' === options.plan ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, deliveryMethod === 'zip' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: setSavingSettings,
+    variant: "primary"
+  }, __('Save Settings', 'simply-static')), deliveryMethod === 'local' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: setSavingSettings,
+    variant: "primary"
+  }, __('Save Settings', 'simply-static'))) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: setSavingSettings,
+    variant: "primary"
+  }, __('Save Settings', 'simply-static')), 'pro' === options.plan && isPro() && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    disabled: isRunning || testDisabled || testRunning,
+    variant: 'secondary',
+    isBusy: isRunning || testRunning,
+    onClick: () => {
+      setTestRunning(true);
+      _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_4___default()({
+        path: '/simplystatic/v1/apply-single',
+        method: 'POST'
+      }).then(resp => {
+        if (parseInt(resp.status) === 404) {
+          alert(resp.message);
+        } else {
+          window.location.reload();
+        }
+      });
+    }
+  }, testDisabled && __('Save settings to test', 'simply-static'), !testDisabled && __('Test Deployment', 'simply-static'))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (DeploymentSettings);
+
+/***/ }),
+
+/***/ "./src/settings/pages/Diagnostics.jsx":
+/*!********************************************!*\
+  !*** ./src/settings/pages/Diagnostics.jsx ***!
+  \********************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _components_HelperVideo__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ../components/HelperVideo */ "./src/settings/components/HelperVideo.jsx");
+
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function Diagnostics() {
+  const {
+    configs,
+    resetDiagnostics
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__.SettingsContext);
+  const [isReset, setIsReset] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const runResetDiagnostics = () => {
+    resetDiagnostics();
+    setIsReset(true);
+    setTimeout(function () {
+      window.location.reload();
+    }, 2000);
+  };
+  const statusData = () => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Diagnostics', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_4__["default"], {
+    title: __('How to use diagnostics', 'simply-static'),
+    videoUrl: 'https://youtu.be/X59YMlz6F2s'
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Our diagnostics tool provides detailed insights into your WordPress installation and server configuration and tells you exactly what needs to be optimized to get the most out of Simply Static. Click the button below to get the latest results.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: runResetDiagnostics,
+    variant: "secondary"
+  }, __('Reset Diagnostics', 'simply-static'))), isReset ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Diagnostics resetted successfully.', 'simply-static')))) : '')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), Object.keys(configs).map(key => {
+    const items = configs[key];
+    return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+      key: key
+    }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, key)), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("table", {
+      style: {
+        width: "100%",
+        tableLayout: "fixed"
+      }
+    }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("tbody", {
+      className: "table-data"
+    }, Object.entries(items).map(item => {
+      return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("tr", {
+        className: "table-row",
+        key: item[0]
+      }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("td", {
+        className: "diagnostics-icon"
+      }, " ", item[1].test ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Dashicon, {
+        className: "icon-yes",
+        icon: "yes"
+      }) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Dashicon, {
+        className: "icon-no",
+        icon: "no"
+      })), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("td", {
+        className: "diagnostics-test"
+      }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, item[0])), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("td", null, item[1].test), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("td", {
+        className: "diagnostics-result"
+      }, " ", item[1].test ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, item[1].description) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, item[1].error)));
+    })))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+      margin: 5
+    }));
+  }));
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "inner-settings"
+  }, statusData());
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (Diagnostics);
+
+/***/ }),
+
+/***/ "./src/settings/pages/FormSettings.jsx":
+/*!*********************************************!*\
+  !*** ./src/settings/pages/FormSettings.jsx ***!
+  \*********************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_4__);
+/* harmony import */ var _components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ../components/HelperVideo */ "./src/settings/components/HelperVideo.jsx");
+
+
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function FormSettings() {
+  const {
+    settings,
+    updateSetting,
+    saveSettings,
+    settingsSaved,
+    setSettingsSaved,
+    isPro
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__.SettingsContext);
+  const [corsMethod, setCorsMethod] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('allowed_http_origins');
+  const [useForms, setUseForms] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [useComments, setUseComments] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [pagesSlugs, setPagesSlugs] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const setSavingSettings = () => {
+    saveSettings();
+    setSettingsSaved(true);
+    setTimeout(function () {
+      setSettingsSaved(false);
+      if (useForms) {
+        localStorage.setItem('ss-initial-page', '/forms');
+        window.location.reload();
+      }
+    }, 2000);
+  };
+  const getPages = () => {
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_4___default()({
+      path: '/simplystatic/v1/pages-slugs'
+    }).then(fetched_pages => {
+      let pages = fetched_pages;
+      pages.unshift({
+        label: __('No page selected', 'simply-static'),
+        value: ''
+      });
+      setPagesSlugs(pages);
+    });
+  };
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useEffect)(() => {
+    getPages();
+    if (settings.fix_cors) {
+      setCorsMethod(settings.fix_cors);
+    }
+    if (settings.use_forms) {
+      setUseForms(settings.use_forms);
+    }
+    if (settings.use_comments) {
+      setUseComments(settings.use_comments);
+    }
+  }, [settings]);
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "inner-settings"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Forms', 'simply-static'))), ('free' === options.plan || !isPro()) && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ExternalLink, {
+    href: "https://simplystatic.com"
+  }, " ", __('Requires Simply Static Pro', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Use forms?', 'simply-static'),
+    help: useForms ? __('Use Forms on your static website.', 'simply-static') : __('Don\'t use forms on your static website.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    checked: useForms,
+    onChange: value => {
+      setUseForms(value);
+      updateSetting('use_forms', value);
+    }
+  }), useForms && options.form_connection_url && 'free' !== options.plan && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    href: options.form_connection_url,
+    variant: "secondary"
+  }, __('Create a form connection', 'simply-static')))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Comments', 'simply-static'))), ('free' === options.plan || !isPro()) && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ExternalLink, {
+    href: "https://simplystatic.com"
+  }, " ", __('Requires Simply Static Pro', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Use comments?', 'simply-static'),
+    help: useComments ? __('Use comments on your static website.', 'simply-static') : __('Don\'t use comments on your static website.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    checked: useComments,
+    onChange: value => {
+      setUseComments(value);
+      updateSetting('use_comments', value);
+    }
+  }), useComments && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Select a redirect page', 'content-protector'),
+    options: pagesSlugs,
+    help: __('The post will be regenerated after comment submission, but it might take a while so its good practice to redirect the visitor.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.comment_redirect,
+    onChange: value => {
+      updateSetting('comment_redirect', value);
+    }
+  })))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('CORS', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+    title: __('How to deal with CORS', 'simply-static'),
+    videoUrl: 'https://youtu.be/fArtvZhkU14'
+  }))), ('free' === options.plan || !isPro()) && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ExternalLink, {
+    href: "https://simplystatic.com"
+  }, " ", __('Requires Simply Static Pro', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('When using Forms and Comments in Simply Static Pro you may encounter CORS issues as you make requests from your static website to your original one.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "warning",
+    isDismissible: false
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Due to the variety of server setups out there, you may need to make changes on your server.', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Static URL', 'simply-static'),
+    type: "url",
+    placeholder: 'https://static-site.com',
+    help: __('Add the URL of your static website to allow CORS from it.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.static_url,
+    onChange: url => {
+      updateSetting('static_url', url);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Select CORS method', 'simply-static'),
+    value: corsMethod,
+    help: __('Choose one of the methods to allow CORS for your website.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    options: [{
+      label: 'allowed_http_origins',
+      value: 'allowed_http_origins'
+    }, {
+      label: 'wp_headers',
+      value: 'wp_headers'
+    }],
+    onChange: method => {
+      setCorsMethod(method);
+      updateSetting('fix_cors', method);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Embed Dynamic Content (iFrame)', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+    title: __('Embed Dynamic Content (iFrame)', 'simply-static'),
+    videoUrl: 'https://youtu.be/ZGRaG_Jma7E'
+  }))), ('free' === options.plan || !isPro()) && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ExternalLink, {
+    href: "https://simplystatic.com"
+  }, " ", __('Requires Simply Static Pro', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('We replace the HTML of the URLs with an iFrame that embeds the content directly from your WordPress website.', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), __('This way you can use dynamic elements on your static website without the need of a specific integration.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "warning",
+    isDismissible: false
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('This requires your WordPress website to be online all the time.', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextareaControl, {
+    label: __('URLs to embed as an iFrame', 'simply-static'),
+    placeholder: options.home + "/my-form-page/",
+    help: __('If you want to embed specific pages from your WordPress website into your static website, add the URLs here (one per line).', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.iframe_urls,
+    onChange: value => {
+      updateSetting('iframe_urls', value);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextareaControl, {
+    label: __('Custom CSS', 'simply-static'),
+    help: __('These styles will only apply to the embedded pages, not your entire website.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.iframe_custom_css,
+    onChange: value => {
+      updateSetting('iframe_custom_css', value);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), settingsSaved && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings saved successfully.', 'simply-static')))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  })), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "save-settings"
+  }, 'pro' === options.plan && isPro() && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: setSavingSettings,
+    variant: "primary"
+  }, __('Save Settings', 'simply-static'))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (FormSettings);
+
+/***/ }),
+
+/***/ "./src/settings/pages/GeneralSettings.jsx":
+/*!************************************************!*\
+  !*** ./src/settings/pages/GeneralSettings.jsx ***!
+  \************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ../components/HelperVideo */ "./src/settings/components/HelperVideo.jsx");
+
+
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function GeneralSettings() {
+  const {
+    settings,
+    updateSetting,
+    saveSettings,
+    settingsSaved,
+    setSettingsSaved,
+    isPro
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_4__.SettingsContext);
+  const [replaceType, setReplaceType] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)('relative');
+  const [useForms, setUseForms] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)(false);
+  const [scheme, setScheme] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)('https://');
+  const [host, setHost] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)('');
+  const [path, setPath] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)('/');
+  const [forceURLReplacement, setForceURLReplacement] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)(false);
+  const [hasCopied, setHasCopied] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)(false);
+  const [generate404, setGenerate404] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)(false);
+  const [enableEnhancedCrawl, setEnableEnhancedCrawl] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)(false);
+  const [addFeeds, setAddFeeds] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)(false);
+  const [addRestApi, setAddRestApi] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)(false);
+  const [crawlers, setCrawlers] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)([]);
+  const [selectedCrawlers, setSelectedCrawlers] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)([]);
+  const [apiError, setApiError] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)(null);
+  const [postTypes, setPostTypes] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)([]);
+  const [selectedPostTypes, setSelectedPostTypes] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)([]);
+  const [postTypesApiError, setPostTypesApiError] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useState)(null);
+  const setSavingSettings = () => {
+    saveSettings();
+    setSettingsSaved(true);
+    setTimeout(function () {
+      setSettingsSaved(false);
+    }, 2000);
+  };
+
+  // Function to fetch crawlers from API
+  const fetchCrawlers = () => {
+    // Reset API error
+    setApiError(null);
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default()({
+      path: '/simplystatic/v1/crawlers',
+      // Use raw: true to get the raw response
+      parse: true
+    }).then(response => {
+      // Check if response is a string (JSON) and try to parse it
+      if (typeof response === 'string') {
+        try {
+          response = JSON.parse(response);
+        } catch (e) {
+          setApiError('Error parsing API response: ' + e.message);
+          return;
+        }
+      }
+      if (response && response.data && response.data.length > 0) {
+        setCrawlers(response.data);
+
+        // If no crawlers are selected or settings.crawlers is not an array, select defaults by active flag
+        // This ensures that if active_crawlers is empty (like when it's enabled for the first time),
+        // only crawlers active by default are added by default
+        if (!settings.crawlers || !Array.isArray(settings.crawlers) || settings.crawlers.length === 0) {
+          const defaultCrawlerIds = response.data.filter(crawler => crawler.active).map(crawler => crawler.id);
+          setSelectedCrawlers(defaultCrawlerIds);
+          updateSetting('crawlers', defaultCrawlerIds);
+        } else if (Array.isArray(settings.crawlers)) {
+          // Ensure all selected crawlers exist in the crawlers list
+          const validCrawlerIds = settings.crawlers.filter(id => response.data.some(crawler => crawler.id === id));
+
+          // If no valid crawlers are selected, select all by default
+          if (validCrawlerIds.length === 0) {
+            const allCrawlerIds = response.data.map(crawler => crawler.id);
+            setSelectedCrawlers(allCrawlerIds);
+            updateSetting('crawlers', allCrawlerIds);
+          } else {
+            setSelectedCrawlers(validCrawlerIds);
+          }
+        }
+      } else {
+        setApiError('Invalid API response structure or empty crawlers array');
+      }
+    }).catch(error => {
+      setApiError('Error fetching crawlers: ' + (error.message || 'Unknown error'));
+    });
+  };
+
+  // Function to fetch post types from API
+  const fetchPostTypes = () => {
+    // Reset API error
+    setPostTypesApiError(null);
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_2___default()({
+      path: '/simplystatic/v1/post-types',
+      parse: true
+    }).then(response => {
+      // Check if response is a string (JSON) and try to parse it
+      if (typeof response === 'string') {
+        try {
+          response = JSON.parse(response);
+        } catch (e) {
+          setPostTypesApiError('Error parsing API response: ' + e.message);
+          return;
+        }
+      }
+      if (response && response.data && response.data.length > 0) {
+        setPostTypes(response.data);
+
+        // If settings.post_types is not an array, initialize it as an empty array
+        if (!settings.post_types || !Array.isArray(settings.post_types)) {
+          const allPostTypeIds = response.data.map(postType => postType.name);
+          setSelectedPostTypes(allPostTypeIds);
+          updateSetting('post_types', allPostTypeIds);
+        } else if (Array.isArray(settings.post_types)) {
+          // Ensure all selected post types exist in the post types list
+          const validPostTypeIds = settings.post_types.filter(name => response.data.some(postType => postType.name === name));
+
+          // If no valid post types are selected, select all by default
+          if (validPostTypeIds.length === 0) {
+            const allPostTypeIds = response.data.map(postType => postType.name);
+            setSelectedPostTypes(allPostTypeIds);
+            updateSetting('post_types', allPostTypeIds);
+          } else {
+            setSelectedPostTypes(validPostTypeIds);
+          }
+        }
+      } else {
+        setPostTypesApiError('Invalid API response structure or empty post types array');
+      }
+    }).catch(error => {
+      setPostTypesApiError('Error fetching post types: ' + (error.message || 'Unknown error'));
+    });
+  };
+
+  // Fetch crawlers and post types when component mounts
+  // We intentionally use an empty dependency array to ensure this only runs once
+  // when the component mounts, not on every settings change
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useEffect)(() => {
+    fetchCrawlers();
+    fetchPostTypes();
+  }, []);
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_3__.useEffect)(() => {
+    if (settings.destination_url_type) {
+      setReplaceType(settings.destination_url_type);
+    }
+    if (settings.destination_scheme) {
+      setScheme(settings.destination_scheme);
+    }
+    if (settings.destination_host) {
+      setHost(settings.destination_host);
+    }
+    if (settings.relative_path) {
+      setPath(settings.relative_path);
+    }
+    if (settings.use_forms || settings.use_comments) {
+      setUseForms(true);
+    }
+    if (settings.force_replace_url) {
+      setForceURLReplacement(settings.force_replace_url);
+    }
+    if (settings.generate_404) {
+      setGenerate404(settings.generate_404);
+    }
+    if (settings.add_feeds) {
+      setAddFeeds(settings.add_feeds);
+    }
+    if (settings.add_rest_api) {
+      setAddRestApi(settings.add_rest_api);
+    }
+    if (settings.smart_crawl) {
+      setEnableEnhancedCrawl(settings.smart_crawl);
+    }
+    if (settings.crawlers) {
+      setSelectedCrawlers(settings.crawlers);
+    }
+    if (settings.post_types !== undefined) {
+      setSelectedPostTypes(Array.isArray(settings.post_types) ? settings.post_types : []);
+    }
+  }, [settings]);
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "inner-settings"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Replacing URLs', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+    title: __('How to replace URLs', 'simply-static'),
+    videoUrl: 'https://youtu.be/cb8jAMJlfGI'
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('When exporting your static site, any links to your WordPress site will be replaced by one of the following: absolute URLs, relative URLs, or URLs contructed for offline use.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Replacing URLs', 'simply-static'),
+    value: replaceType,
+    options: [{
+      label: __('Absolute URLs', 'simply-static'),
+      value: 'absolute'
+    }, {
+      label: __('Relative Path', 'simply-static'),
+      value: 'relative'
+    }, {
+      label: __('Offline Usage', 'simply-static'),
+      value: 'offline'
+    }],
+    onChange: type => {
+      setReplaceType(type);
+      updateSetting('destination_url_type', type);
+    }
+  }), replaceType === 'absolute' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, {
+    style: {
+      minWidth: "15%"
+    }
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Scheme', 'simply-static'),
+    value: scheme,
+    options: [{
+      label: 'https://',
+      value: 'https://'
+    }, {
+      label: 'http://',
+      value: 'http://'
+    }, {
+      label: '//',
+      value: '//'
+    }],
+    onChange: scheme => {
+      setScheme(scheme);
+      updateSetting('destination_scheme', scheme);
+    }
+  })), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, {
+    style: {
+      minWidth: "85%"
+    }
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Host', 'simply-static'),
+    type: "text",
+    placeholder: "example.com",
+    value: host,
+    onChange: host => {
+      setHost(host);
+      updateSetting('destination_host', host);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Convert all URLs for your WordPress site to absolute URLs at the domain specified above.', 'simply-static'))), replaceType === 'relative' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Path', 'simply-static'),
+    type: "text",
+    placeholder: "/",
+    value: path,
+    onChange: path => {
+      setPath(path);
+      updateSetting('relative_path', path);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Convert all URLs for your WordPress site to relative URLs that will work at any domain.', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("br", null), __('Optionally specify a path above if you intend to place the files in a subdirectory.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "warning",
+    isDismissible: false
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Example', 'simply-static'), ": "), __('enter /path above if you wanted to serve your files at www.example.com/path/', 'simply-static')))), replaceType === 'offline' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Convert all URLs for your WordPress site so that you can browse the site locally on your own computer without hosting it on a web server.', 'simply-static')), !useForms && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Force URL replacements', 'simply-static'),
+    help: forceURLReplacement ? __('Replace all occurrences of the WordPress URL with the static URL (includes inline CSS and JS).', 'simply-static') : __('Replace only occurrences of the WordPress URL that match our tag list.', 'simply-static'),
+    checked: forceURLReplacement,
+    onChange: value => {
+      setForceURLReplacement(value);
+      updateSetting('force_replace_url', value);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Enhanced Crawl', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+    title: __('How Enhanced Crawl improves your static exports', 'simply-static'),
+    videoUrl: 'https://youtu.be/QfKxeQ1w7tU'
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Enhanced Crawl uses native WordPress functions to find all pages and files when running a static export.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, __('Enable Enhanced Crawl', 'simply-static')),
+    help: enableEnhancedCrawl ? __('Find pages and files via Enhanced Crawl.', 'simply-static') : __('Don\'t find pages and files via Enhanced Crawl.', 'simply-static'),
+    checked: enableEnhancedCrawl,
+    onChange: value => {
+      setEnableEnhancedCrawl(value);
+      updateSetting('smart_crawl', value);
+    }
+  }), enableEnhancedCrawl && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 2
+  }), apiError && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "error",
+    isDismissible: false
+  }, __('Error loading crawlers: ', 'simply-static'), " ", apiError), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 2
+  })), crawlers.length > 0 ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FormTokenField, {
+    label: __('Active Crawlers', 'simply-static'),
+    value: selectedCrawlers.map(id => {
+      const crawler = crawlers.find(c => c.id === id);
+      return crawler ? crawler.name : id;
+    }),
+    suggestions: crawlers.map(crawler => crawler.name),
+    onChange: value => {
+      // Convert names to IDs for storage
+      const selectedIds = value.map(name => {
+        // First try to find an exact match
+        let crawler = crawlers.find(c => c.name === name);
+
+        // If no exact match, try case-insensitive match
+        if (!crawler) {
+          crawler = crawlers.find(c => c.name.toLowerCase() === name.toLowerCase());
+        }
+
+        // If still no match, check if it's already an ID
+        if (!crawler) {
+          crawler = crawlers.find(c => c.id === name);
+        }
+        return crawler ? crawler.id : name;
+      });
+      setSelectedCrawlers(selectedIds);
+      updateSetting('crawlers', selectedIds);
+    },
+    help: __('Select which crawlers to activate. If none selected, all crawlers will be active by default.', 'simply-static'),
+    tokenizeOnSpace: false,
+    __experimentalExpandOnFocus: true,
+    __experimentalShowHowTo: false,
+    maxSuggestions: 100,
+    className: "horizontal-token-field"
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 2
+  }), selectedCrawlers.includes('post_type') && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 2
+  }), postTypesApiError && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "error",
+    isDismissible: false
+  }, __('Error loading post types: ', 'simply-static'), " ", postTypesApiError), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 2
+  })), postTypes.length > 0 ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FormTokenField, {
+    label: __('Post Types to Include', 'simply-static'),
+    value: Array.isArray(selectedPostTypes) ? selectedPostTypes.map(name => {
+      const postType = postTypes.find(pt => pt.name === name);
+      return postType ? postType.label : name;
+    }) : [],
+    suggestions: postTypes.map(postType => postType.label),
+    onChange: value => {
+      // Convert labels to names for storage
+      const selectedNames = value.map(label => {
+        // First try to find an exact match
+        let postType = postTypes.find(pt => pt.label === label);
+
+        // If no exact match, try case-insensitive match
+        if (!postType) {
+          postType = postTypes.find(pt => pt.label.toLowerCase() === label.toLowerCase());
+        }
+
+        // If still no match, check if it's already a name
+        if (!postType) {
+          postType = postTypes.find(pt => pt.name === label);
+        }
+        return postType ? postType.name : label;
+      });
+      setSelectedPostTypes(selectedNames);
+      updateSetting('post_types', selectedNames);
+    },
+    help: __('Select which post types to include in the static export. If you remove all selections, all post types will be included by default.', 'simply-static'),
+    tokenizeOnSpace: false,
+    __experimentalExpandOnFocus: true,
+    __experimentalShowHowTo: false,
+    maxSuggestions: 100,
+    className: "horizontal-token-field"
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 2
+  })) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Loading post types...', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "crawler-descriptions"
+  }, crawlers.map(crawler => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    key: crawler.id,
+    className: "crawler-description"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, {
+    className: "crawler-name"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("strong", null, crawler.name, ":")), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, crawler.description)))))) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Loading crawlers...', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Include', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+    title: __('Include & Exclude files and pages', 'simply-static'),
+    videoUrl: 'https://youtu.be/voAHfwVMLi8'
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextareaControl, {
+    label: __('Additional URLs', 'simply-static'),
+    placeholder: options.home + "/hidden-page/",
+    help: __('If you want to create static copies of pages or files that aren\'t linked to, add the URLs here (one per line).', 'simply-static'),
+    value: settings.additional_urls,
+    onChange: value => {
+      updateSetting('additional_urls', value);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextareaControl, {
+    label: __('Additional Files and Directories', 'simply-static'),
+    placeholder: options.home_path + "additional-directory/\n" + options.home_path + "additional-file.html",
+    help: __('Sometimes you may want to include additional files (such as files referenced via AJAX) or directories. Add the paths to those files or directories here (one per line).', 'simply-static'),
+    value: settings.additional_files,
+    onChange: value => {
+      updateSetting('additional_files', value);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ClipboardButton, {
+    variant: "secondary",
+    text: options.home_path,
+    onCopy: () => setHasCopied(true),
+    onFinishCopy: () => setHasCopied(false)
+  }, hasCopied ? __('Copied home path', 'simply-static') : __('Copy home path', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, __('Generate 404 Page?', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+      title: __('How to manage 404 pages?', 'simply-static'),
+      videoUrl: 'https://youtu.be/dnRtuQrXG-k'
+    })),
+    help: generate404 ? __('Generate a 404 page based on your theme template.', 'simply-static') : __('Don\'t generate a 404 page.', 'simply-static'),
+    checked: generate404,
+    onChange: value => {
+      setGenerate404(value);
+      updateSetting('generate_404', value);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, __('Include RSS Feeds?', 'simply-static')),
+    help: addFeeds ? __('Include feed URLs of all your posts.', 'simply-static') : __('Don\'t include feed URLs for all your posts.', 'simply-static'),
+    checked: addFeeds,
+    onChange: value => {
+      setAddFeeds(value);
+      updateSetting('add_feeds', value);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, __('Include Rest API?', 'simply-static')),
+    help: addRestApi ? __('Include all Rest API endpoints as JSON files.', 'simply-static') : __('Don\'t include Rest API endpoints as JSON files.', 'simply-static'),
+    checked: addRestApi,
+    onChange: value => {
+      setAddRestApi(value);
+      updateSetting('add_rest_api', value);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Exclude', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+    title: __('Include & Exclude files and pages', 'simply-static'),
+    videoUrl: 'https://youtu.be/voAHfwVMLi8'
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextareaControl, {
+    label: __('Urls to exclude', 'simply-static'),
+    placeholder: "some-directory\nsome-file.json\n.jpg",
+    help: __('Specify URLs (or parts of URLs) you want to exclude from the processing (one per line).', 'simply-static'),
+    value: settings.urls_to_exclude,
+    onChange: value => {
+      updateSetting('urls_to_exclude', value);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), settingsSaved && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings saved successfully.', 'simply-static')))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  })), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "save-settings"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: setSavingSettings,
+    variant: "primary"
+  }, __('Save Settings', 'simply-static'))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (GeneralSettings);
+
+/***/ }),
+
+/***/ "./src/settings/pages/Generate.jsx":
+/*!*****************************************!*\
+  !*** ./src/settings/pages/Generate.jsx ***!
+  \*****************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _components_ActivityLog__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ../components/ActivityLog */ "./src/settings/components/ActivityLog.jsx");
+/* harmony import */ var _components_ExportLog__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ../components/ExportLog */ "./src/settings/components/ExportLog.jsx");
+/* harmony import */ var _components_LogButtons__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! ../components/LogButtons */ "./src/settings/components/LogButtons.jsx");
+/* harmony import */ var _components_Sites__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(/*! ../components/Sites */ "./src/settings/components/Sites.jsx");
+
+
+
+
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function Generate() {
+  const {
+    settings,
+    blogId,
+    setBlogId
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__.SettingsContext);
+  const [selectedSiteUrl, setSelectedSiteURL] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('');
+  const [selectedSiteActivityUrl, setSelectedSiteActivityUrl] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('');
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "inner-settings"
+  }, !options.is_network && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_ActivityLog__WEBPACK_IMPORTED_MODULE_4__["default"], null), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  })), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, {
+    align: "top"
+  }, options.is_network && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, {
+    isBlock: true
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_Sites__WEBPACK_IMPORTED_MODULE_7__["default"], null))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Multisite', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Choose a site to export', 'simply-static'),
+    value: blogId,
+    options: options.sites.map(function (site) {
+      return {
+        label: `${site.name} (${site.url})`,
+        value: site.blog_id
+      };
+    }),
+    onChange: blog_id => {
+      setBlogId(blog_id);
+
+      // Update admin edit URL:
+      options.sites.some(item => {
+        if (item.blog_id === blog_id) {
+          setSelectedSiteURL(item.settings_url);
+          setSelectedSiteActivityUrl(item.activity_log_url);
+        }
+      });
+    }
+  }), selectedSiteUrl && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    isPrimary: true,
+    href: selectedSiteUrl
+  }, "Switch to Site settings"), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    style: {
+      marginLeft: "5px"
+    },
+    isSecondary: true,
+    href: selectedSiteActivityUrl
+  }, "Check progress"))))), settings.debugging_mode && options.log_file && !options.is_network && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, {
+    isBlock: true
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Debugging', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_LogButtons__WEBPACK_IMPORTED_MODULE_6__["default"], null))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Export Log', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_ExportLog__WEBPACK_IMPORTED_MODULE_5__["default"], null))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (Generate);
+
+/***/ }),
+
+/***/ "./src/settings/pages/IntegrationsSettings.jsx":
+/*!*****************************************************!*\
+  !*** ./src/settings/pages/IntegrationsSettings.jsx ***!
+  \*****************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _components_Integration__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ../components/Integration */ "./src/settings/components/Integration.jsx");
+
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function IntegrationsSettings() {
+  const {
+    settings,
+    updateSetting,
+    saveSettings,
+    settingsSaved,
+    setSettingsSaved,
+    maybeQueueIntegration,
+    maybeUnqueueIntegration
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__.SettingsContext);
+  const setSavingSettings = () => {
+    saveSettings();
+    setSettingsSaved(true);
+    setTimeout(function () {
+      setSettingsSaved(false);
+    }, 2000);
+  };
+  const saveIntegration = integration => {
+    let integrations = settings.integrations;
+    if (false === integrations) {
+      integrations = [];
+    }
+    if (integrations.indexOf(integration) >= 0) {
+      return;
+    }
+    integrations.push(integration);
+    updateSetting('integrations', integrations);
+    maybeQueueIntegration(integration);
+  };
+  const removeIntegration = integration => {
+    let integrations = settings.integrations;
+    if (false === integrations) {
+      integrations = [];
+    }
+    const index = integrations.indexOf(integration);
+    if (index < 0) {
+      return;
+    }
+    integrations.splice(index, 1);
+    updateSetting('integrations', integrations);
+    maybeUnqueueIntegration(integration);
+  };
+  const toggleIntegration = (integration, value) => {
+    if (value) {
+      saveIntegration(integration);
+    } else {
+      removeIntegration(integration);
+    }
+  };
+  const canRunIntegrations = Object.keys(options.integrations).filter(item => {
+    return options.integrations[item].can_run && !options.integrations[item].always_active;
+  });
+  const canNotRunIntegrations = Object.keys(options.integrations).filter(item => {
+    return !options.integrations[item].can_run && !options.integrations[item].always_active;
+  });
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "inner-settings"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Integrations', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, __('Control Integrations that will be active during the export of the static site.', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), canRunIntegrations.map(item => {
+    const integration = options.integrations[item];
+    return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_Integration__WEBPACK_IMPORTED_MODULE_4__["default"], {
+      integration: integration,
+      settings: settings,
+      toggleIntegration: toggleIntegration
+    });
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), canNotRunIntegrations.map(item => {
+    const integration = options.integrations[item];
+    return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_Integration__WEBPACK_IMPORTED_MODULE_4__["default"], {
+      integration: integration,
+      settings: settings,
+      toggleIntegration: toggleIntegration
+    });
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), settingsSaved && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings saved successfully.', 'simply-static')))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  })), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "save-settings"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: setSavingSettings,
+    variant: "primary"
+  }, __('Save Settings', 'simply-static'))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (IntegrationsSettings);
+
+/***/ }),
+
+/***/ "./src/settings/pages/Optimize.jsx":
+/*!*****************************************!*\
+  !*** ./src/settings/pages/Optimize.jsx ***!
+  \*****************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! @wordpress/api-fetch */ "@wordpress/api-fetch");
+/* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_4__);
+/* harmony import */ var _components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ../components/HelperVideo */ "./src/settings/components/HelperVideo.jsx");
+
+
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function Optimize() {
+  const {
+    settings,
+    updateSetting,
+    saveSettings,
+    settingsSaved,
+    setSettingsSaved,
+    isPro
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__.SettingsContext);
+  const [minifyFiles, setMinifyFiles] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [minifyHtml, setMinifyHtml] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [minifyCss, setMinifyCss] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [minifyInlineCss, setMinifyInlineCss] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [minifyJavascript, setMinifyJavascript] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [minifyInlineJavascript, setMinifyInlineJavascript] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [wpContentDirectory, setWpContentDirectory] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('wp-content');
+  const [wpIncludesDirectory, setWpIncludesDirectory] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('wp-includes');
+  const [wpUploadsDirectory, setWpUploadsDirectory] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('wp-content/uploads');
+  const [wpPluginsDirectory, setWpPluginsDirectory] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('wp-content/plugins');
+  const [wpThemesDirectory, setWpThemesDirectory] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('wp-content/themes');
+  const [themeStyleName, setThemeStyleName] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('style');
+  const [authorUrl, setAuthorUrl] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('author');
+  const [hideRESTAPI, setHideRESTAPI] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [hideStyleId, setHideStyleId] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [hideComments, setHideComments] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [hideVersion, setHideVersion] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [hidePrefetch, setHidePrefetch] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [hideGenerator, setHideGenerator] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [hideRSD, setHideRSD] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [hideEmojis, setHideEmojis] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [disableXMLRPC, setDisableXMLRPC] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [disableEmbed, setDisableEmbed] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [disableDbDebug, setDisableDbDebug] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [disableWLW, setDisableWLW] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [disableDirectory, setDisableDirectory] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [shortPixelResetting, setShortPixelResetting] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const setSavingSettings = () => {
+    saveSettings();
+    setSettingsSaved(true);
+    setTimeout(function () {
+      setSettingsSaved(false);
+    }, 2000);
+  };
+  const restoreBackups = () => {
+    setShortPixelResetting(true);
+    _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_4___default()({
+      path: '/simplystatic/v1/shortpixel-restore',
+      method: 'POST'
+    }).then(resp => {
+      const json = JSON.parse(resp);
+      setShortPixelResetting(false);
+      alert(json.message);
+    }).catch(error => {
+      setShortPixelResetting(false);
+      alert(error.message);
+    });
+  };
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useEffect)(() => {
+    if (settings.use_minify) {
+      setMinifyFiles(settings.use_minify);
+    }
+    if (settings.minify_html) {
+      setMinifyHtml(settings.minify_html);
+    }
+    if (settings.minify_css) {
+      setMinifyCss(settings.minify_css);
+    }
+    if (settings.minify_inline_css) {
+      setMinifyInlineCss(settings.minify_inline_css);
+    }
+    if (settings.minify_js) {
+      setMinifyJavascript(settings.minify_js);
+    }
+    if (settings.minify_inline_js) {
+      setMinifyInlineJavascript(settings.minify_inline_js);
+    }
+    if (settings.wp_content_directory) {
+      setWpContentDirectory(settings.wp_content_directory);
+    }
+    if (settings.wp_includes_directory) {
+      setWpIncludesDirectory(settings.wp_includes_directory);
+    }
+    if (settings.wp_uploads_directory) {
+      setWpUploadsDirectory(settings.wp_uploads_directory);
+    }
+    if (settings.wp_plugins_directory) {
+      setWpPluginsDirectory(settings.wp_plugins_directory);
+    }
+    if (settings.wp_themes_directory) {
+      setWpThemesDirectory(settings.wp_themes_directory);
+    }
+    if (settings.theme_style_name) {
+      setThemeStyleName(settings.theme_style_name);
+    }
+    if (settings.author_url) {
+      setAuthorUrl(settings.author_url);
+    }
+    if (settings.hide_comments) {
+      setHideComments(settings.hide_comments);
+    }
+    if (settings.hide_version) {
+      setHideVersion(settings.hide_version);
+    }
+    if (settings.hide_generator) {
+      setHideGenerator(settings.hide_generator);
+    }
+    if (settings.hide_prefetch) {
+      setHidePrefetch(settings.hide_prefetch);
+    }
+    if (settings.hide_rsd) {
+      setHideRSD(settings.hide_rsd);
+    }
+    if (settings.hide_emotes) {
+      setHideEmojis(settings.hide_emotes);
+    }
+    if (settings.disable_xmlrpc) {
+      setDisableXMLRPC(settings.disable_xmlrpc);
+    }
+    if (settings.disable_embed) {
+      setDisableEmbed(settings.disable_embed);
+    }
+    if (settings.disable_db_debug) {
+      setDisableDbDebug(settings.disable_db_debug);
+    }
+    if (settings.disable_wlw_manifest) {
+      setDisableWLW(settings.disable_wlw_manifest);
+    }
+    if (settings.disable_directory_browsing) {
+      setDisableDirectory(settings.disable_directory_browsing);
+    }
+  }, [settings]);
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "inner-settings"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Minify', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+    title: __('How to minify HTML, CSS and JavaScript?', 'simply-static'),
+    videoUrl: 'https://youtu.be/52IKv5ai-i4'
+  }))), ('free' === options.plan || !isPro()) && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ExternalLink, {
+    href: "https://simplystatic.com"
+  }, " ", __('Requires Simply Static Pro', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Minify Files?', 'simply-static'),
+    help: minifyFiles ? __('Enable minify files on your static website.', 'simply-static') : __('Don\'t enable minify files on your static website.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    checked: minifyFiles,
+    onChange: value => {
+      setMinifyFiles(value);
+      updateSetting('use_minify', value);
+    }
+  }), minifyFiles && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Minify HTML', 'simply-static'),
+    help: minifyHtml ? __('Minify HTML files.', 'simply-static') : __('Don\'t minify HTML files.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    checked: minifyHtml,
+    onChange: value => {
+      setMinifyHtml(value);
+      updateSetting('minify_html', value);
+    }
+  }), minifyHtml && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Leave quotes inside HTML attributes', 'simply-static'),
+    help: __('If there are issues with comments or JavaScript when minifying HTML, toggle this ON.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    checked: settings.minify_html_leave_quotes,
+    onChange: value => {
+      updateSetting('minify_html_leave_quotes', value);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Minify CSS', 'simply-static'),
+    help: minifyCss ? __('Minify CSS files.', 'simply-static') : __('Don\'t minify CSS files.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    checked: minifyCss,
+    onChange: value => {
+      setMinifyCss(value);
+      updateSetting('minify_css', value);
+    }
+  }), minifyCss && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextareaControl, {
+    label: __('Exclude Stylesheet URLs', 'simply-static'),
+    help: __('Exclude URLs from minification (one per line).', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.minify_css_exclude,
+    onChange: excludes => {
+      updateSetting('minify_css_exclude', excludes);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Minify Inline CSS', 'simply-static'),
+    help: minifyInlineCss ? __('Minify Inline CSS.', 'simply-static') : __('Don\'t minify Inline CSS.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    checked: minifyInlineCss,
+    onChange: value => {
+      setMinifyInlineCss(value);
+      updateSetting('minify_inline_css', value);
+    }
+  })), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Minify JavaScript', 'simply-static'),
+    help: minifyJavascript ? __('Minify JavaScript files.', 'simply-static') : __('Don\'t minify JavaScript files.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    checked: minifyJavascript,
+    onChange: value => {
+      setMinifyJavascript(value);
+      updateSetting('minify_js', value);
+    }
+  }), minifyJavascript && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextareaControl, {
+    label: __('Exclude JavaScript URLs', 'simply-static'),
+    help: __('Exclude URLs from minification (one per line).', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.minify_js_exclude,
+    onChange: excludes => {
+      updateSetting('minify_js_exclude', excludes);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Minify Inline JavaScript', 'simply-static'),
+    help: minifyInlineJavascript ? __('Minify Inline JavaScript.', 'simply-static') : __('Don\'t minify Inline JavaScript.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    checked: minifyInlineJavascript,
+    onChange: value => {
+      setMinifyInlineJavascript(value);
+      updateSetting('minify_inline_js', value);
+    }
+  }))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Image Optimization', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+    title: __('How to optimize images with ShortPixel?', 'simply-static'),
+    videoUrl: 'https://youtu.be/OIfKcXz3cxY'
+  }))), ('free' === options.plan || !isPro()) && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ExternalLink, {
+    href: "https://simplystatic.com"
+  }, " ", __('Requires Simply Static Pro', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Optimize Images with ShortPixel?', 'simply-static'),
+    help: settings.shortpixel_enabled ? __('Optimize images.', 'simply-static') : __('Don\'t optimize images.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    checked: settings.shortpixel_enabled,
+    onChange: value => {
+      updateSetting('shortpixel_enabled', value);
+    }
+  }), settings.shortpixel_enabled && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('ShortPixel API Key', 'simply-static'),
+    type: "password",
+    value: settings.shortpixel_api_key,
+    disabled: 'free' === options.plan || !isPro(),
+    onChange: apiKey => {
+      updateSetting('shortpixel_api_key', apiKey);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    padding: 1
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Convert to webP', 'simply-static'),
+    checked: settings.shortpixel_webp_enabled,
+    disabled: 'free' === options.plan || !isPro(),
+    onChange: value => {
+      updateSetting('shortpixel_webp_enabled', value);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    padding: 1
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Backup the original images?', 'simply-static'),
+    checked: settings.shortpixel_backup_enabled,
+    disabled: 'free' === options.plan || !isPro(),
+    onChange: value => {
+      updateSetting('shortpixel_backup_enabled', value);
+    }
+  }), settings.shortpixel_backup_enabled && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: 'warning',
+    isDismissible: false
+  }, __('It will preserve every image which might increase your disk space usage.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    padding: 1
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    disabled: shortPixelResetting,
+    onClick: restoreBackups,
+    variant: "secondary"
+  }, !shortPixelResetting && __('Restore Original Images', 'simply-static'), shortPixelResetting && [(0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Dashicon, {
+    icon: "update spin"
+  }), __('Restoring...', 'simply-static')]))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Replace', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+    title: __('How to replace WP default paths', 'simply-static'),
+    videoUrl: 'https://youtu.be/GedyNJJMGaY'
+  }))), ('free' === options.plan || !isPro()) && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ExternalLink, {
+    href: "https://simplystatic.com"
+  }, " ", __('Requires Simply Static Pro', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('wp-content directory', 'simply-static'),
+    help: __('Replace the "wp-content" directory.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    type: "text",
+    placeholder: "wp-content",
+    value: wpContentDirectory,
+    onChange: directory => {
+      updateSetting('wp_content_directory', directory);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('wp-includes directory', 'simply-static'),
+    help: __('Replace the "wp-includes" directory.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    type: "text",
+    placeholder: "wp-includes",
+    value: wpIncludesDirectory,
+    onChange: directory => {
+      updateSetting('wp_includes_directory', directory);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('uploads directory', 'simply-static'),
+    help: __('Replace the "wp-content/uploads" directory.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    type: "text",
+    placeholder: "uploads",
+    value: wpUploadsDirectory,
+    onChange: directory => {
+      setWpUploadsDirectory(directory);
+      updateSetting('wp_uploads_directory', directory);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('plugins directory', 'simply-static'),
+    help: __('Replace the "wp-content/plugins" directory.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    type: "text",
+    placeholder: "plugins",
+    value: wpPluginsDirectory,
+    onChange: directory => {
+      setWpPluginsDirectory(directory);
+      updateSetting('wp_plugins_directory', directory);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('themes directory', 'simply-static'),
+    help: __('Replace the "wp-content/themes" directory.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    type: "text",
+    placeholder: "themes",
+    value: wpThemesDirectory,
+    onChange: directory => {
+      setWpThemesDirectory(directory);
+      updateSetting('wp_themes_directory', directory);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalInputControl, {
+    label: __('Theme style name', 'simply-static'),
+    help: __('Replace the style.css filename.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    type: "text",
+    className: "ss-theme-style-name",
+    suffix: '.css',
+    placeholder: "style",
+    value: themeStyleName,
+    onChange: style => {
+      setThemeStyleName(style);
+      updateSetting('theme_style_name', style);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Author URL', 'simply-static'),
+    help: __('Replace the author url.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    type: "text",
+    placeholder: "author",
+    value: authorUrl,
+    onChange: url => {
+      setAuthorUrl(url);
+      updateSetting('author_url', url);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Hide', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+    title: __('How to hide and disable WP core features', 'simply-static'),
+    videoUrl: 'https://youtu.be/GijIsrfFB8o'
+  }))), ('free' === options.plan || !isPro()) && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ExternalLink, {
+    href: "https://simplystatic.com"
+  }, " ", __('Requires Simply Static Pro', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Hide HTML Comments', 'simply-static'),
+    checked: hideComments,
+    disabled: 'free' === options.plan || !isPro(),
+    onChange: value => {
+      setHideComments(value);
+      updateSetting('hide_comments', value);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Hide WordPress Version', 'simply-static'),
+    checked: hideVersion,
+    disabled: 'free' === options.plan || !isPro(),
+    onChange: value => {
+      setHideVersion(value);
+      updateSetting('hide_version', value);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Hide WordPress Generator Meta', 'simply-static'),
+    checked: hideGenerator,
+    disabled: 'free' === options.plan || !isPro(),
+    onChange: value => {
+      setHideGenerator(value);
+      updateSetting('hide_generator', value);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Hide DNS Prefetch WordPress link', 'simply-static'),
+    checked: hidePrefetch,
+    disabled: 'free' === options.plan || !isPro(),
+    onChange: value => {
+      setHidePrefetch(value);
+      updateSetting('hide_prefetch', value);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Hide RSD Header', 'simply-static'),
+    checked: hideRSD,
+    disabled: 'free' === options.plan || !isPro(),
+    onChange: value => {
+      setHideRSD(value);
+      updateSetting('hide_rsd', value);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Hide Emojis if you don\'t use them', 'simply-static'),
+    checked: hideEmojis,
+    disabled: 'free' === options.plan || !isPro(),
+    onChange: value => {
+      setHideEmojis(value);
+      updateSetting('hide_emotes', value);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Disable', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_5__["default"], {
+    title: __('How to hide and disable WP core features', 'simply-static'),
+    videoUrl: 'https://youtu.be/GijIsrfFB8o'
+  }))), ('free' === options.plan || !isPro()) && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ExternalLink, {
+    href: "https://simplystatic.com"
+  }, " ", __('Requires Simply Static Pro', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Disable XML-RPC', 'simply-static'),
+    checked: disableXMLRPC,
+    disabled: 'free' === options.plan || !isPro(),
+    onChange: value => {
+      setDisableXMLRPC(value);
+      updateSetting('disable_xmlrpc', value);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Disable Embed Scripts', 'simply-static'),
+    checked: disableEmbed,
+    disabled: 'free' === options.plan || !isPro(),
+    onChange: value => {
+      setDisableEmbed(value);
+      updateSetting('disable_embed', value);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Disable DB Debug in Frontend', 'simply-static'),
+    checked: disableDbDebug,
+    disabled: 'free' === options.plan || !isPro(),
+    onChange: value => {
+      setDisableDbDebug(value);
+      updateSetting('disable_db_debug', value);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Disable WLW Manifest Scripts', 'simply-static'),
+    checked: disableWLW,
+    disabled: 'free' === options.plan || !isPro(),
+    onChange: value => {
+      setDisableWLW(value);
+      updateSetting('disable_wlw_manifest', value);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), settingsSaved && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings saved successfully.', 'simply-static')))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  })), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "save-settings"
+  }, 'pro' === options.plan && isPro() && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: setSavingSettings,
+    variant: "primary"
+  }, __('Save Settings', 'simply-static'))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (Optimize);
+
+/***/ }),
+
+/***/ "./src/settings/pages/SearchSettings.jsx":
+/*!***********************************************!*\
+  !*** ./src/settings/pages/SearchSettings.jsx ***!
+  \***********************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _components_HelperVideo__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ../components/HelperVideo */ "./src/settings/components/HelperVideo.jsx");
+
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function SearchSettings() {
+  const {
+    settings,
+    updateSetting,
+    saveSettings,
+    settingsSaved,
+    setSettingsSaved,
+    isPro
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__.SettingsContext);
+  const [useSearch, setUseSearch] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [searchType, setSearchType] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)('fuse');
+  const [isMetaModalOpen, setMetaModalOpen] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const openMetaModal = () => setMetaModalOpen(true);
+  const closeMetaModal = () => setMetaModalOpen(false);
+  const setSavingSettings = () => {
+    saveSettings();
+    setSettingsSaved(true);
+    setTimeout(function () {
+      setSettingsSaved(false);
+    }, 2000);
+  };
+  (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useEffect)(() => {
+    if (settings.use_search) {
+      setUseSearch(settings.use_search);
+    }
+    if (settings.search_type) {
+      setSearchType(settings.search_type);
+    }
+  }, [settings]);
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "inner-settings"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Search', 'simply-static'))), ('free' === options.plan || !isPro()) && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ExternalLink, {
+    href: "https://simplystatic.com"
+  }, " ", __('Requires Simply Static Pro', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ToggleControl, {
+    label: __('Use search?', 'simply-static'),
+    help: useSearch ? __('Use search on your static website.', 'simply-static') : __('Don\'t use search on your static website.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    checked: useSearch,
+    onChange: value => {
+      setUseSearch(value);
+      updateSetting('use_search', value);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.SelectControl, {
+    label: __('Search Type', 'simply-static'),
+    value: searchType,
+    help: __('Decide which search type you want to use. Fuse runs locally based on a file, and Algolia is an external API service.', 'simply-static'),
+    options: [{
+      label: 'Fuse JS',
+      value: 'fuse'
+    }, {
+      label: 'Algolia API',
+      value: 'algolia'
+    }],
+    onChange: type => {
+      setSearchType(type);
+      updateSetting('search_type', type);
+    }
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, isMetaModalOpen && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Modal, {
+    title: __('How to select data with meta tags', 'simply-static'),
+    onRequestClose: closeMetaModal
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Targeting for excerpt in the meta description tag.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("pre", null, "<meta name=\"description\" content=\"This content is what we want as excerpt\" />"), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Adding such meta in the excerpt field would be:', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("pre", null, "description|content"), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Targeting for title in the property meta tag.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("pre", null, "<meta property=\"og:title\" content=\"This content is what we want as excerpt\" />"), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Adding such meta in the excerpt field would be:', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("pre", null, "property|og:title"), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('If the second item (after | ) is not <code>content</code>, we\'ll use it as value of that attribute (<code>property="og:title"</code> in this example) and use <code>content</code> for value.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("strong", null, __('Caution: Use meta tags that exist everywhere for title.', 'simply-static')))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Indexing', 'simply-static'))), ('free' === options.plan || !isPro()) && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ExternalLink, {
+    href: "https://simplystatic.com"
+  }, " ", __('Requires Simply Static Pro', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('CSS-Selector for Title', 'simply-static'),
+    type: "text",
+    placeholder: 'title',
+    help: [__('Add the CSS selector which contains the title of the page/post', 'simply-static'), ' ', (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+      variant: 'link',
+      onClick: openMetaModal
+    }, __('Or meta tags. Click for more information.', 'simply-static'))],
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.search_index_title,
+    onChange: title => {
+      updateSetting('search_index_title', title);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('CSS-Selector for Content', 'simply-static'),
+    type: "text",
+    placeholder: 'body',
+    help: [__('Add the CSS selector which contains the content of the page/post.', 'simply-static'), ' ', (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+      variant: 'link',
+      onClick: openMetaModal
+    }, __('Or meta tags. Click for more information.', 'simply-static'))],
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.search_index_content,
+    onChange: content => {
+      updateSetting('search_index_content', content);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('CSS-Selector for Excerpt', 'simply-static'),
+    type: "text",
+    placeholder: '.entry-content',
+    help: [__('Add the CSS selector which contains the excerpt of the page/post.', 'simply-static'), ' ', (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+      variant: 'link',
+      onClick: openMetaModal
+    }, __('Or meta tags. Click for more information.', 'simply-static'))],
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.search_index_excerpt,
+    onChange: excerpt => {
+      updateSetting('search_index_excerpt', excerpt);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextareaControl, {
+    label: __('Exclude URLs', 'simply-static'),
+    placeholder: "author\narchive\ncategory",
+    help: __('Exclude URLs from indexing (one per line). You can use full URLs, parts of an URL or plain words (like stop words).', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.search_excludable,
+    onChange: excludes => {
+      updateSetting('search_excludable', excludes);
+    }
+  })))), searchType === 'fuse' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Fuse.js', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_4__["default"], {
+    title: __('How to add search with FuseJS', 'simply-static'),
+    videoUrl: 'https://youtu.be/K34l1DXjCHk'
+  }))), ('free' === options.plan || !isPro()) && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ExternalLink, {
+    href: "https://simplystatic.com"
+  }, " ", __('Requires Simply Static Pro', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('CSS-Selector', 'simply-static'),
+    type: "text",
+    help: __('Add the CSS selector of your search element here.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.fuse_selector,
+    onChange: selector => {
+      updateSetting('fuse_selector', selector);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalNumberControl, {
+    label: __('Threshold', 'simply-static'),
+    isShiftStepEnabled: true,
+    step: 0.1,
+    min: 0.1,
+    max: 1,
+    help: __(' A threshold of 0.0 requires a perfect match, a threshold of 1.0 would match anything.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.fuse_threshold,
+    placeholder: 0.1,
+    onChange: threshold => {
+      updateSetting('fuse_threshold', threshold);
+    }
+  })))), searchType === 'algolia' && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Flex, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Algolia API', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_4__["default"], {
+    title: __('How to add search with the Algolia API', 'simply-static'),
+    videoUrl: 'https://youtu.be/H9PNZSl0KnU'
+  }))), ('free' === options.plan || !isPro()) && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.FlexItem, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ExternalLink, {
+    href: "https://simplystatic.com"
+  }, " ", __('Requires Simply Static Pro', 'simply-static'))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Application ID', 'simply-static'),
+    type: "password",
+    help: __('Add your Algolia App ID.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.algolia_app_id,
+    onChange: app_id => {
+      updateSetting('algolia_app_id', app_id);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Admin API Key', 'simply-static'),
+    type: "password",
+    help: __('Add your Algolia Admin API Key.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.algolia_admin_api_key,
+    onChange: api_key => {
+      updateSetting('algolia_admin_api_key', api_key);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Search-Only API Key', 'simply-static'),
+    type: "password",
+    help: __('Add your Algolia Search-Only API Key here. This is the only key that will be visible on your static site.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.algolia_search_api_key,
+    onChange: api_key => {
+      updateSetting('algolia_search_api_key', api_key);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('Name for your index', 'simply-static'),
+    type: "text",
+    help: __('Add your Algolia index name here.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.algolia_index,
+    onChange: index => {
+      updateSetting('algolia_index', index);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.TextControl, {
+    label: __('CSS-Selector', 'simply-static'),
+    type: "text",
+    help: __('Add the CSS selector of your search element here.', 'simply-static'),
+    disabled: 'free' === options.plan || !isPro(),
+    value: settings.algolia_selector,
+    onChange: selector => {
+      updateSetting('algolia_selector', selector);
+    }
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "warning",
+    isDismissible: false
+  }, __('If you have multiple search elements with different CSS selectors, separate them by a comma (,) such as: .search-field, .search-field2', 'simply-static')))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), settingsSaved && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings saved successfully.', 'simply-static')))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  })), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "save-settings"
+  }, 'pro' === options.plan && isPro() && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: setSavingSettings,
+    variant: "primary"
+  }, __('Save Settings', 'simply-static'))));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (SearchSettings);
+
+/***/ }),
+
+/***/ "./src/settings/pages/Utilities.jsx":
+/*!******************************************!*\
+  !*** ./src/settings/pages/Utilities.jsx ***!
+  \******************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../context/SettingsContext */ "./src/settings/context/SettingsContext.jsx");
+/* harmony import */ var _components_HelperVideo__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ../components/HelperVideo */ "./src/settings/components/HelperVideo.jsx");
+
+
+
+
+
+const {
+  __
+} = wp.i18n;
+function Utilities() {
+  const {
+    settings,
+    importSettings,
+    saveSettings,
+    resetSettings,
+    migrateSettings,
+    resetDatabase
+  } = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useContext)(_context_SettingsContext__WEBPACK_IMPORTED_MODULE_3__.SettingsContext);
+  const [isExport, setIsExport] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [isImport, setIsImport] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [isReset, setIsReset] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [isResetDatabase, setIsResetDatabase] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [isMigrate, setIsMigrate] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [hasCopied, setHasCopied] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const [importData, setImportData] = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_2__.useState)(false);
+  const setImportDataValue = event => {
+    setImportData(JSON.parse(event.target.value));
+  };
+  const runImportSettings = () => {
+    importSettings(importData);
+    setIsImport(true);
+    setTimeout(function () {
+      setIsImport(false);
+    }, 2000);
+  };
+  const runResetSettings = () => {
+    resetSettings();
+    setIsReset(true);
+    setTimeout(function () {
+      setIsReset(false);
+    }, 2000);
+  };
+  const runResetDatabase = () => {
+    resetDatabase();
+    setIsResetDatabase(true);
+    setTimeout(function () {
+      setIsResetDatabase(false);
+    }, 2000);
+  };
+  const runMigrateSettings = () => {
+    migrateSettings();
+    saveSettings();
+    setIsMigrate(true);
+    setTimeout(function () {
+      setIsMigrate(false);
+      location.reload();
+    }, 2000);
+  };
+  return (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
+    className: "inner-settings"
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Migrate Settings', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Migrate all of your settings to Simply Static 3.0', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: runMigrateSettings,
+    variant: "primary"
+  }, __('Migrate settings', 'simply-static'))), isMigrate ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings migration successfully.', 'simply-static')))) : '')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Export', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_4__["default"], {
+    title: __('Export & Import settings', 'simply-static'),
+    videoUrl: 'https://youtu.be/fmM123Y-gwg'
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, !isExport ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: setIsExport,
+    variant: "primary"
+  }, __('Export Settings', 'simply-static'))) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("code", null, JSON.stringify(settings))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.ClipboardButton, {
+    variant: "secondary",
+    text: JSON.stringify(settings),
+    onCopy: () => setHasCopied(true),
+    onFinishCopy: () => setHasCopied(false)
+  }, hasCopied ? __('Copied!', 'simply-static') : __('Copy export data', 'simply-static')))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Import', 'simply-static'), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_components_HelperVideo__WEBPACK_IMPORTED_MODULE_4__["default"], {
+    title: __('Export & Import settings', 'simply-static'),
+    videoUrl: 'https://youtu.be/fmM123Y-gwg'
+  }))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Paste in the JSON string you got from your export to import all settings for the plugin.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("textarea", {
+    rows: "8",
+    name: "import-data",
+    onChange: setImportDataValue
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: runImportSettings,
+    variant: "primary"
+  }, __('Import Settings', 'simply-static'))), isImport ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings imported successfully.', 'simply-static')))) : '')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.__experimentalSpacer, {
+    margin: 5
+  }), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Card, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardHeader, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("b", null, __('Reset', 'simply-static'))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.CardBody, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('By clicking the "Reset Plugin Settings", you will reset all plugin settings. This can be useful if you want to import a new set of settings or you want a fresh start.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('If you click the "Reset Database Table" button instead, you will keep all your settings, and we will only recreate our DB table.', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: runResetSettings,
+    variant: "secondary"
+  }, __('Reset Plugin Settings', 'simply-static')), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Button, {
+    onClick: runResetDatabase,
+    className: "reset-db-btn",
+    variant: "primary"
+  }, __('Reset Database Table', 'simply-static'))), isReset ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Settings resetted successfully.', 'simply-static')))) : '', isResetDatabase ? (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Animate, {
+    type: "slide-in",
+    options: {
+      origin: 'top'
+    }
+  }, () => (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_1__.Notice, {
+    status: "success",
+    isDismissible: false
+  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", null, __('Database table resetted successfully.', 'simply-static')))) : '')));
+}
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (Utilities);
+
+/***/ }),
+
+/***/ "./src/settings/settings.scss":
+/*!************************************!*\
+  !*** ./src/settings/settings.scss ***!
+  \************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+// extracted by mini-css-extract-plugin
+
+
+/***/ }),
+
+/***/ "@wordpress/api-fetch":
+/*!**********************************!*\
+  !*** external ["wp","apiFetch"] ***!
+  \**********************************/
+/***/ ((module) => {
+
+"use strict";
+module.exports = window["wp"]["apiFetch"];
+
+/***/ }),
+
+/***/ "@wordpress/components":
+/*!************************************!*\
+  !*** external ["wp","components"] ***!
+  \************************************/
+/***/ ((module) => {
+
+"use strict";
+module.exports = window["wp"]["components"];
+
+/***/ }),
+
+/***/ "@wordpress/element":
+/*!*********************************!*\
+  !*** external ["wp","element"] ***!
+  \*********************************/
+/***/ ((module) => {
+
+"use strict";
+module.exports = window["wp"]["element"];
+
+/***/ }),
+
+/***/ "react":
+/*!************************!*\
+  !*** external "React" ***!
+  \************************/
+/***/ ((module) => {
+
+"use strict";
+module.exports = window["React"];
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = __webpack_modules__;
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	(() => {
+/******/ 		// getDefaultExport function for compatibility with non-harmony modules
+/******/ 		__webpack_require__.n = (module) => {
+/******/ 			var getter = module && module.__esModule ?
+/******/ 				() => (module['default']) :
+/******/ 				() => (module);
+/******/ 			__webpack_require__.d(getter, { a: getter });
+/******/ 			return getter;
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/create fake namespace object */
+/******/ 	(() => {
+/******/ 		var getProto = Object.getPrototypeOf ? (obj) => (Object.getPrototypeOf(obj)) : (obj) => (obj.__proto__);
+/******/ 		var leafPrototypes;
+/******/ 		// create a fake namespace object
+/******/ 		// mode & 1: value is a module id, require it
+/******/ 		// mode & 2: merge all properties of value into the ns
+/******/ 		// mode & 4: return value when already ns object
+/******/ 		// mode & 16: return value when it's Promise-like
+/******/ 		// mode & 8|1: behave like require
+/******/ 		__webpack_require__.t = function(value, mode) {
+/******/ 			if(mode & 1) value = this(value);
+/******/ 			if(mode & 8) return value;
+/******/ 			if(typeof value === 'object' && value) {
+/******/ 				if((mode & 4) && value.__esModule) return value;
+/******/ 				if((mode & 16) && typeof value.then === 'function') return value;
+/******/ 			}
+/******/ 			var ns = Object.create(null);
+/******/ 			__webpack_require__.r(ns);
+/******/ 			var def = {};
+/******/ 			leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
+/******/ 			for(var current = mode & 2 && value; (typeof current == 'object' || typeof current == 'function') && !~leafPrototypes.indexOf(current); current = getProto(current)) {
+/******/ 				Object.getOwnPropertyNames(current).forEach((key) => (def[key] = () => (value[key])));
+/******/ 			}
+/******/ 			def['default'] = () => (value);
+/******/ 			__webpack_require__.d(ns, def);
+/******/ 			return ns;
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	(() => {
+/******/ 		// define getter functions for harmony exports
+/******/ 		__webpack_require__.d = (exports, definition) => {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/ensure chunk */
+/******/ 	(() => {
+/******/ 		__webpack_require__.f = {};
+/******/ 		// This file contains only the entry chunk.
+/******/ 		// The chunk loading function for additional chunks
+/******/ 		__webpack_require__.e = (chunkId) => {
+/******/ 			return Promise.all(Object.keys(__webpack_require__.f).reduce((promises, key) => {
+/******/ 				__webpack_require__.f[key](chunkId, promises);
+/******/ 				return promises;
+/******/ 			}, []));
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/get javascript chunk filename */
+/******/ 	(() => {
+/******/ 		// This function allow to reference async chunks
+/******/ 		__webpack_require__.u = (chunkId) => {
+/******/ 			// return url for filenames based on template
+/******/ 			return "" + chunkId + ".js";
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/get mini-css chunk filename */
+/******/ 	(() => {
+/******/ 		// This function allow to reference async chunks
+/******/ 		__webpack_require__.miniCssF = (chunkId) => {
+/******/ 			// return url for filenames based on template
+/******/ 			return undefined;
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/global */
+/******/ 	(() => {
+/******/ 		__webpack_require__.g = (function() {
+/******/ 			if (typeof globalThis === 'object') return globalThis;
+/******/ 			try {
+/******/ 				return this || new Function('return this')();
+/******/ 			} catch (e) {
+/******/ 				if (typeof window === 'object') return window;
+/******/ 			}
+/******/ 		})();
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	(() => {
+/******/ 		__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/load script */
+/******/ 	(() => {
+/******/ 		var inProgress = {};
+/******/ 		var dataWebpackPrefix = "simplystatic-settings:";
+/******/ 		// loadScript function to load a script via script tag
+/******/ 		__webpack_require__.l = (url, done, key, chunkId) => {
+/******/ 			if(inProgress[url]) { inProgress[url].push(done); return; }
+/******/ 			var script, needAttach;
+/******/ 			if(key !== undefined) {
+/******/ 				var scripts = document.getElementsByTagName("script");
+/******/ 				for(var i = 0; i < scripts.length; i++) {
+/******/ 					var s = scripts[i];
+/******/ 					if(s.getAttribute("src") == url || s.getAttribute("data-webpack") == dataWebpackPrefix + key) { script = s; break; }
+/******/ 				}
+/******/ 			}
+/******/ 			if(!script) {
+/******/ 				needAttach = true;
+/******/ 				script = document.createElement('script');
+/******/ 		
+/******/ 				script.charset = 'utf-8';
+/******/ 				script.timeout = 120;
+/******/ 				if (__webpack_require__.nc) {
+/******/ 					script.setAttribute("nonce", __webpack_require__.nc);
+/******/ 				}
+/******/ 				script.setAttribute("data-webpack", dataWebpackPrefix + key);
+/******/ 		
+/******/ 				script.src = url;
+/******/ 			}
+/******/ 			inProgress[url] = [done];
+/******/ 			var onScriptComplete = (prev, event) => {
+/******/ 				// avoid mem leaks in IE.
+/******/ 				script.onerror = script.onload = null;
+/******/ 				clearTimeout(timeout);
+/******/ 				var doneFns = inProgress[url];
+/******/ 				delete inProgress[url];
+/******/ 				script.parentNode && script.parentNode.removeChild(script);
+/******/ 				doneFns && doneFns.forEach((fn) => (fn(event)));
+/******/ 				if(prev) return prev(event);
+/******/ 			}
+/******/ 			var timeout = setTimeout(onScriptComplete.bind(null, undefined, { type: 'timeout', target: script }), 120000);
+/******/ 			script.onerror = onScriptComplete.bind(null, script.onerror);
+/******/ 			script.onload = onScriptComplete.bind(null, script.onload);
+/******/ 			needAttach && document.head.appendChild(script);
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/make namespace object */
+/******/ 	(() => {
+/******/ 		// define __esModule on exports
+/******/ 		__webpack_require__.r = (exports) => {
+/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 			}
+/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/publicPath */
+/******/ 	(() => {
+/******/ 		var scriptUrl;
+/******/ 		if (__webpack_require__.g.importScripts) scriptUrl = __webpack_require__.g.location + "";
+/******/ 		var document = __webpack_require__.g.document;
+/******/ 		if (!scriptUrl && document) {
+/******/ 			if (document.currentScript && document.currentScript.tagName.toUpperCase() === 'SCRIPT')
+/******/ 				scriptUrl = document.currentScript.src;
+/******/ 			if (!scriptUrl) {
+/******/ 				var scripts = document.getElementsByTagName("script");
+/******/ 				if(scripts.length) {
+/******/ 					var i = scripts.length - 1;
+/******/ 					while (i > -1 && (!scriptUrl || !/^http(s?):/.test(scriptUrl))) scriptUrl = scripts[i--].src;
+/******/ 				}
+/******/ 			}
+/******/ 		}
+/******/ 		// When supporting browsers where an automatic publicPath is not supported you must specify an output.publicPath manually via configuration
+/******/ 		// or pass an empty string ("") and set the __webpack_public_path__ variable from your code to use your own logic.
+/******/ 		if (!scriptUrl) throw new Error("Automatic publicPath is not supported in this browser");
+/******/ 		scriptUrl = scriptUrl.replace(/^blob:/, "").replace(/#.*$/, "").replace(/\?.*$/, "").replace(/\/[^\/]+$/, "/");
+/******/ 		__webpack_require__.p = scriptUrl;
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/jsonp chunk loading */
+/******/ 	(() => {
+/******/ 		// no baseURI
+/******/ 		
+/******/ 		// object to store loaded and loading chunks
+/******/ 		// undefined = chunk not loaded, null = chunk preloaded/prefetched
+/******/ 		// [resolve, reject, Promise] = chunk loading, 0 = chunk loaded
+/******/ 		var installedChunks = {
+/******/ 			"index": 0
+/******/ 		};
+/******/ 		
+/******/ 		__webpack_require__.f.j = (chunkId, promises) => {
+/******/ 				// JSONP chunk loading for javascript
+/******/ 				var installedChunkData = __webpack_require__.o(installedChunks, chunkId) ? installedChunks[chunkId] : undefined;
+/******/ 				if(installedChunkData !== 0) { // 0 means "already installed".
+/******/ 		
+/******/ 					// a Promise means "currently loading".
+/******/ 					if(installedChunkData) {
+/******/ 						promises.push(installedChunkData[2]);
+/******/ 					} else {
+/******/ 						if(true) { // all chunks have JS
+/******/ 							// setup Promise in chunk cache
+/******/ 							var promise = new Promise((resolve, reject) => (installedChunkData = installedChunks[chunkId] = [resolve, reject]));
+/******/ 							promises.push(installedChunkData[2] = promise);
+/******/ 		
+/******/ 							// start chunk loading
+/******/ 							var url = __webpack_require__.p + __webpack_require__.u(chunkId);
+/******/ 							// create error before stack unwound to get useful stacktrace later
+/******/ 							var error = new Error();
+/******/ 							var loadingEnded = (event) => {
+/******/ 								if(__webpack_require__.o(installedChunks, chunkId)) {
+/******/ 									installedChunkData = installedChunks[chunkId];
+/******/ 									if(installedChunkData !== 0) installedChunks[chunkId] = undefined;
+/******/ 									if(installedChunkData) {
+/******/ 										var errorType = event && (event.type === 'load' ? 'missing' : event.type);
+/******/ 										var realSrc = event && event.target && event.target.src;
+/******/ 										error.message = 'Loading chunk ' + chunkId + ' failed.\n(' + errorType + ': ' + realSrc + ')';
+/******/ 										error.name = 'ChunkLoadError';
+/******/ 										error.type = errorType;
+/******/ 										error.request = realSrc;
+/******/ 										installedChunkData[1](error);
+/******/ 									}
+/******/ 								}
+/******/ 							};
+/******/ 							__webpack_require__.l(url, loadingEnded, "chunk-" + chunkId, chunkId);
+/******/ 						}
+/******/ 					}
+/******/ 				}
+/******/ 		};
+/******/ 		
+/******/ 		// no prefetching
+/******/ 		
+/******/ 		// no preloaded
+/******/ 		
+/******/ 		// no HMR
+/******/ 		
+/******/ 		// no HMR manifest
+/******/ 		
+/******/ 		// no on chunks loaded
+/******/ 		
+/******/ 		// install a JSONP callback for chunk loading
+/******/ 		var webpackJsonpCallback = (parentChunkLoadingFunction, data) => {
+/******/ 			var [chunkIds, moreModules, runtime] = data;
+/******/ 			// add "moreModules" to the modules object,
+/******/ 			// then flag all "chunkIds" as loaded and fire callback
+/******/ 			var moduleId, chunkId, i = 0;
+/******/ 			if(chunkIds.some((id) => (installedChunks[id] !== 0))) {
+/******/ 				for(moduleId in moreModules) {
+/******/ 					if(__webpack_require__.o(moreModules, moduleId)) {
+/******/ 						__webpack_require__.m[moduleId] = moreModules[moduleId];
+/******/ 					}
+/******/ 				}
+/******/ 				if(runtime) var result = runtime(__webpack_require__);
+/******/ 			}
+/******/ 			if(parentChunkLoadingFunction) parentChunkLoadingFunction(data);
+/******/ 			for(;i < chunkIds.length; i++) {
+/******/ 				chunkId = chunkIds[i];
+/******/ 				if(__webpack_require__.o(installedChunks, chunkId) && installedChunks[chunkId]) {
+/******/ 					installedChunks[chunkId][0]();
+/******/ 				}
+/******/ 				installedChunks[chunkId] = 0;
+/******/ 			}
+/******/ 		
+/******/ 		}
+/******/ 		
+/******/ 		var chunkLoadingGlobal = globalThis["webpackChunksimplystatic_settings"] = globalThis["webpackChunksimplystatic_settings"] || [];
+/******/ 		chunkLoadingGlobal.forEach(webpackJsonpCallback.bind(null, 0));
+/******/ 		chunkLoadingGlobal.push = webpackJsonpCallback.bind(null, chunkLoadingGlobal.push.bind(chunkLoadingGlobal));
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/nonce */
+/******/ 	(() => {
+/******/ 		__webpack_require__.nc = undefined;
+/******/ 	})();
+/******/ 	
+/************************************************************************/
+var __webpack_exports__ = {};
+// This entry needs to be wrapped in an IIFE because it needs to be in strict mode.
+(() => {
+"use strict";
+/*!**********************!*\
+  !*** ./src/index.js ***!
+  \**********************/
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "react");
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @wordpress/element */ "@wordpress/element");
+/* harmony import */ var _wordpress_element__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_element__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _settings_Settings__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./settings/Settings */ "./src/settings/Settings.js");
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+
+
+if (options.screen === 'simplystatic-settings') {
+  let settings = (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_1__.createRoot)(document.getElementById('simplystatic-settings'));
+  settings.render((0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_settings_Settings__WEBPACK_IMPORTED_MODULE_2__["default"], null));
+}
+})();
+
+/******/ })()
+;
+//# sourceMappingURL=index.js.map

--- a/src/admin/build/index.js
+++ b/src/admin/build/index.js
@@ -5951,6 +5951,8 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_14___default = /*#__PURE__*/__webpack_require__.n(_wordpress_api_fetch__WEBPACK_IMPORTED_MODULE_14__);
 /* harmony import */ var _EnvironmentSidebar__WEBPACK_IMPORTED_MODULE_15__ = __webpack_require__(/*! ./EnvironmentSidebar */ "./src/settings/components/EnvironmentSidebar.jsx");
 /* harmony import */ var _SidebarMultisite__WEBPACK_IMPORTED_MODULE_16__ = __webpack_require__(/*! ./SidebarMultisite */ "./src/settings/components/SidebarMultisite.jsx");
+/* harmony import */ var _GenerateButtons__WEBPACK_IMPORTED_MODULE_17__ = __webpack_require__(/*! ./GenerateButtons */ "./src/settings/components/GenerateButtons.jsx");
+
 
 
 
@@ -6169,40 +6171,17 @@ function SettingsPage() {
   }, __('Export Changes', 'simply-static')) : (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("option", {
     disabled: true,
     value: "update"
-  }, __('Export Changes (Requires Simply Static Pro)', 'simply-static'))), buildOptions), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
-    className: "generate-buttons-container"
-  }, !disabledButton && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Button, {
-    onClick: () => {
-      startExport();
-    },
-    disabled: disabledButton || isDelayed,
-    className: activeItem === '/' ? 'is-active-item generate' : 'generate'
-  }, !disabledButton && [(0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
-    icon: "update"
-  }), __('Generate', 'simply-static')], !disabledButton && isDelayed > 0 && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, " ", isDelayed, "s"), disabledButton && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
-    icon: "update spin"
-  })), disabledButton && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, !isPaused && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Button, {
-    label: __('Pause', 'simply-static'),
-    className: "ss-generate-media-button",
-    showToolTip: true,
-    onClick: () => pauseExport()
-  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
-    icon: "controls-pause"
-  })), isPaused && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Button, {
-    label: __('Resume', 'simply-static'),
-    className: "ss-generate-media-button",
-    showToolTip: true,
-    onClick: () => resumeExport()
-  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
-    icon: "controls-play"
-  })), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Button, {
-    onClick: () => cancelExport(),
-    label: __('Cancel', 'simply-static'),
-    className: "ss-generate-cancel-button",
-    showToolTip: true
-  }, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.Dashicon, {
-    icon: 'no'
-  }))))), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.CardBody, null, 'pro' === options.plan && isPro() && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, !options.is_network && canRunIntegration('environments') && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_EnvironmentSidebar__WEBPACK_IMPORTED_MODULE_15__["default"], {
+  }, __('Export Changes (Requires Simply Static Pro)', 'simply-static'))), buildOptions), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_GenerateButtons__WEBPACK_IMPORTED_MODULE_17__["default"], {
+    canGenerate: !disabledButton,
+    startExport: startExport,
+    cancelExport: cancelExport,
+    pauseExport: pauseExport,
+    resumeExport: resumeExport,
+    isRunning: isRunning,
+    isPaused: isPaused,
+    isResumed: isResumed,
+    isDelayed: isDelayed
+  })), (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_5__.CardBody, null, 'pro' === options.plan && isPro() && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, !options.is_network && canRunIntegration('environments') && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(_EnvironmentSidebar__WEBPACK_IMPORTED_MODULE_15__["default"], {
     isRunning: isRunning,
     getSettings: getSettings
   })), !options.is_network && options.is_multisite && (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,react__WEBPACK_IMPORTED_MODULE_0__.createElement)("h4", {

--- a/src/admin/build/reactPlayerDailyMotion.js
+++ b/src/admin/build/reactPlayerDailyMotion.js
@@ -1,1 +1,156 @@
-(globalThis.webpackChunksimplystatic_settings=globalThis.webpackChunksimplystatic_settings||[]).push([[328],{348:(e,t,r)=>{var a,s=Object.create,i=Object.defineProperty,o=Object.getOwnPropertyDescriptor,n=Object.getOwnPropertyNames,l=Object.getPrototypeOf,p=Object.prototype.hasOwnProperty,u=(e,t,r,a)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let s of n(t))p.call(e,s)||s===r||i(e,s,{get:()=>t[s],enumerable:!(a=o(t,s))||a.enumerable});return e},h=(e,t,r)=>(((e,t,r)=>{t in e?i(e,t,{enumerable:!0,configurable:!0,writable:!0,value:r}):e[t]=r})(e,"symbol"!=typeof t?t+"":t,r),r),c={};((e,t)=>{for(var r in t)i(e,r,{get:t[r],enumerable:!0})})(c,{default:()=>g}),e.exports=(a=c,u(i({},"__esModule",{value:!0}),a));var y=((e,t,r)=>(r=null!=e?s(l(e)):{},u(e&&e.__esModule?r:i(r,"default",{value:e,enumerable:!0}),e)))(r(609)),d=r(635),m=r(327);class g extends y.Component{constructor(){super(...arguments),h(this,"callPlayer",d.callPlayer),h(this,"onDurationChange",(()=>{const e=this.getDuration();this.props.onDuration(e)})),h(this,"mute",(()=>{this.callPlayer("setMuted",!0)})),h(this,"unmute",(()=>{this.callPlayer("setMuted",!1)})),h(this,"ref",(e=>{this.container=e}))}componentDidMount(){this.props.onMount&&this.props.onMount(this)}load(e){const{controls:t,config:r,onError:a,playing:s}=this.props,[,i]=e.match(m.MATCH_URL_DAILYMOTION);this.player?this.player.load(i,{start:(0,d.parseStartTime)(e),autoplay:s}):(0,d.getSDK)("https://api.dmcdn.net/all.js","DM","dmAsyncInit",(e=>e.player)).then((s=>{if(!this.container)return;const o=s.player;this.player=new o(this.container,{width:"100%",height:"100%",video:i,params:{controls:t,autoplay:this.props.playing,mute:this.props.muted,start:(0,d.parseStartTime)(e),origin:window.location.origin,...r.params},events:{apiready:this.props.onReady,seeked:()=>this.props.onSeek(this.player.currentTime),video_end:this.props.onEnded,durationchange:this.onDurationChange,pause:this.props.onPause,playing:this.props.onPlay,waiting:this.props.onBuffer,error:e=>a(e)}})}),a)}play(){this.callPlayer("play")}pause(){this.callPlayer("pause")}stop(){}seekTo(e,t=!0){this.callPlayer("seek",e),t||this.pause()}setVolume(e){this.callPlayer("setVolume",e)}getDuration(){return this.player.duration||null}getCurrentTime(){return this.player.currentTime}getSecondsLoaded(){return this.player.bufferedTime}render(){const{display:e}=this.props,t={width:"100%",height:"100%",display:e};return y.default.createElement("div",{style:t},y.default.createElement("div",{ref:this.ref}))}}h(g,"displayName","DailyMotion"),h(g,"canPlay",m.canPlay.dailymotion),h(g,"loopOnEnded",!0)}}]);
+(globalThis["webpackChunksimplystatic_settings"] = globalThis["webpackChunksimplystatic_settings"] || []).push([["reactPlayerDailyMotion"],{
+
+/***/ "./node_modules/react-player/lib/players/DailyMotion.js":
+/*!**************************************************************!*\
+  !*** ./node_modules/react-player/lib/players/DailyMotion.js ***!
+  \**************************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var __publicField = (obj, key, value) => {
+  __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
+var DailyMotion_exports = {};
+__export(DailyMotion_exports, {
+  default: () => DailyMotion
+});
+module.exports = __toCommonJS(DailyMotion_exports);
+var import_react = __toESM(__webpack_require__(/*! react */ "react"));
+var import_utils = __webpack_require__(/*! ../utils */ "./node_modules/react-player/lib/utils.js");
+var import_patterns = __webpack_require__(/*! ../patterns */ "./node_modules/react-player/lib/patterns.js");
+const SDK_URL = "https://api.dmcdn.net/all.js";
+const SDK_GLOBAL = "DM";
+const SDK_GLOBAL_READY = "dmAsyncInit";
+class DailyMotion extends import_react.Component {
+  constructor() {
+    super(...arguments);
+    __publicField(this, "callPlayer", import_utils.callPlayer);
+    __publicField(this, "onDurationChange", () => {
+      const duration = this.getDuration();
+      this.props.onDuration(duration);
+    });
+    __publicField(this, "mute", () => {
+      this.callPlayer("setMuted", true);
+    });
+    __publicField(this, "unmute", () => {
+      this.callPlayer("setMuted", false);
+    });
+    __publicField(this, "ref", (container) => {
+      this.container = container;
+    });
+  }
+  componentDidMount() {
+    this.props.onMount && this.props.onMount(this);
+  }
+  load(url) {
+    const { controls, config, onError, playing } = this.props;
+    const [, id] = url.match(import_patterns.MATCH_URL_DAILYMOTION);
+    if (this.player) {
+      this.player.load(id, {
+        start: (0, import_utils.parseStartTime)(url),
+        autoplay: playing
+      });
+      return;
+    }
+    (0, import_utils.getSDK)(SDK_URL, SDK_GLOBAL, SDK_GLOBAL_READY, (DM) => DM.player).then((DM) => {
+      if (!this.container)
+        return;
+      const Player = DM.player;
+      this.player = new Player(this.container, {
+        width: "100%",
+        height: "100%",
+        video: id,
+        params: {
+          controls,
+          autoplay: this.props.playing,
+          mute: this.props.muted,
+          start: (0, import_utils.parseStartTime)(url),
+          origin: window.location.origin,
+          ...config.params
+        },
+        events: {
+          apiready: this.props.onReady,
+          seeked: () => this.props.onSeek(this.player.currentTime),
+          video_end: this.props.onEnded,
+          durationchange: this.onDurationChange,
+          pause: this.props.onPause,
+          playing: this.props.onPlay,
+          waiting: this.props.onBuffer,
+          error: (event) => onError(event)
+        }
+      });
+    }, onError);
+  }
+  play() {
+    this.callPlayer("play");
+  }
+  pause() {
+    this.callPlayer("pause");
+  }
+  stop() {
+  }
+  seekTo(seconds, keepPlaying = true) {
+    this.callPlayer("seek", seconds);
+    if (!keepPlaying) {
+      this.pause();
+    }
+  }
+  setVolume(fraction) {
+    this.callPlayer("setVolume", fraction);
+  }
+  getDuration() {
+    return this.player.duration || null;
+  }
+  getCurrentTime() {
+    return this.player.currentTime;
+  }
+  getSecondsLoaded() {
+    return this.player.bufferedTime;
+  }
+  render() {
+    const { display } = this.props;
+    const style = {
+      width: "100%",
+      height: "100%",
+      display
+    };
+    return /* @__PURE__ */ import_react.default.createElement("div", { style }, /* @__PURE__ */ import_react.default.createElement("div", { ref: this.ref }));
+  }
+}
+__publicField(DailyMotion, "displayName", "DailyMotion");
+__publicField(DailyMotion, "canPlay", import_patterns.canPlay.dailymotion);
+__publicField(DailyMotion, "loopOnEnded", true);
+
+
+/***/ })
+
+}]);
+//# sourceMappingURL=reactPlayerDailyMotion.js.map

--- a/src/admin/build/reactPlayerFacebook.js
+++ b/src/admin/build/reactPlayerFacebook.js
@@ -1,1 +1,157 @@
-(globalThis.webpackChunksimplystatic_settings=globalThis.webpackChunksimplystatic_settings||[]).push([[887],{343:(e,t,s)=>{var r,a=Object.create,l=Object.defineProperty,i=Object.getOwnPropertyDescriptor,o=Object.getOwnPropertyNames,n=Object.getPrototypeOf,p=Object.prototype.hasOwnProperty,u=(e,t,s,r)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let a of o(t))p.call(e,a)||a===s||l(e,a,{get:()=>t[a],enumerable:!(r=i(t,a))||r.enumerable});return e},c=(e,t,s)=>(((e,t,s)=>{t in e?l(e,t,{enumerable:!0,configurable:!0,writable:!0,value:s}):e[t]=s})(e,"symbol"!=typeof t?t+"":t,s),s),h={};((e,t)=>{for(var s in t)l(e,s,{get:t[s],enumerable:!0})})(h,{default:()=>g}),e.exports=(r=h,u(l({},"__esModule",{value:!0}),r));var y=((e,t,s)=>(s=null!=e?a(n(e)):{},u(e&&e.__esModule?s:l(s,"default",{value:e,enumerable:!0}),e)))(s(609)),b=s(635),d=s(327);const f="https://connect.facebook.net/en_US/sdk.js",m="fbAsyncInit";class g extends y.Component{constructor(){super(...arguments),c(this,"callPlayer",b.callPlayer),c(this,"playerID",this.props.config.playerId||`facebook-player-${(0,b.randomString)()}`),c(this,"mute",(()=>{this.callPlayer("mute")})),c(this,"unmute",(()=>{this.callPlayer("unmute")}))}componentDidMount(){this.props.onMount&&this.props.onMount(this)}load(e,t){t?(0,b.getSDK)(f,"FB",m).then((e=>e.XFBML.parse())):(0,b.getSDK)(f,"FB",m).then((e=>{e.init({appId:this.props.config.appId,xfbml:!0,version:this.props.config.version}),e.Event.subscribe("xfbml.render",(e=>{this.props.onLoaded()})),e.Event.subscribe("xfbml.ready",(e=>{"video"===e.type&&e.id===this.playerID&&(this.player=e.instance,this.player.subscribe("startedPlaying",this.props.onPlay),this.player.subscribe("paused",this.props.onPause),this.player.subscribe("finishedPlaying",this.props.onEnded),this.player.subscribe("startedBuffering",this.props.onBuffer),this.player.subscribe("finishedBuffering",this.props.onBufferEnd),this.player.subscribe("error",this.props.onError),this.props.muted?this.callPlayer("mute"):this.callPlayer("unmute"),this.props.onReady(),document.getElementById(this.playerID).querySelector("iframe").style.visibility="visible")}))}))}play(){this.callPlayer("play")}pause(){this.callPlayer("pause")}stop(){}seekTo(e,t=!0){this.callPlayer("seek",e),t||this.pause()}setVolume(e){this.callPlayer("setVolume",e)}getDuration(){return this.callPlayer("getDuration")}getCurrentTime(){return this.callPlayer("getCurrentPosition")}getSecondsLoaded(){return null}render(){const{attributes:e}=this.props.config;return y.default.createElement("div",{style:{width:"100%",height:"100%"},id:this.playerID,className:"fb-video","data-href":this.props.url,"data-autoplay":this.props.playing?"true":"false","data-allowfullscreen":"true","data-controls":this.props.controls?"true":"false",...e})}}c(g,"displayName","Facebook"),c(g,"canPlay",d.canPlay.facebook),c(g,"loopOnEnded",!0)}}]);
+(globalThis["webpackChunksimplystatic_settings"] = globalThis["webpackChunksimplystatic_settings"] || []).push([["reactPlayerFacebook"],{
+
+/***/ "./node_modules/react-player/lib/players/Facebook.js":
+/*!***********************************************************!*\
+  !*** ./node_modules/react-player/lib/players/Facebook.js ***!
+  \***********************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var __publicField = (obj, key, value) => {
+  __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
+var Facebook_exports = {};
+__export(Facebook_exports, {
+  default: () => Facebook
+});
+module.exports = __toCommonJS(Facebook_exports);
+var import_react = __toESM(__webpack_require__(/*! react */ "react"));
+var import_utils = __webpack_require__(/*! ../utils */ "./node_modules/react-player/lib/utils.js");
+var import_patterns = __webpack_require__(/*! ../patterns */ "./node_modules/react-player/lib/patterns.js");
+const SDK_URL = "https://connect.facebook.net/en_US/sdk.js";
+const SDK_GLOBAL = "FB";
+const SDK_GLOBAL_READY = "fbAsyncInit";
+const PLAYER_ID_PREFIX = "facebook-player-";
+class Facebook extends import_react.Component {
+  constructor() {
+    super(...arguments);
+    __publicField(this, "callPlayer", import_utils.callPlayer);
+    __publicField(this, "playerID", this.props.config.playerId || `${PLAYER_ID_PREFIX}${(0, import_utils.randomString)()}`);
+    __publicField(this, "mute", () => {
+      this.callPlayer("mute");
+    });
+    __publicField(this, "unmute", () => {
+      this.callPlayer("unmute");
+    });
+  }
+  componentDidMount() {
+    this.props.onMount && this.props.onMount(this);
+  }
+  load(url, isReady) {
+    if (isReady) {
+      (0, import_utils.getSDK)(SDK_URL, SDK_GLOBAL, SDK_GLOBAL_READY).then((FB) => FB.XFBML.parse());
+      return;
+    }
+    (0, import_utils.getSDK)(SDK_URL, SDK_GLOBAL, SDK_GLOBAL_READY).then((FB) => {
+      FB.init({
+        appId: this.props.config.appId,
+        xfbml: true,
+        version: this.props.config.version
+      });
+      FB.Event.subscribe("xfbml.render", (msg) => {
+        this.props.onLoaded();
+      });
+      FB.Event.subscribe("xfbml.ready", (msg) => {
+        if (msg.type === "video" && msg.id === this.playerID) {
+          this.player = msg.instance;
+          this.player.subscribe("startedPlaying", this.props.onPlay);
+          this.player.subscribe("paused", this.props.onPause);
+          this.player.subscribe("finishedPlaying", this.props.onEnded);
+          this.player.subscribe("startedBuffering", this.props.onBuffer);
+          this.player.subscribe("finishedBuffering", this.props.onBufferEnd);
+          this.player.subscribe("error", this.props.onError);
+          if (this.props.muted) {
+            this.callPlayer("mute");
+          } else {
+            this.callPlayer("unmute");
+          }
+          this.props.onReady();
+          document.getElementById(this.playerID).querySelector("iframe").style.visibility = "visible";
+        }
+      });
+    });
+  }
+  play() {
+    this.callPlayer("play");
+  }
+  pause() {
+    this.callPlayer("pause");
+  }
+  stop() {
+  }
+  seekTo(seconds, keepPlaying = true) {
+    this.callPlayer("seek", seconds);
+    if (!keepPlaying) {
+      this.pause();
+    }
+  }
+  setVolume(fraction) {
+    this.callPlayer("setVolume", fraction);
+  }
+  getDuration() {
+    return this.callPlayer("getDuration");
+  }
+  getCurrentTime() {
+    return this.callPlayer("getCurrentPosition");
+  }
+  getSecondsLoaded() {
+    return null;
+  }
+  render() {
+    const { attributes } = this.props.config;
+    const style = {
+      width: "100%",
+      height: "100%"
+    };
+    return /* @__PURE__ */ import_react.default.createElement(
+      "div",
+      {
+        style,
+        id: this.playerID,
+        className: "fb-video",
+        "data-href": this.props.url,
+        "data-autoplay": this.props.playing ? "true" : "false",
+        "data-allowfullscreen": "true",
+        "data-controls": this.props.controls ? "true" : "false",
+        ...attributes
+      }
+    );
+  }
+}
+__publicField(Facebook, "displayName", "Facebook");
+__publicField(Facebook, "canPlay", import_patterns.canPlay.facebook);
+__publicField(Facebook, "loopOnEnded", true);
+
+
+/***/ })
+
+}]);
+//# sourceMappingURL=reactPlayerFacebook.js.map

--- a/src/admin/build/reactPlayerFilePlayer.js
+++ b/src/admin/build/reactPlayerFilePlayer.js
@@ -1,1 +1,386 @@
-(globalThis.webpackChunksimplystatic_settings=globalThis.webpackChunksimplystatic_settings||[]).push([[458],{688:(e,t,s)=>{var r,i=Object.create,n=Object.defineProperty,o=Object.getOwnPropertyDescriptor,a=Object.getOwnPropertyNames,h=Object.getPrototypeOf,l=Object.prototype.hasOwnProperty,p=(e,t,s,r)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let i of a(t))l.call(e,i)||i===s||n(e,i,{get:()=>t[i],enumerable:!(r=o(t,i))||r.enumerable});return e},d=(e,t,s)=>(((e,t,s)=>{t in e?n(e,t,{enumerable:!0,configurable:!0,writable:!0,value:s}):e[t]=s})(e,"symbol"!=typeof t?t+"":t,s),s),u={};((e,t)=>{for(var s in t)n(e,s,{get:t[s],enumerable:!0})})(u,{default:()=>L}),e.exports=(r=u,p(n({},"__esModule",{value:!0}),r));var c=((e,t,s)=>(s=null!=e?i(h(e)):{},p(e&&e.__esModule?s:n(s,"default",{value:e,enumerable:!0}),e)))(s(609)),y=s(635),f=s(327);const m="undefined"!=typeof navigator,v=m&&"MacIntel"===navigator.platform&&navigator.maxTouchPoints>1,E=m&&(/iPad|iPhone|iPod/.test(navigator.userAgent)||v)&&!window.MSStream,P=m&&/^((?!chrome|android).)*safari/i.test(navigator.userAgent)&&!window.MSStream,g=/www\.dropbox\.com\/.+/,b=/https:\/\/watch\.cloudflarestream\.com\/([a-z0-9]+)/;class L extends c.Component{constructor(){super(...arguments),d(this,"onReady",((...e)=>this.props.onReady(...e))),d(this,"onPlay",((...e)=>this.props.onPlay(...e))),d(this,"onBuffer",((...e)=>this.props.onBuffer(...e))),d(this,"onBufferEnd",((...e)=>this.props.onBufferEnd(...e))),d(this,"onPause",((...e)=>this.props.onPause(...e))),d(this,"onEnded",((...e)=>this.props.onEnded(...e))),d(this,"onError",((...e)=>this.props.onError(...e))),d(this,"onPlayBackRateChange",(e=>this.props.onPlaybackRateChange(e.target.playbackRate))),d(this,"onEnablePIP",((...e)=>this.props.onEnablePIP(...e))),d(this,"onDisablePIP",(e=>{const{onDisablePIP:t,playing:s}=this.props;t(e),s&&this.play()})),d(this,"onPresentationModeChange",(e=>{if(this.player&&(0,y.supportsWebKitPresentationMode)(this.player)){const{webkitPresentationMode:t}=this.player;"picture-in-picture"===t?this.onEnablePIP(e):"inline"===t&&this.onDisablePIP(e)}})),d(this,"onSeek",(e=>{this.props.onSeek(e.target.currentTime)})),d(this,"mute",(()=>{this.player.muted=!0})),d(this,"unmute",(()=>{this.player.muted=!1})),d(this,"renderSourceElement",((e,t)=>"string"==typeof e?c.default.createElement("source",{key:t,src:e}):c.default.createElement("source",{key:t,...e}))),d(this,"renderTrack",((e,t)=>c.default.createElement("track",{key:t,...e}))),d(this,"ref",(e=>{this.player&&(this.prevPlayer=this.player),this.player=e}))}componentDidMount(){this.props.onMount&&this.props.onMount(this),this.addListeners(this.player);const e=this.getSource(this.props.url);e&&(this.player.src=e),(E||this.props.config.forceDisableHls)&&this.player.load()}componentDidUpdate(e){this.shouldUseAudio(this.props)!==this.shouldUseAudio(e)&&(this.removeListeners(this.prevPlayer,e.url),this.addListeners(this.player)),this.props.url===e.url||(0,y.isMediaStream)(this.props.url)||this.props.url instanceof Array||(this.player.srcObject=null)}componentWillUnmount(){this.player.removeAttribute("src"),this.removeListeners(this.player),this.hls&&this.hls.destroy()}addListeners(e){const{url:t,playsinline:s}=this.props;e.addEventListener("play",this.onPlay),e.addEventListener("waiting",this.onBuffer),e.addEventListener("playing",this.onBufferEnd),e.addEventListener("pause",this.onPause),e.addEventListener("seeked",this.onSeek),e.addEventListener("ended",this.onEnded),e.addEventListener("error",this.onError),e.addEventListener("ratechange",this.onPlayBackRateChange),e.addEventListener("enterpictureinpicture",this.onEnablePIP),e.addEventListener("leavepictureinpicture",this.onDisablePIP),e.addEventListener("webkitpresentationmodechanged",this.onPresentationModeChange),this.shouldUseHLS(t)||e.addEventListener("canplay",this.onReady),s&&(e.setAttribute("playsinline",""),e.setAttribute("webkit-playsinline",""),e.setAttribute("x5-playsinline",""))}removeListeners(e,t){e.removeEventListener("canplay",this.onReady),e.removeEventListener("play",this.onPlay),e.removeEventListener("waiting",this.onBuffer),e.removeEventListener("playing",this.onBufferEnd),e.removeEventListener("pause",this.onPause),e.removeEventListener("seeked",this.onSeek),e.removeEventListener("ended",this.onEnded),e.removeEventListener("error",this.onError),e.removeEventListener("ratechange",this.onPlayBackRateChange),e.removeEventListener("enterpictureinpicture",this.onEnablePIP),e.removeEventListener("leavepictureinpicture",this.onDisablePIP),e.removeEventListener("webkitpresentationmodechanged",this.onPresentationModeChange),this.shouldUseHLS(t)||e.removeEventListener("canplay",this.onReady)}shouldUseAudio(e){return!e.config.forceVideo&&!e.config.attributes.poster&&(f.AUDIO_EXTENSIONS.test(e.url)||e.config.forceAudio)}shouldUseHLS(e){return!!(P&&this.props.config.forceSafariHLS||this.props.config.forceHLS)||!E&&!this.props.config.forceDisableHls&&(f.HLS_EXTENSIONS.test(e)||b.test(e))}shouldUseDASH(e){return f.DASH_EXTENSIONS.test(e)||this.props.config.forceDASH}shouldUseFLV(e){return f.FLV_EXTENSIONS.test(e)||this.props.config.forceFLV}load(e){const{hlsVersion:t,hlsOptions:s,dashVersion:r,flvVersion:i}=this.props.config;if(this.hls&&this.hls.destroy(),this.dash&&this.dash.reset(),this.shouldUseHLS(e)&&(0,y.getSDK)("https://cdn.jsdelivr.net/npm/hls.js@VERSION/dist/hls.min.js".replace("VERSION",t),"Hls").then((t=>{if(this.hls=new t(s),this.hls.on(t.Events.MANIFEST_PARSED,(()=>{this.props.onReady()})),this.hls.on(t.Events.ERROR,((e,s)=>{this.props.onError(e,s,this.hls,t)})),b.test(e)){const t=e.match(b)[1];this.hls.loadSource("https://videodelivery.net/{id}/manifest/video.m3u8".replace("{id}",t))}else this.hls.loadSource(e);this.hls.attachMedia(this.player),this.props.onLoaded()})),this.shouldUseDASH(e)&&(0,y.getSDK)("https://cdnjs.cloudflare.com/ajax/libs/dashjs/VERSION/dash.all.min.js".replace("VERSION",r),"dashjs").then((t=>{this.dash=t.MediaPlayer().create(),this.dash.initialize(this.player,e,this.props.playing),this.dash.on("error",this.props.onError),parseInt(r)<3?this.dash.getDebug().setLogToBrowserConsole(!1):this.dash.updateSettings({debug:{logLevel:t.Debug.LOG_LEVEL_NONE}}),this.props.onLoaded()})),this.shouldUseFLV(e)&&(0,y.getSDK)("https://cdn.jsdelivr.net/npm/flv.js@VERSION/dist/flv.min.js".replace("VERSION",i),"flvjs").then((t=>{this.flv=t.createPlayer({type:"flv",url:e}),this.flv.attachMediaElement(this.player),this.flv.on(t.Events.ERROR,((e,s)=>{this.props.onError(e,s,this.flv,t)})),this.flv.load(),this.props.onLoaded()})),e instanceof Array)this.player.load();else if((0,y.isMediaStream)(e))try{this.player.srcObject=e}catch(t){this.player.src=window.URL.createObjectURL(e)}}play(){const e=this.player.play();e&&e.catch(this.props.onError)}pause(){this.player.pause()}stop(){this.player.removeAttribute("src"),this.dash&&this.dash.reset()}seekTo(e,t=!0){this.player.currentTime=e,t||this.pause()}setVolume(e){this.player.volume=e}enablePIP(){this.player.requestPictureInPicture&&document.pictureInPictureElement!==this.player?this.player.requestPictureInPicture():(0,y.supportsWebKitPresentationMode)(this.player)&&"picture-in-picture"!==this.player.webkitPresentationMode&&this.player.webkitSetPresentationMode("picture-in-picture")}disablePIP(){document.exitPictureInPicture&&document.pictureInPictureElement===this.player?document.exitPictureInPicture():(0,y.supportsWebKitPresentationMode)(this.player)&&"inline"!==this.player.webkitPresentationMode&&this.player.webkitSetPresentationMode("inline")}setPlaybackRate(e){try{this.player.playbackRate=e}catch(e){this.props.onError(e)}}getDuration(){if(!this.player)return null;const{duration:e,seekable:t}=this.player;return e===1/0&&t.length>0?t.end(t.length-1):e}getCurrentTime(){return this.player?this.player.currentTime:null}getSecondsLoaded(){if(!this.player)return null;const{buffered:e}=this.player;if(0===e.length)return 0;const t=e.end(e.length-1),s=this.getDuration();return t>s?s:t}getSource(e){const t=this.shouldUseHLS(e),s=this.shouldUseDASH(e),r=this.shouldUseFLV(e);if(!(e instanceof Array||(0,y.isMediaStream)(e)||t||s||r))return g.test(e)?e.replace("www.dropbox.com","dl.dropboxusercontent.com"):e}render(){const{url:e,playing:t,loop:s,controls:r,muted:i,config:n,width:o,height:a}=this.props,h=this.shouldUseAudio(this.props)?"audio":"video",l={width:"auto"===o?o:"100%",height:"auto"===a?a:"100%"};return c.default.createElement(h,{ref:this.ref,src:this.getSource(e),style:l,preload:"auto",autoPlay:t||void 0,controls:r,muted:i,loop:s,...n.attributes},e instanceof Array&&e.map(this.renderSourceElement),n.tracks.map(this.renderTrack))}}d(L,"displayName","FilePlayer"),d(L,"canPlay",f.canPlay.file)}}]);
+(globalThis["webpackChunksimplystatic_settings"] = globalThis["webpackChunksimplystatic_settings"] || []).push([["reactPlayerFilePlayer"],{
+
+/***/ "./node_modules/react-player/lib/players/FilePlayer.js":
+/*!*************************************************************!*\
+  !*** ./node_modules/react-player/lib/players/FilePlayer.js ***!
+  \*************************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var __publicField = (obj, key, value) => {
+  __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
+var FilePlayer_exports = {};
+__export(FilePlayer_exports, {
+  default: () => FilePlayer
+});
+module.exports = __toCommonJS(FilePlayer_exports);
+var import_react = __toESM(__webpack_require__(/*! react */ "react"));
+var import_utils = __webpack_require__(/*! ../utils */ "./node_modules/react-player/lib/utils.js");
+var import_patterns = __webpack_require__(/*! ../patterns */ "./node_modules/react-player/lib/patterns.js");
+const HAS_NAVIGATOR = typeof navigator !== "undefined";
+const IS_IPAD_PRO = HAS_NAVIGATOR && navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1;
+const IS_IOS = HAS_NAVIGATOR && (/iPad|iPhone|iPod/.test(navigator.userAgent) || IS_IPAD_PRO) && !window.MSStream;
+const IS_SAFARI = HAS_NAVIGATOR && /^((?!chrome|android).)*safari/i.test(navigator.userAgent) && !window.MSStream;
+const HLS_SDK_URL = "https://cdn.jsdelivr.net/npm/hls.js@VERSION/dist/hls.min.js";
+const HLS_GLOBAL = "Hls";
+const DASH_SDK_URL = "https://cdnjs.cloudflare.com/ajax/libs/dashjs/VERSION/dash.all.min.js";
+const DASH_GLOBAL = "dashjs";
+const FLV_SDK_URL = "https://cdn.jsdelivr.net/npm/flv.js@VERSION/dist/flv.min.js";
+const FLV_GLOBAL = "flvjs";
+const MATCH_DROPBOX_URL = /www\.dropbox\.com\/.+/;
+const MATCH_CLOUDFLARE_STREAM = /https:\/\/watch\.cloudflarestream\.com\/([a-z0-9]+)/;
+const REPLACE_CLOUDFLARE_STREAM = "https://videodelivery.net/{id}/manifest/video.m3u8";
+class FilePlayer extends import_react.Component {
+  constructor() {
+    super(...arguments);
+    // Proxy methods to prevent listener leaks
+    __publicField(this, "onReady", (...args) => this.props.onReady(...args));
+    __publicField(this, "onPlay", (...args) => this.props.onPlay(...args));
+    __publicField(this, "onBuffer", (...args) => this.props.onBuffer(...args));
+    __publicField(this, "onBufferEnd", (...args) => this.props.onBufferEnd(...args));
+    __publicField(this, "onPause", (...args) => this.props.onPause(...args));
+    __publicField(this, "onEnded", (...args) => this.props.onEnded(...args));
+    __publicField(this, "onError", (...args) => this.props.onError(...args));
+    __publicField(this, "onPlayBackRateChange", (event) => this.props.onPlaybackRateChange(event.target.playbackRate));
+    __publicField(this, "onEnablePIP", (...args) => this.props.onEnablePIP(...args));
+    __publicField(this, "onDisablePIP", (e) => {
+      const { onDisablePIP, playing } = this.props;
+      onDisablePIP(e);
+      if (playing) {
+        this.play();
+      }
+    });
+    __publicField(this, "onPresentationModeChange", (e) => {
+      if (this.player && (0, import_utils.supportsWebKitPresentationMode)(this.player)) {
+        const { webkitPresentationMode } = this.player;
+        if (webkitPresentationMode === "picture-in-picture") {
+          this.onEnablePIP(e);
+        } else if (webkitPresentationMode === "inline") {
+          this.onDisablePIP(e);
+        }
+      }
+    });
+    __publicField(this, "onSeek", (e) => {
+      this.props.onSeek(e.target.currentTime);
+    });
+    __publicField(this, "mute", () => {
+      this.player.muted = true;
+    });
+    __publicField(this, "unmute", () => {
+      this.player.muted = false;
+    });
+    __publicField(this, "renderSourceElement", (source, index) => {
+      if (typeof source === "string") {
+        return /* @__PURE__ */ import_react.default.createElement("source", { key: index, src: source });
+      }
+      return /* @__PURE__ */ import_react.default.createElement("source", { key: index, ...source });
+    });
+    __publicField(this, "renderTrack", (track, index) => {
+      return /* @__PURE__ */ import_react.default.createElement("track", { key: index, ...track });
+    });
+    __publicField(this, "ref", (player) => {
+      if (this.player) {
+        this.prevPlayer = this.player;
+      }
+      this.player = player;
+    });
+  }
+  componentDidMount() {
+    this.props.onMount && this.props.onMount(this);
+    this.addListeners(this.player);
+    const src = this.getSource(this.props.url);
+    if (src) {
+      this.player.src = src;
+    }
+    if (IS_IOS || this.props.config.forceDisableHls) {
+      this.player.load();
+    }
+  }
+  componentDidUpdate(prevProps) {
+    if (this.shouldUseAudio(this.props) !== this.shouldUseAudio(prevProps)) {
+      this.removeListeners(this.prevPlayer, prevProps.url);
+      this.addListeners(this.player);
+    }
+    if (this.props.url !== prevProps.url && !(0, import_utils.isMediaStream)(this.props.url) && !(this.props.url instanceof Array)) {
+      this.player.srcObject = null;
+    }
+  }
+  componentWillUnmount() {
+    this.player.removeAttribute("src");
+    this.removeListeners(this.player);
+    if (this.hls) {
+      this.hls.destroy();
+    }
+  }
+  addListeners(player) {
+    const { url, playsinline } = this.props;
+    player.addEventListener("play", this.onPlay);
+    player.addEventListener("waiting", this.onBuffer);
+    player.addEventListener("playing", this.onBufferEnd);
+    player.addEventListener("pause", this.onPause);
+    player.addEventListener("seeked", this.onSeek);
+    player.addEventListener("ended", this.onEnded);
+    player.addEventListener("error", this.onError);
+    player.addEventListener("ratechange", this.onPlayBackRateChange);
+    player.addEventListener("enterpictureinpicture", this.onEnablePIP);
+    player.addEventListener("leavepictureinpicture", this.onDisablePIP);
+    player.addEventListener("webkitpresentationmodechanged", this.onPresentationModeChange);
+    if (!this.shouldUseHLS(url)) {
+      player.addEventListener("canplay", this.onReady);
+    }
+    if (playsinline) {
+      player.setAttribute("playsinline", "");
+      player.setAttribute("webkit-playsinline", "");
+      player.setAttribute("x5-playsinline", "");
+    }
+  }
+  removeListeners(player, url) {
+    player.removeEventListener("canplay", this.onReady);
+    player.removeEventListener("play", this.onPlay);
+    player.removeEventListener("waiting", this.onBuffer);
+    player.removeEventListener("playing", this.onBufferEnd);
+    player.removeEventListener("pause", this.onPause);
+    player.removeEventListener("seeked", this.onSeek);
+    player.removeEventListener("ended", this.onEnded);
+    player.removeEventListener("error", this.onError);
+    player.removeEventListener("ratechange", this.onPlayBackRateChange);
+    player.removeEventListener("enterpictureinpicture", this.onEnablePIP);
+    player.removeEventListener("leavepictureinpicture", this.onDisablePIP);
+    player.removeEventListener("webkitpresentationmodechanged", this.onPresentationModeChange);
+    if (!this.shouldUseHLS(url)) {
+      player.removeEventListener("canplay", this.onReady);
+    }
+  }
+  shouldUseAudio(props) {
+    if (props.config.forceVideo) {
+      return false;
+    }
+    if (props.config.attributes.poster) {
+      return false;
+    }
+    return import_patterns.AUDIO_EXTENSIONS.test(props.url) || props.config.forceAudio;
+  }
+  shouldUseHLS(url) {
+    if (IS_SAFARI && this.props.config.forceSafariHLS || this.props.config.forceHLS) {
+      return true;
+    }
+    if (IS_IOS || this.props.config.forceDisableHls) {
+      return false;
+    }
+    return import_patterns.HLS_EXTENSIONS.test(url) || MATCH_CLOUDFLARE_STREAM.test(url);
+  }
+  shouldUseDASH(url) {
+    return import_patterns.DASH_EXTENSIONS.test(url) || this.props.config.forceDASH;
+  }
+  shouldUseFLV(url) {
+    return import_patterns.FLV_EXTENSIONS.test(url) || this.props.config.forceFLV;
+  }
+  load(url) {
+    const { hlsVersion, hlsOptions, dashVersion, flvVersion } = this.props.config;
+    if (this.hls) {
+      this.hls.destroy();
+    }
+    if (this.dash) {
+      this.dash.reset();
+    }
+    if (this.shouldUseHLS(url)) {
+      (0, import_utils.getSDK)(HLS_SDK_URL.replace("VERSION", hlsVersion), HLS_GLOBAL).then((Hls) => {
+        this.hls = new Hls(hlsOptions);
+        this.hls.on(Hls.Events.MANIFEST_PARSED, () => {
+          this.props.onReady();
+        });
+        this.hls.on(Hls.Events.ERROR, (e, data) => {
+          this.props.onError(e, data, this.hls, Hls);
+        });
+        if (MATCH_CLOUDFLARE_STREAM.test(url)) {
+          const id = url.match(MATCH_CLOUDFLARE_STREAM)[1];
+          this.hls.loadSource(REPLACE_CLOUDFLARE_STREAM.replace("{id}", id));
+        } else {
+          this.hls.loadSource(url);
+        }
+        this.hls.attachMedia(this.player);
+        this.props.onLoaded();
+      });
+    }
+    if (this.shouldUseDASH(url)) {
+      (0, import_utils.getSDK)(DASH_SDK_URL.replace("VERSION", dashVersion), DASH_GLOBAL).then((dashjs) => {
+        this.dash = dashjs.MediaPlayer().create();
+        this.dash.initialize(this.player, url, this.props.playing);
+        this.dash.on("error", this.props.onError);
+        if (parseInt(dashVersion) < 3) {
+          this.dash.getDebug().setLogToBrowserConsole(false);
+        } else {
+          this.dash.updateSettings({ debug: { logLevel: dashjs.Debug.LOG_LEVEL_NONE } });
+        }
+        this.props.onLoaded();
+      });
+    }
+    if (this.shouldUseFLV(url)) {
+      (0, import_utils.getSDK)(FLV_SDK_URL.replace("VERSION", flvVersion), FLV_GLOBAL).then((flvjs) => {
+        this.flv = flvjs.createPlayer({ type: "flv", url });
+        this.flv.attachMediaElement(this.player);
+        this.flv.on(flvjs.Events.ERROR, (e, data) => {
+          this.props.onError(e, data, this.flv, flvjs);
+        });
+        this.flv.load();
+        this.props.onLoaded();
+      });
+    }
+    if (url instanceof Array) {
+      this.player.load();
+    } else if ((0, import_utils.isMediaStream)(url)) {
+      try {
+        this.player.srcObject = url;
+      } catch (e) {
+        this.player.src = window.URL.createObjectURL(url);
+      }
+    }
+  }
+  play() {
+    const promise = this.player.play();
+    if (promise) {
+      promise.catch(this.props.onError);
+    }
+  }
+  pause() {
+    this.player.pause();
+  }
+  stop() {
+    this.player.removeAttribute("src");
+    if (this.dash) {
+      this.dash.reset();
+    }
+  }
+  seekTo(seconds, keepPlaying = true) {
+    this.player.currentTime = seconds;
+    if (!keepPlaying) {
+      this.pause();
+    }
+  }
+  setVolume(fraction) {
+    this.player.volume = fraction;
+  }
+  enablePIP() {
+    if (this.player.requestPictureInPicture && document.pictureInPictureElement !== this.player) {
+      this.player.requestPictureInPicture();
+    } else if ((0, import_utils.supportsWebKitPresentationMode)(this.player) && this.player.webkitPresentationMode !== "picture-in-picture") {
+      this.player.webkitSetPresentationMode("picture-in-picture");
+    }
+  }
+  disablePIP() {
+    if (document.exitPictureInPicture && document.pictureInPictureElement === this.player) {
+      document.exitPictureInPicture();
+    } else if ((0, import_utils.supportsWebKitPresentationMode)(this.player) && this.player.webkitPresentationMode !== "inline") {
+      this.player.webkitSetPresentationMode("inline");
+    }
+  }
+  setPlaybackRate(rate) {
+    try {
+      this.player.playbackRate = rate;
+    } catch (error) {
+      this.props.onError(error);
+    }
+  }
+  getDuration() {
+    if (!this.player)
+      return null;
+    const { duration, seekable } = this.player;
+    if (duration === Infinity && seekable.length > 0) {
+      return seekable.end(seekable.length - 1);
+    }
+    return duration;
+  }
+  getCurrentTime() {
+    if (!this.player)
+      return null;
+    return this.player.currentTime;
+  }
+  getSecondsLoaded() {
+    if (!this.player)
+      return null;
+    const { buffered } = this.player;
+    if (buffered.length === 0) {
+      return 0;
+    }
+    const end = buffered.end(buffered.length - 1);
+    const duration = this.getDuration();
+    if (end > duration) {
+      return duration;
+    }
+    return end;
+  }
+  getSource(url) {
+    const useHLS = this.shouldUseHLS(url);
+    const useDASH = this.shouldUseDASH(url);
+    const useFLV = this.shouldUseFLV(url);
+    if (url instanceof Array || (0, import_utils.isMediaStream)(url) || useHLS || useDASH || useFLV) {
+      return void 0;
+    }
+    if (MATCH_DROPBOX_URL.test(url)) {
+      return url.replace("www.dropbox.com", "dl.dropboxusercontent.com");
+    }
+    return url;
+  }
+  render() {
+    const { url, playing, loop, controls, muted, config, width, height } = this.props;
+    const useAudio = this.shouldUseAudio(this.props);
+    const Element = useAudio ? "audio" : "video";
+    const style = {
+      width: width === "auto" ? width : "100%",
+      height: height === "auto" ? height : "100%"
+    };
+    return /* @__PURE__ */ import_react.default.createElement(
+      Element,
+      {
+        ref: this.ref,
+        src: this.getSource(url),
+        style,
+        preload: "auto",
+        autoPlay: playing || void 0,
+        controls,
+        muted,
+        loop,
+        ...config.attributes
+      },
+      url instanceof Array && url.map(this.renderSourceElement),
+      config.tracks.map(this.renderTrack)
+    );
+  }
+}
+__publicField(FilePlayer, "displayName", "FilePlayer");
+__publicField(FilePlayer, "canPlay", import_patterns.canPlay.file);
+
+
+/***/ })
+
+}]);
+//# sourceMappingURL=reactPlayerFilePlayer.js.map

--- a/src/admin/build/reactPlayerKaltura.js
+++ b/src/admin/build/reactPlayerKaltura.js
@@ -1,1 +1,154 @@
-(globalThis.webpackChunksimplystatic_settings=globalThis.webpackChunksimplystatic_settings||[]).push([[463],{945:(e,t,r)=>{var s,a=Object.create,l=Object.defineProperty,o=Object.getOwnPropertyDescriptor,n=Object.getOwnPropertyNames,i=Object.getPrototypeOf,u=Object.prototype.hasOwnProperty,p=(e,t,r,s)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let a of n(t))u.call(e,a)||a===r||l(e,a,{get:()=>t[a],enumerable:!(s=o(t,a))||s.enumerable});return e},h=(e,t,r)=>(((e,t,r)=>{t in e?l(e,t,{enumerable:!0,configurable:!0,writable:!0,value:r}):e[t]=r})(e,"symbol"!=typeof t?t+"":t,r),r),d={};((e,t)=>{for(var r in t)l(e,r,{get:t[r],enumerable:!0})})(d,{default:()=>f}),e.exports=(s=d,p(l({},"__esModule",{value:!0}),s));var c=((e,t,r)=>(r=null!=e?a(i(e)):{},p(e&&e.__esModule?r:l(r,"default",{value:e,enumerable:!0}),e)))(r(609)),y=r(635),m=r(327);class f extends c.Component{constructor(){super(...arguments),h(this,"callPlayer",y.callPlayer),h(this,"duration",null),h(this,"currentTime",null),h(this,"secondsLoaded",null),h(this,"mute",(()=>{this.callPlayer("mute")})),h(this,"unmute",(()=>{this.callPlayer("unmute")})),h(this,"ref",(e=>{this.iframe=e}))}componentDidMount(){this.props.onMount&&this.props.onMount(this)}load(e){(0,y.getSDK)("https://cdn.embed.ly/player-0.1.0.min.js","playerjs").then((e=>{this.iframe&&(this.player=new e.Player(this.iframe),this.player.on("ready",(()=>{setTimeout((()=>{this.player.isReady=!0,this.player.setLoop(this.props.loop),this.props.muted&&this.player.mute(),this.addListeners(this.player,this.props),this.props.onReady()}),500)})))}),this.props.onError)}addListeners(e,t){e.on("play",t.onPlay),e.on("pause",t.onPause),e.on("ended",t.onEnded),e.on("error",t.onError),e.on("timeupdate",(({duration:e,seconds:t})=>{this.duration=e,this.currentTime=t}))}play(){this.callPlayer("play")}pause(){this.callPlayer("pause")}stop(){}seekTo(e,t=!0){this.callPlayer("setCurrentTime",e),t||this.pause()}setVolume(e){this.callPlayer("setVolume",e)}setLoop(e){this.callPlayer("setLoop",e)}getDuration(){return this.duration}getCurrentTime(){return this.currentTime}getSecondsLoaded(){return this.secondsLoaded}render(){return c.default.createElement("iframe",{ref:this.ref,src:this.props.url,frameBorder:"0",scrolling:"no",style:{width:"100%",height:"100%"},allow:"encrypted-media; autoplay; fullscreen;",referrerPolicy:"no-referrer-when-downgrade"})}}h(f,"displayName","Kaltura"),h(f,"canPlay",m.canPlay.kaltura)}}]);
+(globalThis["webpackChunksimplystatic_settings"] = globalThis["webpackChunksimplystatic_settings"] || []).push([["reactPlayerKaltura"],{
+
+/***/ "./node_modules/react-player/lib/players/Kaltura.js":
+/*!**********************************************************!*\
+  !*** ./node_modules/react-player/lib/players/Kaltura.js ***!
+  \**********************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var __publicField = (obj, key, value) => {
+  __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
+var Kaltura_exports = {};
+__export(Kaltura_exports, {
+  default: () => Kaltura
+});
+module.exports = __toCommonJS(Kaltura_exports);
+var import_react = __toESM(__webpack_require__(/*! react */ "react"));
+var import_utils = __webpack_require__(/*! ../utils */ "./node_modules/react-player/lib/utils.js");
+var import_patterns = __webpack_require__(/*! ../patterns */ "./node_modules/react-player/lib/patterns.js");
+const SDK_URL = "https://cdn.embed.ly/player-0.1.0.min.js";
+const SDK_GLOBAL = "playerjs";
+class Kaltura extends import_react.Component {
+  constructor() {
+    super(...arguments);
+    __publicField(this, "callPlayer", import_utils.callPlayer);
+    __publicField(this, "duration", null);
+    __publicField(this, "currentTime", null);
+    __publicField(this, "secondsLoaded", null);
+    __publicField(this, "mute", () => {
+      this.callPlayer("mute");
+    });
+    __publicField(this, "unmute", () => {
+      this.callPlayer("unmute");
+    });
+    __publicField(this, "ref", (iframe) => {
+      this.iframe = iframe;
+    });
+  }
+  componentDidMount() {
+    this.props.onMount && this.props.onMount(this);
+  }
+  load(url) {
+    (0, import_utils.getSDK)(SDK_URL, SDK_GLOBAL).then((playerjs) => {
+      if (!this.iframe)
+        return;
+      this.player = new playerjs.Player(this.iframe);
+      this.player.on("ready", () => {
+        setTimeout(() => {
+          this.player.isReady = true;
+          this.player.setLoop(this.props.loop);
+          if (this.props.muted) {
+            this.player.mute();
+          }
+          this.addListeners(this.player, this.props);
+          this.props.onReady();
+        }, 500);
+      });
+    }, this.props.onError);
+  }
+  addListeners(player, props) {
+    player.on("play", props.onPlay);
+    player.on("pause", props.onPause);
+    player.on("ended", props.onEnded);
+    player.on("error", props.onError);
+    player.on("timeupdate", ({ duration, seconds }) => {
+      this.duration = duration;
+      this.currentTime = seconds;
+    });
+  }
+  play() {
+    this.callPlayer("play");
+  }
+  pause() {
+    this.callPlayer("pause");
+  }
+  stop() {
+  }
+  seekTo(seconds, keepPlaying = true) {
+    this.callPlayer("setCurrentTime", seconds);
+    if (!keepPlaying) {
+      this.pause();
+    }
+  }
+  setVolume(fraction) {
+    this.callPlayer("setVolume", fraction);
+  }
+  setLoop(loop) {
+    this.callPlayer("setLoop", loop);
+  }
+  getDuration() {
+    return this.duration;
+  }
+  getCurrentTime() {
+    return this.currentTime;
+  }
+  getSecondsLoaded() {
+    return this.secondsLoaded;
+  }
+  render() {
+    const style = {
+      width: "100%",
+      height: "100%"
+    };
+    return /* @__PURE__ */ import_react.default.createElement(
+      "iframe",
+      {
+        ref: this.ref,
+        src: this.props.url,
+        frameBorder: "0",
+        scrolling: "no",
+        style,
+        allow: "encrypted-media; autoplay; fullscreen;",
+        referrerPolicy: "no-referrer-when-downgrade"
+      }
+    );
+  }
+}
+__publicField(Kaltura, "displayName", "Kaltura");
+__publicField(Kaltura, "canPlay", import_patterns.canPlay.kaltura);
+
+
+/***/ })
+
+}]);
+//# sourceMappingURL=reactPlayerKaltura.js.map

--- a/src/admin/build/reactPlayerMixcloud.js
+++ b/src/admin/build/reactPlayerMixcloud.js
@@ -1,1 +1,142 @@
-(globalThis.webpackChunksimplystatic_settings=globalThis.webpackChunksimplystatic_settings||[]).push([[570],{276:(e,t,r)=>{var s,o=Object.create,i=Object.defineProperty,a=Object.getOwnPropertyDescriptor,l=Object.getOwnPropertyNames,n=Object.getPrototypeOf,p=Object.prototype.hasOwnProperty,u=(e,t,r,s)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let o of l(t))p.call(e,o)||o===r||i(e,o,{get:()=>t[o],enumerable:!(s=a(t,o))||s.enumerable});return e},h=(e,t,r)=>(((e,t,r)=>{t in e?i(e,t,{enumerable:!0,configurable:!0,writable:!0,value:r}):e[t]=r})(e,"symbol"!=typeof t?t+"":t,r),r),c={};((e,t)=>{for(var r in t)i(e,r,{get:t[r],enumerable:!0})})(c,{default:()=>f}),e.exports=(s=c,u(i({},"__esModule",{value:!0}),s));var d=((e,t,r)=>(r=null!=e?o(n(e)):{},u(e&&e.__esModule?r:i(r,"default",{value:e,enumerable:!0}),e)))(r(609)),y=r(635),m=r(327);class f extends d.Component{constructor(){super(...arguments),h(this,"callPlayer",y.callPlayer),h(this,"duration",null),h(this,"currentTime",null),h(this,"secondsLoaded",null),h(this,"mute",(()=>{})),h(this,"unmute",(()=>{})),h(this,"ref",(e=>{this.iframe=e}))}componentDidMount(){this.props.onMount&&this.props.onMount(this)}load(e){(0,y.getSDK)("https://widget.mixcloud.com/media/js/widgetApi.js","Mixcloud").then((e=>{this.player=e.PlayerWidget(this.iframe),this.player.ready.then((()=>{this.player.events.play.on(this.props.onPlay),this.player.events.pause.on(this.props.onPause),this.player.events.ended.on(this.props.onEnded),this.player.events.error.on(this.props.error),this.player.events.progress.on(((e,t)=>{this.currentTime=e,this.duration=t})),this.props.onReady()}))}),this.props.onError)}play(){this.callPlayer("play")}pause(){this.callPlayer("pause")}stop(){}seekTo(e,t=!0){this.callPlayer("seek",e),t||this.pause()}setVolume(e){}getDuration(){return this.duration}getCurrentTime(){return this.currentTime}getSecondsLoaded(){return null}render(){const{url:e,config:t}=this.props,r=e.match(m.MATCH_URL_MIXCLOUD)[1],s=(0,y.queryString)({...t.options,feed:`/${r}/`});return d.default.createElement("iframe",{key:r,ref:this.ref,style:{width:"100%",height:"100%"},src:`https://www.mixcloud.com/widget/iframe/?${s}`,frameBorder:"0",allow:"autoplay"})}}h(f,"displayName","Mixcloud"),h(f,"canPlay",m.canPlay.mixcloud),h(f,"loopOnEnded",!0)}}]);
+(globalThis["webpackChunksimplystatic_settings"] = globalThis["webpackChunksimplystatic_settings"] || []).push([["reactPlayerMixcloud"],{
+
+/***/ "./node_modules/react-player/lib/players/Mixcloud.js":
+/*!***********************************************************!*\
+  !*** ./node_modules/react-player/lib/players/Mixcloud.js ***!
+  \***********************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var __publicField = (obj, key, value) => {
+  __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
+var Mixcloud_exports = {};
+__export(Mixcloud_exports, {
+  default: () => Mixcloud
+});
+module.exports = __toCommonJS(Mixcloud_exports);
+var import_react = __toESM(__webpack_require__(/*! react */ "react"));
+var import_utils = __webpack_require__(/*! ../utils */ "./node_modules/react-player/lib/utils.js");
+var import_patterns = __webpack_require__(/*! ../patterns */ "./node_modules/react-player/lib/patterns.js");
+const SDK_URL = "https://widget.mixcloud.com/media/js/widgetApi.js";
+const SDK_GLOBAL = "Mixcloud";
+class Mixcloud extends import_react.Component {
+  constructor() {
+    super(...arguments);
+    __publicField(this, "callPlayer", import_utils.callPlayer);
+    __publicField(this, "duration", null);
+    __publicField(this, "currentTime", null);
+    __publicField(this, "secondsLoaded", null);
+    __publicField(this, "mute", () => {
+    });
+    __publicField(this, "unmute", () => {
+    });
+    __publicField(this, "ref", (iframe) => {
+      this.iframe = iframe;
+    });
+  }
+  componentDidMount() {
+    this.props.onMount && this.props.onMount(this);
+  }
+  load(url) {
+    (0, import_utils.getSDK)(SDK_URL, SDK_GLOBAL).then((Mixcloud2) => {
+      this.player = Mixcloud2.PlayerWidget(this.iframe);
+      this.player.ready.then(() => {
+        this.player.events.play.on(this.props.onPlay);
+        this.player.events.pause.on(this.props.onPause);
+        this.player.events.ended.on(this.props.onEnded);
+        this.player.events.error.on(this.props.error);
+        this.player.events.progress.on((seconds, duration) => {
+          this.currentTime = seconds;
+          this.duration = duration;
+        });
+        this.props.onReady();
+      });
+    }, this.props.onError);
+  }
+  play() {
+    this.callPlayer("play");
+  }
+  pause() {
+    this.callPlayer("pause");
+  }
+  stop() {
+  }
+  seekTo(seconds, keepPlaying = true) {
+    this.callPlayer("seek", seconds);
+    if (!keepPlaying) {
+      this.pause();
+    }
+  }
+  setVolume(fraction) {
+  }
+  getDuration() {
+    return this.duration;
+  }
+  getCurrentTime() {
+    return this.currentTime;
+  }
+  getSecondsLoaded() {
+    return null;
+  }
+  render() {
+    const { url, config } = this.props;
+    const id = url.match(import_patterns.MATCH_URL_MIXCLOUD)[1];
+    const style = {
+      width: "100%",
+      height: "100%"
+    };
+    const query = (0, import_utils.queryString)({
+      ...config.options,
+      feed: `/${id}/`
+    });
+    return /* @__PURE__ */ import_react.default.createElement(
+      "iframe",
+      {
+        key: id,
+        ref: this.ref,
+        style,
+        src: `https://player-widget.mixcloud.com/widget/iframe/?${query}`,
+        frameBorder: "0",
+        allow: "autoplay"
+      }
+    );
+  }
+}
+__publicField(Mixcloud, "displayName", "Mixcloud");
+__publicField(Mixcloud, "canPlay", import_patterns.canPlay.mixcloud);
+__publicField(Mixcloud, "loopOnEnded", true);
+
+
+/***/ })
+
+}]);
+//# sourceMappingURL=reactPlayerMixcloud.js.map

--- a/src/admin/build/reactPlayerMux.js
+++ b/src/admin/build/reactPlayerMux.js
@@ -1,1 +1,242 @@
-(globalThis.webpackChunksimplystatic_settings=globalThis.webpackChunksimplystatic_settings||[]).push([[723],{553:(e,t,n)=>{var r,s=Object.create,i=Object.defineProperty,a=Object.getOwnPropertyDescriptor,o=Object.getOwnPropertyNames,l=Object.getPrototypeOf,p=Object.prototype.hasOwnProperty,h=(e,t,n,r)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let s of o(t))p.call(e,s)||s===n||i(e,s,{get:()=>t[s],enumerable:!(r=a(t,s))||r.enumerable});return e},u=(e,t,n)=>(((e,t,n)=>{t in e?i(e,t,{enumerable:!0,configurable:!0,writable:!0,value:n}):e[t]=n})(e,"symbol"!=typeof t?t+"":t,n),n),c={};((e,t)=>{for(var n in t)i(e,n,{get:t[n],enumerable:!0})})(c,{default:()=>m}),e.exports=(r=c,h(i({},"__esModule",{value:!0}),r));var d=((e,t,n)=>(n=null!=e?s(l(e)):{},h(e&&e.__esModule?n:i(n,"default",{value:e,enumerable:!0}),e)))(n(609)),y=n(327);class m extends d.Component{constructor(){super(...arguments),u(this,"onReady",((...e)=>this.props.onReady(...e))),u(this,"onPlay",((...e)=>this.props.onPlay(...e))),u(this,"onBuffer",((...e)=>this.props.onBuffer(...e))),u(this,"onBufferEnd",((...e)=>this.props.onBufferEnd(...e))),u(this,"onPause",((...e)=>this.props.onPause(...e))),u(this,"onEnded",((...e)=>this.props.onEnded(...e))),u(this,"onError",((...e)=>this.props.onError(...e))),u(this,"onPlayBackRateChange",(e=>this.props.onPlaybackRateChange(e.target.playbackRate))),u(this,"onEnablePIP",((...e)=>this.props.onEnablePIP(...e))),u(this,"onSeek",(e=>{this.props.onSeek(e.target.currentTime)})),u(this,"onDurationChange",(()=>{const e=this.getDuration();this.props.onDuration(e)})),u(this,"mute",(()=>{this.player.muted=!0})),u(this,"unmute",(()=>{this.player.muted=!1})),u(this,"ref",(e=>{this.player=e}))}componentDidMount(){this.props.onMount&&this.props.onMount(this),this.addListeners(this.player);const e=this.getPlaybackId(this.props.url);e&&(this.player.playbackId=e)}componentWillUnmount(){this.player.playbackId=null,this.removeListeners(this.player)}addListeners(e){const{playsinline:t}=this.props;e.addEventListener("play",this.onPlay),e.addEventListener("waiting",this.onBuffer),e.addEventListener("playing",this.onBufferEnd),e.addEventListener("pause",this.onPause),e.addEventListener("seeked",this.onSeek),e.addEventListener("ended",this.onEnded),e.addEventListener("error",this.onError),e.addEventListener("ratechange",this.onPlayBackRateChange),e.addEventListener("enterpictureinpicture",this.onEnablePIP),e.addEventListener("leavepictureinpicture",this.onDisablePIP),e.addEventListener("webkitpresentationmodechanged",this.onPresentationModeChange),e.addEventListener("canplay",this.onReady),t&&e.setAttribute("playsinline","")}removeListeners(e){e.removeEventListener("canplay",this.onReady),e.removeEventListener("play",this.onPlay),e.removeEventListener("waiting",this.onBuffer),e.removeEventListener("playing",this.onBufferEnd),e.removeEventListener("pause",this.onPause),e.removeEventListener("seeked",this.onSeek),e.removeEventListener("ended",this.onEnded),e.removeEventListener("error",this.onError),e.removeEventListener("ratechange",this.onPlayBackRateChange),e.removeEventListener("enterpictureinpicture",this.onEnablePIP),e.removeEventListener("leavepictureinpicture",this.onDisablePIP),e.removeEventListener("canplay",this.onReady)}async load(e){var t;const{onError:n,config:r}=this.props;if(!(null==(t=globalThis.customElements)?void 0:t.get("mux-player")))try{const e="https://cdn.jsdelivr.net/npm/@mux/mux-player@VERSION/dist/mux-player.mjs".replace("VERSION",r.version);await import(`${e}`),this.props.onLoaded()}catch(e){n(e)}const[,s]=e.match(y.MATCH_URL_MUX);this.player.playbackId=s}play(){const e=this.player.play();e&&e.catch(this.props.onError)}pause(){this.player.pause()}stop(){this.player.playbackId=null}seekTo(e,t=!0){this.player.currentTime=e,t||this.pause()}setVolume(e){this.player.volume=e}enablePIP(){this.player.requestPictureInPicture&&document.pictureInPictureElement!==this.player&&this.player.requestPictureInPicture()}disablePIP(){document.exitPictureInPicture&&document.pictureInPictureElement===this.player&&document.exitPictureInPicture()}setPlaybackRate(e){try{this.player.playbackRate=e}catch(e){this.props.onError(e)}}getDuration(){if(!this.player)return null;const{duration:e,seekable:t}=this.player;return e===1/0&&t.length>0?t.end(t.length-1):e}getCurrentTime(){return this.player?this.player.currentTime:null}getSecondsLoaded(){if(!this.player)return null;const{buffered:e}=this.player;if(0===e.length)return 0;const t=e.end(e.length-1),n=this.getDuration();return t>n?n:t}getPlaybackId(e){const[,t]=e.match(y.MATCH_URL_MUX);return t}render(){const{url:e,playing:t,loop:n,controls:r,muted:s,config:i,width:a,height:o}=this.props,l={width:"auto"===a?a:"100%",height:"auto"===o?o:"100%"};return!1===r&&(l["--controls"]="none"),d.default.createElement("mux-player",{ref:this.ref,"playback-id":this.getPlaybackId(e),style:l,preload:"auto",autoPlay:t||void 0,muted:s?"":void 0,loop:n?"":void 0,...i.attributes})}}u(m,"displayName","Mux"),u(m,"canPlay",y.canPlay.mux)}}]);
+(globalThis["webpackChunksimplystatic_settings"] = globalThis["webpackChunksimplystatic_settings"] || []).push([["reactPlayerMux"],{
+
+/***/ "./node_modules/react-player/lib/players/Mux.js":
+/*!******************************************************!*\
+  !*** ./node_modules/react-player/lib/players/Mux.js ***!
+  \******************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var __publicField = (obj, key, value) => {
+  __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
+var Mux_exports = {};
+__export(Mux_exports, {
+  default: () => Mux
+});
+module.exports = __toCommonJS(Mux_exports);
+var import_react = __toESM(__webpack_require__(/*! react */ "react"));
+var import_patterns = __webpack_require__(/*! ../patterns */ "./node_modules/react-player/lib/patterns.js");
+const SDK_URL = "https://cdn.jsdelivr.net/npm/@mux/mux-player@VERSION/dist/mux-player.mjs";
+class Mux extends import_react.Component {
+  constructor() {
+    super(...arguments);
+    // Proxy methods to prevent listener leaks
+    __publicField(this, "onReady", (...args) => this.props.onReady(...args));
+    __publicField(this, "onPlay", (...args) => this.props.onPlay(...args));
+    __publicField(this, "onBuffer", (...args) => this.props.onBuffer(...args));
+    __publicField(this, "onBufferEnd", (...args) => this.props.onBufferEnd(...args));
+    __publicField(this, "onPause", (...args) => this.props.onPause(...args));
+    __publicField(this, "onEnded", (...args) => this.props.onEnded(...args));
+    __publicField(this, "onError", (...args) => this.props.onError(...args));
+    __publicField(this, "onPlayBackRateChange", (event) => this.props.onPlaybackRateChange(event.target.playbackRate));
+    __publicField(this, "onEnablePIP", (...args) => this.props.onEnablePIP(...args));
+    __publicField(this, "onSeek", (e) => {
+      this.props.onSeek(e.target.currentTime);
+    });
+    __publicField(this, "onDurationChange", () => {
+      const duration = this.getDuration();
+      this.props.onDuration(duration);
+    });
+    __publicField(this, "mute", () => {
+      this.player.muted = true;
+    });
+    __publicField(this, "unmute", () => {
+      this.player.muted = false;
+    });
+    __publicField(this, "ref", (player) => {
+      this.player = player;
+    });
+  }
+  componentDidMount() {
+    this.props.onMount && this.props.onMount(this);
+    this.addListeners(this.player);
+    const playbackId = this.getPlaybackId(this.props.url);
+    if (playbackId) {
+      this.player.playbackId = playbackId;
+    }
+  }
+  componentWillUnmount() {
+    this.player.playbackId = null;
+    this.removeListeners(this.player);
+  }
+  addListeners(player) {
+    const { playsinline } = this.props;
+    player.addEventListener("play", this.onPlay);
+    player.addEventListener("waiting", this.onBuffer);
+    player.addEventListener("playing", this.onBufferEnd);
+    player.addEventListener("pause", this.onPause);
+    player.addEventListener("seeked", this.onSeek);
+    player.addEventListener("ended", this.onEnded);
+    player.addEventListener("error", this.onError);
+    player.addEventListener("ratechange", this.onPlayBackRateChange);
+    player.addEventListener("enterpictureinpicture", this.onEnablePIP);
+    player.addEventListener("leavepictureinpicture", this.onDisablePIP);
+    player.addEventListener("webkitpresentationmodechanged", this.onPresentationModeChange);
+    player.addEventListener("canplay", this.onReady);
+    if (playsinline) {
+      player.setAttribute("playsinline", "");
+    }
+  }
+  removeListeners(player) {
+    player.removeEventListener("canplay", this.onReady);
+    player.removeEventListener("play", this.onPlay);
+    player.removeEventListener("waiting", this.onBuffer);
+    player.removeEventListener("playing", this.onBufferEnd);
+    player.removeEventListener("pause", this.onPause);
+    player.removeEventListener("seeked", this.onSeek);
+    player.removeEventListener("ended", this.onEnded);
+    player.removeEventListener("error", this.onError);
+    player.removeEventListener("ratechange", this.onPlayBackRateChange);
+    player.removeEventListener("enterpictureinpicture", this.onEnablePIP);
+    player.removeEventListener("leavepictureinpicture", this.onDisablePIP);
+    player.removeEventListener("canplay", this.onReady);
+  }
+  async load(url) {
+    var _a;
+    const { onError, config } = this.props;
+    if (!((_a = globalThis.customElements) == null ? void 0 : _a.get("mux-player"))) {
+      try {
+        const sdkUrl = SDK_URL.replace("VERSION", config.version);
+        await import(
+          /* webpackIgnore: true */
+          `${sdkUrl}`
+        );
+        this.props.onLoaded();
+      } catch (error) {
+        onError(error);
+      }
+    }
+    const [, id] = url.match(import_patterns.MATCH_URL_MUX);
+    this.player.playbackId = id;
+  }
+  play() {
+    const promise = this.player.play();
+    if (promise) {
+      promise.catch(this.props.onError);
+    }
+  }
+  pause() {
+    this.player.pause();
+  }
+  stop() {
+    this.player.playbackId = null;
+  }
+  seekTo(seconds, keepPlaying = true) {
+    this.player.currentTime = seconds;
+    if (!keepPlaying) {
+      this.pause();
+    }
+  }
+  setVolume(fraction) {
+    this.player.volume = fraction;
+  }
+  enablePIP() {
+    if (this.player.requestPictureInPicture && document.pictureInPictureElement !== this.player) {
+      this.player.requestPictureInPicture();
+    }
+  }
+  disablePIP() {
+    if (document.exitPictureInPicture && document.pictureInPictureElement === this.player) {
+      document.exitPictureInPicture();
+    }
+  }
+  setPlaybackRate(rate) {
+    try {
+      this.player.playbackRate = rate;
+    } catch (error) {
+      this.props.onError(error);
+    }
+  }
+  getDuration() {
+    if (!this.player)
+      return null;
+    const { duration, seekable } = this.player;
+    if (duration === Infinity && seekable.length > 0) {
+      return seekable.end(seekable.length - 1);
+    }
+    return duration;
+  }
+  getCurrentTime() {
+    if (!this.player)
+      return null;
+    return this.player.currentTime;
+  }
+  getSecondsLoaded() {
+    if (!this.player)
+      return null;
+    const { buffered } = this.player;
+    if (buffered.length === 0) {
+      return 0;
+    }
+    const end = buffered.end(buffered.length - 1);
+    const duration = this.getDuration();
+    if (end > duration) {
+      return duration;
+    }
+    return end;
+  }
+  getPlaybackId(url) {
+    const [, id] = url.match(import_patterns.MATCH_URL_MUX);
+    return id;
+  }
+  render() {
+    const { url, playing, loop, controls, muted, config, width, height } = this.props;
+    const style = {
+      width: width === "auto" ? width : "100%",
+      height: height === "auto" ? height : "100%"
+    };
+    if (controls === false) {
+      style["--controls"] = "none";
+    }
+    return /* @__PURE__ */ import_react.default.createElement(
+      "mux-player",
+      {
+        ref: this.ref,
+        "playback-id": this.getPlaybackId(url),
+        style,
+        preload: "auto",
+        autoPlay: playing || void 0,
+        muted: muted ? "" : void 0,
+        loop: loop ? "" : void 0,
+        ...config.attributes
+      }
+    );
+  }
+}
+__publicField(Mux, "displayName", "Mux");
+__publicField(Mux, "canPlay", import_patterns.canPlay.mux);
+
+
+/***/ })
+
+}]);
+//# sourceMappingURL=reactPlayerMux.js.map

--- a/src/admin/build/reactPlayerPreview.js
+++ b/src/admin/build/reactPlayerPreview.js
@@ -1,1 +1,151 @@
-(globalThis.webpackChunksimplystatic_settings=globalThis.webpackChunksimplystatic_settings||[]).push([[353],{734:(e,t,a)=>{var r,i=Object.create,l=Object.defineProperty,n=Object.getOwnPropertyDescriptor,s=Object.getOwnPropertyNames,o=Object.getPrototypeOf,p=Object.prototype.hasOwnProperty,c=(e,t,a,r)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let i of s(t))p.call(e,i)||i===a||l(e,i,{get:()=>t[i],enumerable:!(r=n(t,i))||r.enumerable});return e},h=(e,t,a)=>(((e,t,a)=>{t in e?l(e,t,{enumerable:!0,configurable:!0,writable:!0,value:a}):e[t]=a})(e,"symbol"!=typeof t?t+"":t,a),a),u={};((e,t)=>{for(var a in t)l(e,a,{get:t[a],enumerable:!0})})(u,{default:()=>b}),e.exports=(r=u,c(l({},"__esModule",{value:!0}),r));var d=((e,t,a)=>(a=null!=e?i(o(e)):{},c(e&&e.__esModule?a:l(a,"default",{value:e,enumerable:!0}),e)))(a(609));const m="64px",g={};class b extends d.Component{constructor(){super(...arguments),h(this,"mounted",!1),h(this,"state",{image:null}),h(this,"handleKeyPress",(e=>{"Enter"!==e.key&&" "!==e.key||this.props.onClick()}))}componentDidMount(){this.mounted=!0,this.fetchImage(this.props)}componentDidUpdate(e){const{url:t,light:a}=this.props;e.url===t&&e.light===a||this.fetchImage(this.props)}componentWillUnmount(){this.mounted=!1}fetchImage({url:e,light:t,oEmbedUrl:a}){if(!d.default.isValidElement(t))if("string"!=typeof t){if(!g[e])return this.setState({image:null}),window.fetch(a.replace("{url}",e)).then((e=>e.json())).then((t=>{if(t.thumbnail_url&&this.mounted){const a=t.thumbnail_url.replace("height=100","height=480").replace("-d_295x166","-d_640");this.setState({image:a}),g[e]=a}}));this.setState({image:g[e]})}else this.setState({image:t})}render(){const{light:e,onClick:t,playIcon:a,previewTabIndex:r,previewAriaLabel:i}=this.props,{image:l}=this.state,n=d.default.isValidElement(e),s={display:"flex",alignItems:"center",justifyContent:"center"},o={preview:{width:"100%",height:"100%",backgroundImage:l&&!n?`url(${l})`:void 0,backgroundSize:"cover",backgroundPosition:"center",cursor:"pointer",...s},shadow:{background:"radial-gradient(rgb(0, 0, 0, 0.3), rgba(0, 0, 0, 0) 60%)",borderRadius:m,width:m,height:m,position:n?"absolute":void 0,...s},playIcon:{borderStyle:"solid",borderWidth:"16px 0 16px 26px",borderColor:"transparent transparent transparent white",marginLeft:"7px"}},p=d.default.createElement("div",{style:o.shadow,className:"react-player__shadow"},d.default.createElement("div",{style:o.playIcon,className:"react-player__play-icon"}));return d.default.createElement("div",{style:o.preview,className:"react-player__preview",onClick:t,tabIndex:r,onKeyPress:this.handleKeyPress,...i?{"aria-label":i}:{}},n?e:null,a||p)}}}}]);
+(globalThis["webpackChunksimplystatic_settings"] = globalThis["webpackChunksimplystatic_settings"] || []).push([["reactPlayerPreview"],{
+
+/***/ "./node_modules/react-player/lib/Preview.js":
+/*!**************************************************!*\
+  !*** ./node_modules/react-player/lib/Preview.js ***!
+  \**************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var __publicField = (obj, key, value) => {
+  __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
+var Preview_exports = {};
+__export(Preview_exports, {
+  default: () => Preview
+});
+module.exports = __toCommonJS(Preview_exports);
+var import_react = __toESM(__webpack_require__(/*! react */ "react"));
+const ICON_SIZE = "64px";
+const cache = {};
+class Preview extends import_react.Component {
+  constructor() {
+    super(...arguments);
+    __publicField(this, "mounted", false);
+    __publicField(this, "state", {
+      image: null
+    });
+    __publicField(this, "handleKeyPress", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        this.props.onClick();
+      }
+    });
+  }
+  componentDidMount() {
+    this.mounted = true;
+    this.fetchImage(this.props);
+  }
+  componentDidUpdate(prevProps) {
+    const { url, light } = this.props;
+    if (prevProps.url !== url || prevProps.light !== light) {
+      this.fetchImage(this.props);
+    }
+  }
+  componentWillUnmount() {
+    this.mounted = false;
+  }
+  fetchImage({ url, light, oEmbedUrl }) {
+    if (import_react.default.isValidElement(light)) {
+      return;
+    }
+    if (typeof light === "string") {
+      this.setState({ image: light });
+      return;
+    }
+    if (cache[url]) {
+      this.setState({ image: cache[url] });
+      return;
+    }
+    this.setState({ image: null });
+    return window.fetch(oEmbedUrl.replace("{url}", url)).then((response) => response.json()).then((data) => {
+      if (data.thumbnail_url && this.mounted) {
+        const image = data.thumbnail_url.replace("height=100", "height=480").replace("-d_295x166", "-d_640");
+        this.setState({ image });
+        cache[url] = image;
+      }
+    });
+  }
+  render() {
+    const { light, onClick, playIcon, previewTabIndex, previewAriaLabel } = this.props;
+    const { image } = this.state;
+    const isElement = import_react.default.isValidElement(light);
+    const flexCenter = {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center"
+    };
+    const styles = {
+      preview: {
+        width: "100%",
+        height: "100%",
+        backgroundImage: image && !isElement ? `url(${image})` : void 0,
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+        cursor: "pointer",
+        ...flexCenter
+      },
+      shadow: {
+        background: "radial-gradient(rgb(0, 0, 0, 0.3), rgba(0, 0, 0, 0) 60%)",
+        borderRadius: ICON_SIZE,
+        width: ICON_SIZE,
+        height: ICON_SIZE,
+        position: isElement ? "absolute" : void 0,
+        ...flexCenter
+      },
+      playIcon: {
+        borderStyle: "solid",
+        borderWidth: "16px 0 16px 26px",
+        borderColor: "transparent transparent transparent white",
+        marginLeft: "7px"
+      }
+    };
+    const defaultPlayIcon = /* @__PURE__ */ import_react.default.createElement("div", { style: styles.shadow, className: "react-player__shadow" }, /* @__PURE__ */ import_react.default.createElement("div", { style: styles.playIcon, className: "react-player__play-icon" }));
+    return /* @__PURE__ */ import_react.default.createElement(
+      "div",
+      {
+        style: styles.preview,
+        className: "react-player__preview",
+        onClick,
+        tabIndex: previewTabIndex,
+        onKeyPress: this.handleKeyPress,
+        ...previewAriaLabel ? { "aria-label": previewAriaLabel } : {}
+      },
+      isElement ? light : null,
+      playIcon || defaultPlayIcon
+    );
+  }
+}
+
+
+/***/ })
+
+}]);
+//# sourceMappingURL=reactPlayerPreview.js.map

--- a/src/admin/build/reactPlayerSoundCloud.js
+++ b/src/admin/build/reactPlayerSoundCloud.js
@@ -1,1 +1,159 @@
-(globalThis.webpackChunksimplystatic_settings=globalThis.webpackChunksimplystatic_settings||[]).push([[979],{127:(e,t,s)=>{var r,o=Object.create,i=Object.defineProperty,l=Object.getOwnPropertyDescriptor,a=Object.getOwnPropertyNames,n=Object.getPrototypeOf,u=Object.prototype.hasOwnProperty,p=(e,t,s,r)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let o of a(t))u.call(e,o)||o===s||i(e,o,{get:()=>t[o],enumerable:!(r=l(t,o))||r.enumerable});return e},h=(e,t,s)=>(((e,t,s)=>{t in e?i(e,t,{enumerable:!0,configurable:!0,writable:!0,value:s}):e[t]=s})(e,"symbol"!=typeof t?t+"":t,s),s),d={};((e,t)=>{for(var s in t)i(e,s,{get:t[s],enumerable:!0})})(d,{default:()=>f}),e.exports=(r=d,p(i({},"__esModule",{value:!0}),r));var c=((e,t,s)=>(s=null!=e?o(n(e)):{},p(e&&e.__esModule?s:i(s,"default",{value:e,enumerable:!0}),e)))(s(609)),y=s(635),m=s(327);class f extends c.Component{constructor(){super(...arguments),h(this,"callPlayer",y.callPlayer),h(this,"duration",null),h(this,"currentTime",null),h(this,"fractionLoaded",null),h(this,"mute",(()=>{this.setVolume(0)})),h(this,"unmute",(()=>{null!==this.props.volume&&this.setVolume(this.props.volume)})),h(this,"ref",(e=>{this.iframe=e}))}componentDidMount(){this.props.onMount&&this.props.onMount(this)}load(e,t){(0,y.getSDK)("https://w.soundcloud.com/player/api.js","SC").then((s=>{if(!this.iframe)return;const{PLAY:r,PLAY_PROGRESS:o,PAUSE:i,FINISH:l,ERROR:a}=s.Widget.Events;t||(this.player=s.Widget(this.iframe),this.player.bind(r,this.props.onPlay),this.player.bind(i,(()=>{this.duration-this.currentTime<.05||this.props.onPause()})),this.player.bind(o,(e=>{this.currentTime=e.currentPosition/1e3,this.fractionLoaded=e.loadedProgress})),this.player.bind(l,(()=>this.props.onEnded())),this.player.bind(a,(e=>this.props.onError(e)))),this.player.load(e,{...this.props.config.options,callback:()=>{this.player.getDuration((e=>{this.duration=e/1e3,this.props.onReady()}))}})}))}play(){this.callPlayer("play")}pause(){this.callPlayer("pause")}stop(){}seekTo(e,t=!0){this.callPlayer("seekTo",1e3*e),t||this.pause()}setVolume(e){this.callPlayer("setVolume",100*e)}getDuration(){return this.duration}getCurrentTime(){return this.currentTime}getSecondsLoaded(){return this.fractionLoaded*this.duration}render(){const{display:e}=this.props,t={width:"100%",height:"100%",display:e};return c.default.createElement("iframe",{ref:this.ref,src:`https://w.soundcloud.com/player/?url=${encodeURIComponent(this.props.url)}`,style:t,frameBorder:0,allow:"autoplay"})}}h(f,"displayName","SoundCloud"),h(f,"canPlay",m.canPlay.soundcloud),h(f,"loopOnEnded",!0)}}]);
+(globalThis["webpackChunksimplystatic_settings"] = globalThis["webpackChunksimplystatic_settings"] || []).push([["reactPlayerSoundCloud"],{
+
+/***/ "./node_modules/react-player/lib/players/SoundCloud.js":
+/*!*************************************************************!*\
+  !*** ./node_modules/react-player/lib/players/SoundCloud.js ***!
+  \*************************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var __publicField = (obj, key, value) => {
+  __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
+var SoundCloud_exports = {};
+__export(SoundCloud_exports, {
+  default: () => SoundCloud
+});
+module.exports = __toCommonJS(SoundCloud_exports);
+var import_react = __toESM(__webpack_require__(/*! react */ "react"));
+var import_utils = __webpack_require__(/*! ../utils */ "./node_modules/react-player/lib/utils.js");
+var import_patterns = __webpack_require__(/*! ../patterns */ "./node_modules/react-player/lib/patterns.js");
+const SDK_URL = "https://w.soundcloud.com/player/api.js";
+const SDK_GLOBAL = "SC";
+class SoundCloud extends import_react.Component {
+  constructor() {
+    super(...arguments);
+    __publicField(this, "callPlayer", import_utils.callPlayer);
+    __publicField(this, "duration", null);
+    __publicField(this, "currentTime", null);
+    __publicField(this, "fractionLoaded", null);
+    __publicField(this, "mute", () => {
+      this.setVolume(0);
+    });
+    __publicField(this, "unmute", () => {
+      if (this.props.volume !== null) {
+        this.setVolume(this.props.volume);
+      }
+    });
+    __publicField(this, "ref", (iframe) => {
+      this.iframe = iframe;
+    });
+  }
+  componentDidMount() {
+    this.props.onMount && this.props.onMount(this);
+  }
+  load(url, isReady) {
+    (0, import_utils.getSDK)(SDK_URL, SDK_GLOBAL).then((SC) => {
+      if (!this.iframe)
+        return;
+      const { PLAY, PLAY_PROGRESS, PAUSE, FINISH, ERROR } = SC.Widget.Events;
+      if (!isReady) {
+        this.player = SC.Widget(this.iframe);
+        this.player.bind(PLAY, this.props.onPlay);
+        this.player.bind(PAUSE, () => {
+          const remaining = this.duration - this.currentTime;
+          if (remaining < 0.05) {
+            return;
+          }
+          this.props.onPause();
+        });
+        this.player.bind(PLAY_PROGRESS, (e) => {
+          this.currentTime = e.currentPosition / 1e3;
+          this.fractionLoaded = e.loadedProgress;
+        });
+        this.player.bind(FINISH, () => this.props.onEnded());
+        this.player.bind(ERROR, (e) => this.props.onError(e));
+      }
+      this.player.load(url, {
+        ...this.props.config.options,
+        callback: () => {
+          this.player.getDuration((duration) => {
+            this.duration = duration / 1e3;
+            this.props.onReady();
+          });
+        }
+      });
+    });
+  }
+  play() {
+    this.callPlayer("play");
+  }
+  pause() {
+    this.callPlayer("pause");
+  }
+  stop() {
+  }
+  seekTo(seconds, keepPlaying = true) {
+    this.callPlayer("seekTo", seconds * 1e3);
+    if (!keepPlaying) {
+      this.pause();
+    }
+  }
+  setVolume(fraction) {
+    this.callPlayer("setVolume", fraction * 100);
+  }
+  getDuration() {
+    return this.duration;
+  }
+  getCurrentTime() {
+    return this.currentTime;
+  }
+  getSecondsLoaded() {
+    return this.fractionLoaded * this.duration;
+  }
+  render() {
+    const { display } = this.props;
+    const style = {
+      width: "100%",
+      height: "100%",
+      display
+    };
+    return /* @__PURE__ */ import_react.default.createElement(
+      "iframe",
+      {
+        ref: this.ref,
+        src: `https://w.soundcloud.com/player/?url=${encodeURIComponent(this.props.url)}`,
+        style,
+        frameBorder: 0,
+        allow: "autoplay"
+      }
+    );
+  }
+}
+__publicField(SoundCloud, "displayName", "SoundCloud");
+__publicField(SoundCloud, "canPlay", import_patterns.canPlay.soundcloud);
+__publicField(SoundCloud, "loopOnEnded", true);
+
+
+/***/ })
+
+}]);
+//# sourceMappingURL=reactPlayerSoundCloud.js.map

--- a/src/admin/build/reactPlayerStreamable.js
+++ b/src/admin/build/reactPlayerStreamable.js
@@ -1,1 +1,152 @@
-(globalThis.webpackChunksimplystatic_settings=globalThis.webpackChunksimplystatic_settings||[]).push([[627],{643:(e,t,r)=>{var s,a=Object.create,o=Object.defineProperty,l=Object.getOwnPropertyDescriptor,i=Object.getOwnPropertyNames,n=Object.getPrototypeOf,p=Object.prototype.hasOwnProperty,h=(e,t,r,s)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let a of i(t))p.call(e,a)||a===r||o(e,a,{get:()=>t[a],enumerable:!(s=l(t,a))||s.enumerable});return e},u=(e,t,r)=>(((e,t,r)=>{t in e?o(e,t,{enumerable:!0,configurable:!0,writable:!0,value:r}):e[t]=r})(e,"symbol"!=typeof t?t+"":t,r),r),c={};((e,t)=>{for(var r in t)o(e,r,{get:t[r],enumerable:!0})})(c,{default:()=>f}),e.exports=(s=c,h(o({},"__esModule",{value:!0}),s));var y=((e,t,r)=>(r=null!=e?a(n(e)):{},h(e&&e.__esModule?r:o(r,"default",{value:e,enumerable:!0}),e)))(r(609)),d=r(635),m=r(327);class f extends y.Component{constructor(){super(...arguments),u(this,"callPlayer",d.callPlayer),u(this,"duration",null),u(this,"currentTime",null),u(this,"secondsLoaded",null),u(this,"mute",(()=>{this.callPlayer("mute")})),u(this,"unmute",(()=>{this.callPlayer("unmute")})),u(this,"ref",(e=>{this.iframe=e}))}componentDidMount(){this.props.onMount&&this.props.onMount(this)}load(e){(0,d.getSDK)("https://cdn.embed.ly/player-0.1.0.min.js","playerjs").then((e=>{this.iframe&&(this.player=new e.Player(this.iframe),this.player.setLoop(this.props.loop),this.player.on("ready",this.props.onReady),this.player.on("play",this.props.onPlay),this.player.on("pause",this.props.onPause),this.player.on("seeked",this.props.onSeek),this.player.on("ended",this.props.onEnded),this.player.on("error",this.props.onError),this.player.on("timeupdate",(({duration:e,seconds:t})=>{this.duration=e,this.currentTime=t})),this.player.on("buffered",(({percent:e})=>{this.duration&&(this.secondsLoaded=this.duration*e)})),this.props.muted&&this.player.mute())}),this.props.onError)}play(){this.callPlayer("play")}pause(){this.callPlayer("pause")}stop(){}seekTo(e,t=!0){this.callPlayer("setCurrentTime",e),t||this.pause()}setVolume(e){this.callPlayer("setVolume",100*e)}setLoop(e){this.callPlayer("setLoop",e)}getDuration(){return this.duration}getCurrentTime(){return this.currentTime}getSecondsLoaded(){return this.secondsLoaded}render(){const e=this.props.url.match(m.MATCH_URL_STREAMABLE)[1];return y.default.createElement("iframe",{ref:this.ref,src:`https://streamable.com/o/${e}`,frameBorder:"0",scrolling:"no",style:{width:"100%",height:"100%"},allow:"encrypted-media; autoplay; fullscreen;"})}}u(f,"displayName","Streamable"),u(f,"canPlay",m.canPlay.streamable)}}]);
+(globalThis["webpackChunksimplystatic_settings"] = globalThis["webpackChunksimplystatic_settings"] || []).push([["reactPlayerStreamable"],{
+
+/***/ "./node_modules/react-player/lib/players/Streamable.js":
+/*!*************************************************************!*\
+  !*** ./node_modules/react-player/lib/players/Streamable.js ***!
+  \*************************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var __publicField = (obj, key, value) => {
+  __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
+var Streamable_exports = {};
+__export(Streamable_exports, {
+  default: () => Streamable
+});
+module.exports = __toCommonJS(Streamable_exports);
+var import_react = __toESM(__webpack_require__(/*! react */ "react"));
+var import_utils = __webpack_require__(/*! ../utils */ "./node_modules/react-player/lib/utils.js");
+var import_patterns = __webpack_require__(/*! ../patterns */ "./node_modules/react-player/lib/patterns.js");
+const SDK_URL = "https://cdn.embed.ly/player-0.1.0.min.js";
+const SDK_GLOBAL = "playerjs";
+class Streamable extends import_react.Component {
+  constructor() {
+    super(...arguments);
+    __publicField(this, "callPlayer", import_utils.callPlayer);
+    __publicField(this, "duration", null);
+    __publicField(this, "currentTime", null);
+    __publicField(this, "secondsLoaded", null);
+    __publicField(this, "mute", () => {
+      this.callPlayer("mute");
+    });
+    __publicField(this, "unmute", () => {
+      this.callPlayer("unmute");
+    });
+    __publicField(this, "ref", (iframe) => {
+      this.iframe = iframe;
+    });
+  }
+  componentDidMount() {
+    this.props.onMount && this.props.onMount(this);
+  }
+  load(url) {
+    (0, import_utils.getSDK)(SDK_URL, SDK_GLOBAL).then((playerjs) => {
+      if (!this.iframe)
+        return;
+      this.player = new playerjs.Player(this.iframe);
+      this.player.setLoop(this.props.loop);
+      this.player.on("ready", this.props.onReady);
+      this.player.on("play", this.props.onPlay);
+      this.player.on("pause", this.props.onPause);
+      this.player.on("seeked", this.props.onSeek);
+      this.player.on("ended", this.props.onEnded);
+      this.player.on("error", this.props.onError);
+      this.player.on("timeupdate", ({ duration, seconds }) => {
+        this.duration = duration;
+        this.currentTime = seconds;
+      });
+      this.player.on("buffered", ({ percent }) => {
+        if (this.duration) {
+          this.secondsLoaded = this.duration * percent;
+        }
+      });
+      if (this.props.muted) {
+        this.player.mute();
+      }
+    }, this.props.onError);
+  }
+  play() {
+    this.callPlayer("play");
+  }
+  pause() {
+    this.callPlayer("pause");
+  }
+  stop() {
+  }
+  seekTo(seconds, keepPlaying = true) {
+    this.callPlayer("setCurrentTime", seconds);
+    if (!keepPlaying) {
+      this.pause();
+    }
+  }
+  setVolume(fraction) {
+    this.callPlayer("setVolume", fraction * 100);
+  }
+  setLoop(loop) {
+    this.callPlayer("setLoop", loop);
+  }
+  getDuration() {
+    return this.duration;
+  }
+  getCurrentTime() {
+    return this.currentTime;
+  }
+  getSecondsLoaded() {
+    return this.secondsLoaded;
+  }
+  render() {
+    const id = this.props.url.match(import_patterns.MATCH_URL_STREAMABLE)[1];
+    const style = {
+      width: "100%",
+      height: "100%"
+    };
+    return /* @__PURE__ */ import_react.default.createElement(
+      "iframe",
+      {
+        ref: this.ref,
+        src: `https://streamable.com/o/${id}`,
+        frameBorder: "0",
+        scrolling: "no",
+        style,
+        allow: "encrypted-media; autoplay; fullscreen;"
+      }
+    );
+  }
+}
+__publicField(Streamable, "displayName", "Streamable");
+__publicField(Streamable, "canPlay", import_patterns.canPlay.streamable);
+
+
+/***/ })
+
+}]);
+//# sourceMappingURL=reactPlayerStreamable.js.map

--- a/src/admin/build/reactPlayerTwitch.js
+++ b/src/admin/build/reactPlayerTwitch.js
@@ -1,1 +1,146 @@
-(globalThis.webpackChunksimplystatic_settings=globalThis.webpackChunksimplystatic_settings||[]).push([[42],{400:(e,t,s)=>{var a,r=Object.create,l=Object.defineProperty,i=Object.getOwnPropertyDescriptor,n=Object.getOwnPropertyNames,o=Object.getPrototypeOf,p=Object.prototype.hasOwnProperty,h=(e,t,s,a)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let r of n(t))p.call(e,r)||r===s||l(e,r,{get:()=>t[r],enumerable:!(a=i(t,r))||a.enumerable});return e},y=(e,t,s)=>(((e,t,s)=>{t in e?l(e,t,{enumerable:!0,configurable:!0,writable:!0,value:s}):e[t]=s})(e,"symbol"!=typeof t?t+"":t,s),s),d={};((e,t)=>{for(var s in t)l(e,s,{get:t[s],enumerable:!0})})(d,{default:()=>P}),e.exports=(a=d,h(l({},"__esModule",{value:!0}),a));var c=((e,t,s)=>(s=null!=e?r(o(e)):{},h(e&&e.__esModule?s:l(s,"default",{value:e,enumerable:!0}),e)))(s(609)),u=s(635),m=s(327);class P extends c.Component{constructor(){super(...arguments),y(this,"callPlayer",u.callPlayer),y(this,"playerID",this.props.config.playerId||`twitch-player-${(0,u.randomString)()}`),y(this,"mute",(()=>{this.callPlayer("setMuted",!0)})),y(this,"unmute",(()=>{this.callPlayer("setMuted",!1)}))}componentDidMount(){this.props.onMount&&this.props.onMount(this)}load(e,t){const{playsinline:s,onError:a,config:r,controls:l}=this.props,i=m.MATCH_URL_TWITCH_CHANNEL.test(e),n=i?e.match(m.MATCH_URL_TWITCH_CHANNEL)[1]:e.match(m.MATCH_URL_TWITCH_VIDEO)[1];t?i?this.player.setChannel(n):this.player.setVideo("v"+n):(0,u.getSDK)("https://player.twitch.tv/js/embed/v1.js","Twitch").then((t=>{this.player=new t.Player(this.playerID,{video:i?"":n,channel:i?n:"",height:"100%",width:"100%",playsinline:s,autoplay:this.props.playing,muted:this.props.muted,controls:!!i||l,time:(0,u.parseStartTime)(e),...r.options});const{READY:a,PLAYING:o,PAUSE:p,ENDED:h,ONLINE:y,OFFLINE:d,SEEK:c}=t.Player;this.player.addEventListener(a,this.props.onReady),this.player.addEventListener(o,this.props.onPlay),this.player.addEventListener(p,this.props.onPause),this.player.addEventListener(h,this.props.onEnded),this.player.addEventListener(c,this.props.onSeek),this.player.addEventListener(y,this.props.onLoaded),this.player.addEventListener(d,this.props.onLoaded)}),a)}play(){this.callPlayer("play")}pause(){this.callPlayer("pause")}stop(){this.callPlayer("pause")}seekTo(e,t=!0){this.callPlayer("seek",e),t||this.pause()}setVolume(e){this.callPlayer("setVolume",e)}getDuration(){return this.callPlayer("getDuration")}getCurrentTime(){return this.callPlayer("getCurrentTime")}getSecondsLoaded(){return null}render(){return c.default.createElement("div",{style:{width:"100%",height:"100%"},id:this.playerID})}}y(P,"displayName","Twitch"),y(P,"canPlay",m.canPlay.twitch),y(P,"loopOnEnded",!0)}}]);
+(globalThis["webpackChunksimplystatic_settings"] = globalThis["webpackChunksimplystatic_settings"] || []).push([["reactPlayerTwitch"],{
+
+/***/ "./node_modules/react-player/lib/players/Twitch.js":
+/*!*********************************************************!*\
+  !*** ./node_modules/react-player/lib/players/Twitch.js ***!
+  \*********************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var __publicField = (obj, key, value) => {
+  __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
+var Twitch_exports = {};
+__export(Twitch_exports, {
+  default: () => Twitch
+});
+module.exports = __toCommonJS(Twitch_exports);
+var import_react = __toESM(__webpack_require__(/*! react */ "react"));
+var import_utils = __webpack_require__(/*! ../utils */ "./node_modules/react-player/lib/utils.js");
+var import_patterns = __webpack_require__(/*! ../patterns */ "./node_modules/react-player/lib/patterns.js");
+const SDK_URL = "https://player.twitch.tv/js/embed/v1.js";
+const SDK_GLOBAL = "Twitch";
+const PLAYER_ID_PREFIX = "twitch-player-";
+class Twitch extends import_react.Component {
+  constructor() {
+    super(...arguments);
+    __publicField(this, "callPlayer", import_utils.callPlayer);
+    __publicField(this, "playerID", this.props.config.playerId || `${PLAYER_ID_PREFIX}${(0, import_utils.randomString)()}`);
+    __publicField(this, "mute", () => {
+      this.callPlayer("setMuted", true);
+    });
+    __publicField(this, "unmute", () => {
+      this.callPlayer("setMuted", false);
+    });
+  }
+  componentDidMount() {
+    this.props.onMount && this.props.onMount(this);
+  }
+  load(url, isReady) {
+    const { playsinline, onError, config, controls } = this.props;
+    const isChannel = import_patterns.MATCH_URL_TWITCH_CHANNEL.test(url);
+    const id = isChannel ? url.match(import_patterns.MATCH_URL_TWITCH_CHANNEL)[1] : url.match(import_patterns.MATCH_URL_TWITCH_VIDEO)[1];
+    if (isReady) {
+      if (isChannel) {
+        this.player.setChannel(id);
+      } else {
+        this.player.setVideo("v" + id);
+      }
+      return;
+    }
+    (0, import_utils.getSDK)(SDK_URL, SDK_GLOBAL).then((Twitch2) => {
+      this.player = new Twitch2.Player(this.playerID, {
+        video: isChannel ? "" : id,
+        channel: isChannel ? id : "",
+        height: "100%",
+        width: "100%",
+        playsinline,
+        autoplay: this.props.playing,
+        muted: this.props.muted,
+        // https://github.com/CookPete/react-player/issues/733#issuecomment-549085859
+        controls: isChannel ? true : controls,
+        time: (0, import_utils.parseStartTime)(url),
+        ...config.options
+      });
+      const { READY, PLAYING, PAUSE, ENDED, ONLINE, OFFLINE, SEEK } = Twitch2.Player;
+      this.player.addEventListener(READY, this.props.onReady);
+      this.player.addEventListener(PLAYING, this.props.onPlay);
+      this.player.addEventListener(PAUSE, this.props.onPause);
+      this.player.addEventListener(ENDED, this.props.onEnded);
+      this.player.addEventListener(SEEK, this.props.onSeek);
+      this.player.addEventListener(ONLINE, this.props.onLoaded);
+      this.player.addEventListener(OFFLINE, this.props.onLoaded);
+    }, onError);
+  }
+  play() {
+    this.callPlayer("play");
+  }
+  pause() {
+    this.callPlayer("pause");
+  }
+  stop() {
+    this.callPlayer("pause");
+  }
+  seekTo(seconds, keepPlaying = true) {
+    this.callPlayer("seek", seconds);
+    if (!keepPlaying) {
+      this.pause();
+    }
+  }
+  setVolume(fraction) {
+    this.callPlayer("setVolume", fraction);
+  }
+  getDuration() {
+    return this.callPlayer("getDuration");
+  }
+  getCurrentTime() {
+    return this.callPlayer("getCurrentTime");
+  }
+  getSecondsLoaded() {
+    return null;
+  }
+  render() {
+    const style = {
+      width: "100%",
+      height: "100%"
+    };
+    return /* @__PURE__ */ import_react.default.createElement("div", { style, id: this.playerID });
+  }
+}
+__publicField(Twitch, "displayName", "Twitch");
+__publicField(Twitch, "canPlay", import_patterns.canPlay.twitch);
+__publicField(Twitch, "loopOnEnded", true);
+
+
+/***/ })
+
+}]);
+//# sourceMappingURL=reactPlayerTwitch.js.map

--- a/src/admin/build/reactPlayerVidyard.js
+++ b/src/admin/build/reactPlayerVidyard.js
@@ -1,1 +1,150 @@
-(globalThis.webpackChunksimplystatic_settings=globalThis.webpackChunksimplystatic_settings||[]).push([[392],{552:(e,t,a)=>{var s,r=Object.create,l=Object.defineProperty,i=Object.getOwnPropertyDescriptor,o=Object.getOwnPropertyNames,n=Object.getPrototypeOf,p=Object.prototype.hasOwnProperty,y=(e,t,a,s)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let r of o(t))p.call(e,r)||r===a||l(e,r,{get:()=>t[r],enumerable:!(s=i(t,r))||s.enumerable});return e},h=(e,t,a)=>(((e,t,a)=>{t in e?l(e,t,{enumerable:!0,configurable:!0,writable:!0,value:a}):e[t]=a})(e,"symbol"!=typeof t?t+"":t,a),a),u={};((e,t)=>{for(var a in t)l(e,a,{get:t[a],enumerable:!0})})(u,{default:()=>P}),e.exports=(s=u,y(l({},"__esModule",{value:!0}),s));var d=((e,t,a)=>(a=null!=e?r(n(e)):{},y(e&&e.__esModule?a:l(a,"default",{value:e,enumerable:!0}),e)))(a(609)),c=a(635),m=a(327);class P extends d.Component{constructor(){super(...arguments),h(this,"callPlayer",c.callPlayer),h(this,"mute",(()=>{this.setVolume(0)})),h(this,"unmute",(()=>{null!==this.props.volume&&this.setVolume(this.props.volume)})),h(this,"ref",(e=>{this.container=e}))}componentDidMount(){this.props.onMount&&this.props.onMount(this)}load(e){const{playing:t,config:a,onError:s,onDuration:r}=this.props,l=e&&e.match(m.MATCH_URL_VIDYARD)[1];this.player&&this.stop(),(0,c.getSDK)("https://play.vidyard.com/embed/v4.js","VidyardV4","onVidyardAPI").then((e=>{this.container&&(e.api.addReadyListener(((e,t)=>{this.player||(this.player=t,this.player.on("ready",this.props.onReady),this.player.on("play",this.props.onPlay),this.player.on("pause",this.props.onPause),this.player.on("seek",this.props.onSeek),this.player.on("playerComplete",this.props.onEnded))}),l),e.api.renderPlayer({uuid:l,container:this.container,autoplay:t?1:0,...a.options}),e.api.getPlayerMetadata(l).then((e=>{this.duration=e.length_in_seconds,r(e.length_in_seconds)})))}),s)}play(){this.callPlayer("play")}pause(){this.callPlayer("pause")}stop(){window.VidyardV4.api.destroyPlayer(this.player)}seekTo(e,t=!0){this.callPlayer("seek",e),t||this.pause()}setVolume(e){this.callPlayer("setVolume",e)}setPlaybackRate(e){this.callPlayer("setPlaybackSpeed",e)}getDuration(){return this.duration}getCurrentTime(){return this.callPlayer("currentTime")}getSecondsLoaded(){return null}render(){const{display:e}=this.props,t={width:"100%",height:"100%",display:e};return d.default.createElement("div",{style:t},d.default.createElement("div",{ref:this.ref}))}}h(P,"displayName","Vidyard"),h(P,"canPlay",m.canPlay.vidyard)}}]);
+(globalThis["webpackChunksimplystatic_settings"] = globalThis["webpackChunksimplystatic_settings"] || []).push([["reactPlayerVidyard"],{
+
+/***/ "./node_modules/react-player/lib/players/Vidyard.js":
+/*!**********************************************************!*\
+  !*** ./node_modules/react-player/lib/players/Vidyard.js ***!
+  \**********************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var __publicField = (obj, key, value) => {
+  __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
+var Vidyard_exports = {};
+__export(Vidyard_exports, {
+  default: () => Vidyard
+});
+module.exports = __toCommonJS(Vidyard_exports);
+var import_react = __toESM(__webpack_require__(/*! react */ "react"));
+var import_utils = __webpack_require__(/*! ../utils */ "./node_modules/react-player/lib/utils.js");
+var import_patterns = __webpack_require__(/*! ../patterns */ "./node_modules/react-player/lib/patterns.js");
+const SDK_URL = "https://play.vidyard.com/embed/v4.js";
+const SDK_GLOBAL = "VidyardV4";
+const SDK_GLOBAL_READY = "onVidyardAPI";
+class Vidyard extends import_react.Component {
+  constructor() {
+    super(...arguments);
+    __publicField(this, "callPlayer", import_utils.callPlayer);
+    __publicField(this, "mute", () => {
+      this.setVolume(0);
+    });
+    __publicField(this, "unmute", () => {
+      if (this.props.volume !== null) {
+        this.setVolume(this.props.volume);
+      }
+    });
+    __publicField(this, "ref", (container) => {
+      this.container = container;
+    });
+  }
+  componentDidMount() {
+    this.props.onMount && this.props.onMount(this);
+  }
+  load(url) {
+    const { playing, config, onError, onDuration } = this.props;
+    const id = url && url.match(import_patterns.MATCH_URL_VIDYARD)[1];
+    if (this.player) {
+      this.stop();
+    }
+    (0, import_utils.getSDK)(SDK_URL, SDK_GLOBAL, SDK_GLOBAL_READY).then((Vidyard2) => {
+      if (!this.container)
+        return;
+      Vidyard2.api.addReadyListener((data, player) => {
+        if (this.player) {
+          return;
+        }
+        this.player = player;
+        this.player.on("ready", this.props.onReady);
+        this.player.on("play", this.props.onPlay);
+        this.player.on("pause", this.props.onPause);
+        this.player.on("seek", this.props.onSeek);
+        this.player.on("playerComplete", this.props.onEnded);
+      }, id);
+      Vidyard2.api.renderPlayer({
+        uuid: id,
+        container: this.container,
+        autoplay: playing ? 1 : 0,
+        ...config.options
+      });
+      Vidyard2.api.getPlayerMetadata(id).then((meta) => {
+        this.duration = meta.length_in_seconds;
+        onDuration(meta.length_in_seconds);
+      });
+    }, onError);
+  }
+  play() {
+    this.callPlayer("play");
+  }
+  pause() {
+    this.callPlayer("pause");
+  }
+  stop() {
+    window.VidyardV4.api.destroyPlayer(this.player);
+  }
+  seekTo(amount, keepPlaying = true) {
+    this.callPlayer("seek", amount);
+    if (!keepPlaying) {
+      this.pause();
+    }
+  }
+  setVolume(fraction) {
+    this.callPlayer("setVolume", fraction);
+  }
+  setPlaybackRate(rate) {
+    this.callPlayer("setPlaybackSpeed", rate);
+  }
+  getDuration() {
+    return this.duration;
+  }
+  getCurrentTime() {
+    return this.callPlayer("currentTime");
+  }
+  getSecondsLoaded() {
+    return null;
+  }
+  render() {
+    const { display } = this.props;
+    const style = {
+      width: "100%",
+      height: "100%",
+      display
+    };
+    return /* @__PURE__ */ import_react.default.createElement("div", { style }, /* @__PURE__ */ import_react.default.createElement("div", { ref: this.ref }));
+  }
+}
+__publicField(Vidyard, "displayName", "Vidyard");
+__publicField(Vidyard, "canPlay", import_patterns.canPlay.vidyard);
+
+
+/***/ })
+
+}]);
+//# sourceMappingURL=reactPlayerVidyard.js.map

--- a/src/admin/build/reactPlayerVimeo.js
+++ b/src/admin/build/reactPlayerVimeo.js
@@ -1,1 +1,191 @@
-(globalThis.webpackChunksimplystatic_settings=globalThis.webpackChunksimplystatic_settings||[]).push([[173],{423:(e,t,s)=>{var r,o=Object.create,a=Object.defineProperty,i=Object.getOwnPropertyDescriptor,l=Object.getOwnPropertyNames,n=Object.getPrototypeOf,p=Object.prototype.hasOwnProperty,h=(e,t,s,r)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let o of l(t))p.call(e,o)||o===s||a(e,o,{get:()=>t[o],enumerable:!(r=i(t,o))||r.enumerable});return e},u=(e,t,s)=>(((e,t,s)=>{t in e?a(e,t,{enumerable:!0,configurable:!0,writable:!0,value:s}):e[t]=s})(e,"symbol"!=typeof t?t+"":t,s),s),c={};((e,t)=>{for(var s in t)a(e,s,{get:t[s],enumerable:!0})})(c,{default:()=>b}),e.exports=(r=c,h(a({},"__esModule",{value:!0}),r));var y=((e,t,s)=>(s=null!=e?o(n(e)):{},h(e&&e.__esModule?s:a(s,"default",{value:e,enumerable:!0}),e)))(s(609)),d=s(635),f=s(327);const m=e=>e.replace("/manage/videos","");class b extends y.Component{constructor(){super(...arguments),u(this,"callPlayer",d.callPlayer),u(this,"duration",null),u(this,"currentTime",null),u(this,"secondsLoaded",null),u(this,"mute",(()=>{this.setMuted(!0)})),u(this,"unmute",(()=>{this.setMuted(!1)})),u(this,"ref",(e=>{this.container=e}))}componentDidMount(){this.props.onMount&&this.props.onMount(this)}load(e){this.duration=null,(0,d.getSDK)("https://player.vimeo.com/api/player.js","Vimeo").then((t=>{if(!this.container)return;const{playerOptions:s,title:r}=this.props.config;this.player=new t.Player(this.container,{url:m(e),autoplay:this.props.playing,muted:this.props.muted,loop:this.props.loop,playsinline:this.props.playsinline,controls:this.props.controls,...s}),this.player.ready().then((()=>{const e=this.container.querySelector("iframe");e.style.width="100%",e.style.height="100%",r&&(e.title=r)})).catch(this.props.onError),this.player.on("loaded",(()=>{this.props.onReady(),this.refreshDuration()})),this.player.on("play",(()=>{this.props.onPlay(),this.refreshDuration()})),this.player.on("pause",this.props.onPause),this.player.on("seeked",(e=>this.props.onSeek(e.seconds))),this.player.on("ended",this.props.onEnded),this.player.on("error",this.props.onError),this.player.on("timeupdate",(({seconds:e})=>{this.currentTime=e})),this.player.on("progress",(({seconds:e})=>{this.secondsLoaded=e})),this.player.on("bufferstart",this.props.onBuffer),this.player.on("bufferend",this.props.onBufferEnd),this.player.on("playbackratechange",(e=>this.props.onPlaybackRateChange(e.playbackRate)))}),this.props.onError)}refreshDuration(){this.player.getDuration().then((e=>{this.duration=e}))}play(){const e=this.callPlayer("play");e&&e.catch(this.props.onError)}pause(){this.callPlayer("pause")}stop(){this.callPlayer("unload")}seekTo(e,t=!0){this.callPlayer("setCurrentTime",e),t||this.pause()}setVolume(e){this.callPlayer("setVolume",e)}setMuted(e){this.callPlayer("setMuted",e)}setLoop(e){this.callPlayer("setLoop",e)}setPlaybackRate(e){this.callPlayer("setPlaybackRate",e)}getDuration(){return this.duration}getCurrentTime(){return this.currentTime}getSecondsLoaded(){return this.secondsLoaded}render(){const{display:e}=this.props,t={width:"100%",height:"100%",overflow:"hidden",display:e};return y.default.createElement("div",{key:this.props.url,ref:this.ref,style:t})}}u(b,"displayName","Vimeo"),u(b,"canPlay",f.canPlay.vimeo),u(b,"forceLoad",!0)}}]);
+(globalThis["webpackChunksimplystatic_settings"] = globalThis["webpackChunksimplystatic_settings"] || []).push([["reactPlayerVimeo"],{
+
+/***/ "./node_modules/react-player/lib/players/Vimeo.js":
+/*!********************************************************!*\
+  !*** ./node_modules/react-player/lib/players/Vimeo.js ***!
+  \********************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var __publicField = (obj, key, value) => {
+  __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
+var Vimeo_exports = {};
+__export(Vimeo_exports, {
+  default: () => Vimeo
+});
+module.exports = __toCommonJS(Vimeo_exports);
+var import_react = __toESM(__webpack_require__(/*! react */ "react"));
+var import_utils = __webpack_require__(/*! ../utils */ "./node_modules/react-player/lib/utils.js");
+var import_patterns = __webpack_require__(/*! ../patterns */ "./node_modules/react-player/lib/patterns.js");
+const SDK_URL = "https://player.vimeo.com/api/player.js";
+const SDK_GLOBAL = "Vimeo";
+const cleanUrl = (url) => {
+  return url.replace("/manage/videos", "");
+};
+class Vimeo extends import_react.Component {
+  constructor() {
+    super(...arguments);
+    // Prevent checking isLoading when URL changes
+    __publicField(this, "callPlayer", import_utils.callPlayer);
+    __publicField(this, "duration", null);
+    __publicField(this, "currentTime", null);
+    __publicField(this, "secondsLoaded", null);
+    __publicField(this, "mute", () => {
+      this.setMuted(true);
+    });
+    __publicField(this, "unmute", () => {
+      this.setMuted(false);
+    });
+    __publicField(this, "ref", (container) => {
+      this.container = container;
+    });
+  }
+  componentDidMount() {
+    this.props.onMount && this.props.onMount(this);
+  }
+  load(url) {
+    this.duration = null;
+    (0, import_utils.getSDK)(SDK_URL, SDK_GLOBAL).then((Vimeo2) => {
+      if (!this.container)
+        return;
+      const { playerOptions, title } = this.props.config;
+      this.player = new Vimeo2.Player(this.container, {
+        url: cleanUrl(url),
+        autoplay: this.props.playing,
+        muted: this.props.muted,
+        loop: this.props.loop,
+        playsinline: this.props.playsinline,
+        controls: this.props.controls,
+        ...playerOptions
+      });
+      this.player.ready().then(() => {
+        const iframe = this.container.querySelector("iframe");
+        iframe.style.width = "100%";
+        iframe.style.height = "100%";
+        if (title) {
+          iframe.title = title;
+        }
+      }).catch(this.props.onError);
+      this.player.on("loaded", () => {
+        this.props.onReady();
+        this.refreshDuration();
+      });
+      this.player.on("play", () => {
+        this.props.onPlay();
+        this.refreshDuration();
+      });
+      this.player.on("pause", this.props.onPause);
+      this.player.on("seeked", (e) => this.props.onSeek(e.seconds));
+      this.player.on("ended", this.props.onEnded);
+      this.player.on("error", this.props.onError);
+      this.player.on("timeupdate", ({ seconds }) => {
+        this.currentTime = seconds;
+      });
+      this.player.on("progress", ({ seconds }) => {
+        this.secondsLoaded = seconds;
+      });
+      this.player.on("bufferstart", this.props.onBuffer);
+      this.player.on("bufferend", this.props.onBufferEnd);
+      this.player.on("playbackratechange", (e) => this.props.onPlaybackRateChange(e.playbackRate));
+    }, this.props.onError);
+  }
+  refreshDuration() {
+    this.player.getDuration().then((duration) => {
+      this.duration = duration;
+    });
+  }
+  play() {
+    const promise = this.callPlayer("play");
+    if (promise) {
+      promise.catch(this.props.onError);
+    }
+  }
+  pause() {
+    this.callPlayer("pause");
+  }
+  stop() {
+    this.callPlayer("unload");
+  }
+  seekTo(seconds, keepPlaying = true) {
+    this.callPlayer("setCurrentTime", seconds);
+    if (!keepPlaying) {
+      this.pause();
+    }
+  }
+  setVolume(fraction) {
+    this.callPlayer("setVolume", fraction);
+  }
+  setMuted(muted) {
+    this.callPlayer("setMuted", muted);
+  }
+  setLoop(loop) {
+    this.callPlayer("setLoop", loop);
+  }
+  setPlaybackRate(rate) {
+    this.callPlayer("setPlaybackRate", rate);
+  }
+  getDuration() {
+    return this.duration;
+  }
+  getCurrentTime() {
+    return this.currentTime;
+  }
+  getSecondsLoaded() {
+    return this.secondsLoaded;
+  }
+  render() {
+    const { display } = this.props;
+    const style = {
+      width: "100%",
+      height: "100%",
+      overflow: "hidden",
+      display
+    };
+    return /* @__PURE__ */ import_react.default.createElement(
+      "div",
+      {
+        key: this.props.url,
+        ref: this.ref,
+        style
+      }
+    );
+  }
+}
+__publicField(Vimeo, "displayName", "Vimeo");
+__publicField(Vimeo, "canPlay", import_patterns.canPlay.vimeo);
+__publicField(Vimeo, "forceLoad", true);
+
+
+/***/ })
+
+}]);
+//# sourceMappingURL=reactPlayerVimeo.js.map

--- a/src/admin/build/reactPlayerWistia.js
+++ b/src/admin/build/reactPlayerWistia.js
@@ -1,1 +1,166 @@
-(globalThis.webpackChunksimplystatic_settings=globalThis.webpackChunksimplystatic_settings||[]).push([[340],{330:(e,t,a)=>{var s,l=Object.create,n=Object.defineProperty,i=Object.getOwnPropertyDescriptor,o=Object.getOwnPropertyNames,r=Object.getPrototypeOf,p=Object.prototype.hasOwnProperty,h=(e,t,a,s)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let l of o(t))p.call(e,l)||l===a||n(e,l,{get:()=>t[l],enumerable:!(s=i(t,l))||s.enumerable});return e},u=(e,t,a)=>(((e,t,a)=>{t in e?n(e,t,{enumerable:!0,configurable:!0,writable:!0,value:a}):e[t]=a})(e,"symbol"!=typeof t?t+"":t,a),a),y={};((e,t)=>{for(var a in t)n(e,a,{get:t[a],enumerable:!0})})(y,{default:()=>P}),e.exports=(s=y,h(n({},"__esModule",{value:!0}),s));var c=((e,t,a)=>(a=null!=e?l(r(e)):{},h(e&&e.__esModule?a:n(a,"default",{value:e,enumerable:!0}),e)))(a(609)),d=a(635),b=a(327);class P extends c.Component{constructor(){super(...arguments),u(this,"callPlayer",d.callPlayer),u(this,"playerID",this.props.config.playerId||`wistia-player-${(0,d.randomString)()}`),u(this,"onPlay",((...e)=>this.props.onPlay(...e))),u(this,"onPause",((...e)=>this.props.onPause(...e))),u(this,"onSeek",((...e)=>this.props.onSeek(...e))),u(this,"onEnded",((...e)=>this.props.onEnded(...e))),u(this,"onPlaybackRateChange",((...e)=>this.props.onPlaybackRateChange(...e))),u(this,"mute",(()=>{this.callPlayer("mute")})),u(this,"unmute",(()=>{this.callPlayer("unmute")}))}componentDidMount(){this.props.onMount&&this.props.onMount(this)}load(e){const{playing:t,muted:a,controls:s,onReady:l,config:n,onError:i}=this.props;(0,d.getSDK)("https://fast.wistia.com/assets/external/E-v1.js","Wistia").then((e=>{n.customControls&&n.customControls.forEach((t=>e.defineControl(t))),window._wq=window._wq||[],window._wq.push({id:this.playerID,options:{autoPlay:t,silentAutoPlay:"allow",muted:a,controlsVisibleOnLoad:s,fullscreenButton:s,playbar:s,playbackRateControl:s,qualityControl:s,volumeControl:s,settingsControl:s,smallPlayButton:s,...n.options},onReady:e=>{this.player=e,this.unbind(),this.player.bind("play",this.onPlay),this.player.bind("pause",this.onPause),this.player.bind("seek",this.onSeek),this.player.bind("end",this.onEnded),this.player.bind("playbackratechange",this.onPlaybackRateChange),l()}})}),i)}unbind(){this.player.unbind("play",this.onPlay),this.player.unbind("pause",this.onPause),this.player.unbind("seek",this.onSeek),this.player.unbind("end",this.onEnded),this.player.unbind("playbackratechange",this.onPlaybackRateChange)}play(){this.callPlayer("play")}pause(){this.callPlayer("pause")}stop(){this.unbind(),this.callPlayer("remove")}seekTo(e,t=!0){this.callPlayer("time",e),t||this.pause()}setVolume(e){this.callPlayer("volume",e)}setPlaybackRate(e){this.callPlayer("playbackRate",e)}getDuration(){return this.callPlayer("duration")}getCurrentTime(){return this.callPlayer("time")}getSecondsLoaded(){return null}render(){const{url:e}=this.props,t=e&&e.match(b.MATCH_URL_WISTIA)[1],a=`wistia_embed wistia_async_${t}`;return c.default.createElement("div",{id:this.playerID,key:t,className:a,style:{width:"100%",height:"100%"}})}}u(P,"displayName","Wistia"),u(P,"canPlay",b.canPlay.wistia),u(P,"loopOnEnded",!0)}}]);
+(globalThis["webpackChunksimplystatic_settings"] = globalThis["webpackChunksimplystatic_settings"] || []).push([["reactPlayerWistia"],{
+
+/***/ "./node_modules/react-player/lib/players/Wistia.js":
+/*!*********************************************************!*\
+  !*** ./node_modules/react-player/lib/players/Wistia.js ***!
+  \*********************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var __publicField = (obj, key, value) => {
+  __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
+var Wistia_exports = {};
+__export(Wistia_exports, {
+  default: () => Wistia
+});
+module.exports = __toCommonJS(Wistia_exports);
+var import_react = __toESM(__webpack_require__(/*! react */ "react"));
+var import_utils = __webpack_require__(/*! ../utils */ "./node_modules/react-player/lib/utils.js");
+var import_patterns = __webpack_require__(/*! ../patterns */ "./node_modules/react-player/lib/patterns.js");
+const SDK_URL = "https://fast.wistia.com/assets/external/E-v1.js";
+const SDK_GLOBAL = "Wistia";
+const PLAYER_ID_PREFIX = "wistia-player-";
+class Wistia extends import_react.Component {
+  constructor() {
+    super(...arguments);
+    __publicField(this, "callPlayer", import_utils.callPlayer);
+    __publicField(this, "playerID", this.props.config.playerId || `${PLAYER_ID_PREFIX}${(0, import_utils.randomString)()}`);
+    // Proxy methods to prevent listener leaks
+    __publicField(this, "onPlay", (...args) => this.props.onPlay(...args));
+    __publicField(this, "onPause", (...args) => this.props.onPause(...args));
+    __publicField(this, "onSeek", (...args) => this.props.onSeek(...args));
+    __publicField(this, "onEnded", (...args) => this.props.onEnded(...args));
+    __publicField(this, "onPlaybackRateChange", (...args) => this.props.onPlaybackRateChange(...args));
+    __publicField(this, "mute", () => {
+      this.callPlayer("mute");
+    });
+    __publicField(this, "unmute", () => {
+      this.callPlayer("unmute");
+    });
+  }
+  componentDidMount() {
+    this.props.onMount && this.props.onMount(this);
+  }
+  load(url) {
+    const { playing, muted, controls, onReady, config, onError } = this.props;
+    (0, import_utils.getSDK)(SDK_URL, SDK_GLOBAL).then((Wistia2) => {
+      if (config.customControls) {
+        config.customControls.forEach((control) => Wistia2.defineControl(control));
+      }
+      window._wq = window._wq || [];
+      window._wq.push({
+        id: this.playerID,
+        options: {
+          autoPlay: playing,
+          silentAutoPlay: "allow",
+          muted,
+          controlsVisibleOnLoad: controls,
+          fullscreenButton: controls,
+          playbar: controls,
+          playbackRateControl: controls,
+          qualityControl: controls,
+          volumeControl: controls,
+          settingsControl: controls,
+          smallPlayButton: controls,
+          ...config.options
+        },
+        onReady: (player) => {
+          this.player = player;
+          this.unbind();
+          this.player.bind("play", this.onPlay);
+          this.player.bind("pause", this.onPause);
+          this.player.bind("seek", this.onSeek);
+          this.player.bind("end", this.onEnded);
+          this.player.bind("playbackratechange", this.onPlaybackRateChange);
+          onReady();
+        }
+      });
+    }, onError);
+  }
+  unbind() {
+    this.player.unbind("play", this.onPlay);
+    this.player.unbind("pause", this.onPause);
+    this.player.unbind("seek", this.onSeek);
+    this.player.unbind("end", this.onEnded);
+    this.player.unbind("playbackratechange", this.onPlaybackRateChange);
+  }
+  play() {
+    this.callPlayer("play");
+  }
+  pause() {
+    this.callPlayer("pause");
+  }
+  stop() {
+    this.unbind();
+    this.callPlayer("remove");
+  }
+  seekTo(seconds, keepPlaying = true) {
+    this.callPlayer("time", seconds);
+    if (!keepPlaying) {
+      this.pause();
+    }
+  }
+  setVolume(fraction) {
+    this.callPlayer("volume", fraction);
+  }
+  setPlaybackRate(rate) {
+    this.callPlayer("playbackRate", rate);
+  }
+  getDuration() {
+    return this.callPlayer("duration");
+  }
+  getCurrentTime() {
+    return this.callPlayer("time");
+  }
+  getSecondsLoaded() {
+    return null;
+  }
+  render() {
+    const { url } = this.props;
+    const videoID = url && url.match(import_patterns.MATCH_URL_WISTIA)[1];
+    const className = `wistia_embed wistia_async_${videoID}`;
+    const style = {
+      width: "100%",
+      height: "100%"
+    };
+    return /* @__PURE__ */ import_react.default.createElement("div", { id: this.playerID, key: videoID, className, style });
+  }
+}
+__publicField(Wistia, "displayName", "Wistia");
+__publicField(Wistia, "canPlay", import_patterns.canPlay.wistia);
+__publicField(Wistia, "loopOnEnded", true);
+
+
+/***/ })
+
+}]);
+//# sourceMappingURL=reactPlayerWistia.js.map

--- a/src/admin/build/reactPlayerYouTube.js
+++ b/src/admin/build/reactPlayerYouTube.js
@@ -1,1 +1,236 @@
-(globalThis.webpackChunksimplystatic_settings=globalThis.webpackChunksimplystatic_settings||[]).push([[446],{910:(e,t,a)=>{var s,l=Object.create,o=Object.defineProperty,n=Object.getOwnPropertyDescriptor,r=Object.getOwnPropertyNames,i=Object.getPrototypeOf,p=Object.prototype.hasOwnProperty,y=(e,t,a,s)=>{if(t&&"object"==typeof t||"function"==typeof t)for(let l of r(t))p.call(e,l)||l===a||o(e,l,{get:()=>t[l],enumerable:!(s=n(t,l))||s.enumerable});return e},c=(e,t,a)=>(((e,t,a)=>{t in e?o(e,t,{enumerable:!0,configurable:!0,writable:!0,value:a}):e[t]=a})(e,"symbol"!=typeof t?t+"":t,a),a),u={};((e,t)=>{for(var a in t)o(e,a,{get:t[a],enumerable:!0})})(u,{default:()=>f}),e.exports=(s=u,y(o({},"__esModule",{value:!0}),s));var h=((e,t,a)=>(a=null!=e?l(i(e)):{},y(e&&e.__esModule?a:o(a,"default",{value:e,enumerable:!0}),e)))(a(609)),d=a(635),P=a(327);const g=/[?&](?:list|channel)=([a-zA-Z0-9_-]+)/,m=/user\/([a-zA-Z0-9_-]+)\/?/,b=/youtube-nocookie\.com/;class f extends h.Component{constructor(){super(...arguments),c(this,"callPlayer",d.callPlayer),c(this,"parsePlaylist",(e=>{if(e instanceof Array)return{listType:"playlist",playlist:e.map(this.getID).join(",")};if(g.test(e)){const[,t]=e.match(g);return{listType:"playlist",list:t.replace(/^UC/,"UU")}}if(m.test(e)){const[,t]=e.match(m);return{listType:"user_uploads",list:t}}return{}})),c(this,"onStateChange",(e=>{const{data:t}=e,{onPlay:a,onPause:s,onBuffer:l,onBufferEnd:o,onEnded:n,onReady:r,loop:i,config:{playerVars:p,onUnstarted:y}}=this.props,{UNSTARTED:c,PLAYING:u,PAUSED:h,BUFFERING:d,ENDED:P,CUED:g}=window.YT.PlayerState;if(t===c&&y(),t===u&&(a(),o()),t===h&&s(),t===d&&l(),t===P){const e=!!this.callPlayer("getPlaylist");i&&!e&&(p.start?this.seekTo(p.start):this.play()),n()}t===g&&r()})),c(this,"mute",(()=>{this.callPlayer("mute")})),c(this,"unmute",(()=>{this.callPlayer("unMute")})),c(this,"ref",(e=>{this.container=e}))}componentDidMount(){this.props.onMount&&this.props.onMount(this)}getID(e){return!e||e instanceof Array||g.test(e)?null:e.match(P.MATCH_URL_YOUTUBE)[1]}load(e,t){const{playing:a,muted:s,playsinline:l,controls:o,loop:n,config:r,onError:i}=this.props,{playerVars:p,embedOptions:y}=r,c=this.getID(e);if(t)return g.test(e)||m.test(e)||e instanceof Array?void this.player.loadPlaylist(this.parsePlaylist(e)):void this.player.cueVideoById({videoId:c,startSeconds:(0,d.parseStartTime)(e)||p.start,endSeconds:(0,d.parseEndTime)(e)||p.end});(0,d.getSDK)("https://www.youtube.com/iframe_api","YT","onYouTubeIframeAPIReady",(e=>e.loaded)).then((t=>{this.container&&(this.player=new t.Player(this.container,{width:"100%",height:"100%",videoId:c,playerVars:{autoplay:a?1:0,mute:s?1:0,controls:o?1:0,start:(0,d.parseStartTime)(e),end:(0,d.parseEndTime)(e),origin:window.location.origin,playsinline:l?1:0,...this.parsePlaylist(e),...p},events:{onReady:()=>{n&&this.player.setLoop(!0),this.props.onReady()},onPlaybackRateChange:e=>this.props.onPlaybackRateChange(e.data),onPlaybackQualityChange:e=>this.props.onPlaybackQualityChange(e),onStateChange:this.onStateChange,onError:e=>i(e.data)},host:b.test(e)?"https://www.youtube-nocookie.com":void 0,...y}))}),i),y.events&&console.warn("Using `embedOptions.events` will likely break things. Use ReactPlayer’s callback props instead, eg onReady, onPlay, onPause")}play(){this.callPlayer("playVideo")}pause(){this.callPlayer("pauseVideo")}stop(){document.body.contains(this.callPlayer("getIframe"))&&this.callPlayer("stopVideo")}seekTo(e,t=!1){this.callPlayer("seekTo",e),t||this.props.playing||this.pause()}setVolume(e){this.callPlayer("setVolume",100*e)}setPlaybackRate(e){this.callPlayer("setPlaybackRate",e)}setLoop(e){this.callPlayer("setLoop",e)}getDuration(){return this.callPlayer("getDuration")}getCurrentTime(){return this.callPlayer("getCurrentTime")}getSecondsLoaded(){return this.callPlayer("getVideoLoadedFraction")*this.getDuration()}render(){const{display:e}=this.props,t={width:"100%",height:"100%",display:e};return h.default.createElement("div",{style:t},h.default.createElement("div",{ref:this.ref}))}}c(f,"displayName","YouTube"),c(f,"canPlay",P.canPlay.youtube)}}]);
+(globalThis["webpackChunksimplystatic_settings"] = globalThis["webpackChunksimplystatic_settings"] || []).push([["reactPlayerYouTube"],{
+
+/***/ "./node_modules/react-player/lib/players/YouTube.js":
+/*!**********************************************************!*\
+  !*** ./node_modules/react-player/lib/players/YouTube.js ***!
+  \**********************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var __publicField = (obj, key, value) => {
+  __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
+var YouTube_exports = {};
+__export(YouTube_exports, {
+  default: () => YouTube
+});
+module.exports = __toCommonJS(YouTube_exports);
+var import_react = __toESM(__webpack_require__(/*! react */ "react"));
+var import_utils = __webpack_require__(/*! ../utils */ "./node_modules/react-player/lib/utils.js");
+var import_patterns = __webpack_require__(/*! ../patterns */ "./node_modules/react-player/lib/patterns.js");
+const SDK_URL = "https://www.youtube.com/iframe_api";
+const SDK_GLOBAL = "YT";
+const SDK_GLOBAL_READY = "onYouTubeIframeAPIReady";
+const MATCH_PLAYLIST = /[?&](?:list|channel)=([a-zA-Z0-9_-]+)/;
+const MATCH_USER_UPLOADS = /user\/([a-zA-Z0-9_-]+)\/?/;
+const MATCH_NOCOOKIE = /youtube-nocookie\.com/;
+const NOCOOKIE_HOST = "https://www.youtube-nocookie.com";
+class YouTube extends import_react.Component {
+  constructor() {
+    super(...arguments);
+    __publicField(this, "callPlayer", import_utils.callPlayer);
+    __publicField(this, "parsePlaylist", (url) => {
+      if (url instanceof Array) {
+        return {
+          listType: "playlist",
+          playlist: url.map(this.getID).join(",")
+        };
+      }
+      if (MATCH_PLAYLIST.test(url)) {
+        const [, playlistId] = url.match(MATCH_PLAYLIST);
+        return {
+          listType: "playlist",
+          list: playlistId.replace(/^UC/, "UU")
+        };
+      }
+      if (MATCH_USER_UPLOADS.test(url)) {
+        const [, username] = url.match(MATCH_USER_UPLOADS);
+        return {
+          listType: "user_uploads",
+          list: username
+        };
+      }
+      return {};
+    });
+    __publicField(this, "onStateChange", (event) => {
+      const { data } = event;
+      const { onPlay, onPause, onBuffer, onBufferEnd, onEnded, onReady, loop, config: { playerVars, onUnstarted } } = this.props;
+      const { UNSTARTED, PLAYING, PAUSED, BUFFERING, ENDED, CUED } = window[SDK_GLOBAL].PlayerState;
+      if (data === UNSTARTED)
+        onUnstarted();
+      if (data === PLAYING) {
+        onPlay();
+        onBufferEnd();
+      }
+      if (data === PAUSED)
+        onPause();
+      if (data === BUFFERING)
+        onBuffer();
+      if (data === ENDED) {
+        const isPlaylist = !!this.callPlayer("getPlaylist");
+        if (loop && !isPlaylist) {
+          if (playerVars.start) {
+            this.seekTo(playerVars.start);
+          } else {
+            this.play();
+          }
+        }
+        onEnded();
+      }
+      if (data === CUED)
+        onReady();
+    });
+    __publicField(this, "mute", () => {
+      this.callPlayer("mute");
+    });
+    __publicField(this, "unmute", () => {
+      this.callPlayer("unMute");
+    });
+    __publicField(this, "ref", (container) => {
+      this.container = container;
+    });
+  }
+  componentDidMount() {
+    this.props.onMount && this.props.onMount(this);
+  }
+  getID(url) {
+    if (!url || url instanceof Array || MATCH_PLAYLIST.test(url)) {
+      return null;
+    }
+    return url.match(import_patterns.MATCH_URL_YOUTUBE)[1];
+  }
+  load(url, isReady) {
+    const { playing, muted, playsinline, controls, loop, config, onError } = this.props;
+    const { playerVars, embedOptions } = config;
+    const id = this.getID(url);
+    if (isReady) {
+      if (MATCH_PLAYLIST.test(url) || MATCH_USER_UPLOADS.test(url) || url instanceof Array) {
+        this.player.loadPlaylist(this.parsePlaylist(url));
+        return;
+      }
+      this.player.cueVideoById({
+        videoId: id,
+        startSeconds: (0, import_utils.parseStartTime)(url) || playerVars.start,
+        endSeconds: (0, import_utils.parseEndTime)(url) || playerVars.end
+      });
+      return;
+    }
+    (0, import_utils.getSDK)(SDK_URL, SDK_GLOBAL, SDK_GLOBAL_READY, (YT) => YT.loaded).then((YT) => {
+      if (!this.container)
+        return;
+      this.player = new YT.Player(this.container, {
+        width: "100%",
+        height: "100%",
+        videoId: id,
+        playerVars: {
+          autoplay: playing ? 1 : 0,
+          mute: muted ? 1 : 0,
+          controls: controls ? 1 : 0,
+          start: (0, import_utils.parseStartTime)(url),
+          end: (0, import_utils.parseEndTime)(url),
+          origin: window.location.origin,
+          playsinline: playsinline ? 1 : 0,
+          ...this.parsePlaylist(url),
+          ...playerVars
+        },
+        events: {
+          onReady: () => {
+            if (loop) {
+              this.player.setLoop(true);
+            }
+            this.props.onReady();
+          },
+          onPlaybackRateChange: (event) => this.props.onPlaybackRateChange(event.data),
+          onPlaybackQualityChange: (event) => this.props.onPlaybackQualityChange(event),
+          onStateChange: this.onStateChange,
+          onError: (event) => onError(event.data)
+        },
+        host: MATCH_NOCOOKIE.test(url) ? NOCOOKIE_HOST : void 0,
+        ...embedOptions
+      });
+    }, onError);
+    if (embedOptions.events) {
+      console.warn("Using `embedOptions.events` will likely break things. Use ReactPlayer\u2019s callback props instead, eg onReady, onPlay, onPause");
+    }
+  }
+  play() {
+    this.callPlayer("playVideo");
+  }
+  pause() {
+    this.callPlayer("pauseVideo");
+  }
+  stop() {
+    if (!document.body.contains(this.callPlayer("getIframe")))
+      return;
+    this.callPlayer("stopVideo");
+  }
+  seekTo(amount, keepPlaying = false) {
+    this.callPlayer("seekTo", amount);
+    if (!keepPlaying && !this.props.playing) {
+      this.pause();
+    }
+  }
+  setVolume(fraction) {
+    this.callPlayer("setVolume", fraction * 100);
+  }
+  setPlaybackRate(rate) {
+    this.callPlayer("setPlaybackRate", rate);
+  }
+  setLoop(loop) {
+    this.callPlayer("setLoop", loop);
+  }
+  getDuration() {
+    return this.callPlayer("getDuration");
+  }
+  getCurrentTime() {
+    return this.callPlayer("getCurrentTime");
+  }
+  getSecondsLoaded() {
+    return this.callPlayer("getVideoLoadedFraction") * this.getDuration();
+  }
+  render() {
+    const { display } = this.props;
+    const style = {
+      width: "100%",
+      height: "100%",
+      display
+    };
+    return /* @__PURE__ */ import_react.default.createElement("div", { style }, /* @__PURE__ */ import_react.default.createElement("div", { ref: this.ref }));
+  }
+}
+__publicField(YouTube, "displayName", "YouTube");
+__publicField(YouTube, "canPlay", import_patterns.canPlay.youtube);
+
+
+/***/ })
+
+}]);
+//# sourceMappingURL=reactPlayerYouTube.js.map

--- a/src/admin/inc/class-ss-admin-settings.php
+++ b/src/admin/inc/class-ss-admin-settings.php
@@ -313,6 +313,14 @@ class Admin_Settings {
                         return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'settings' ) );
                     },
             ) );
+
+            register_rest_route( 'simplystatic/v1', '/trigger-cron', array(
+                    'methods'             => 'POST',
+                    'callback'            => [ $this, 'trigger_cron' ],
+                    'permission_callback' => function () {
+                        return current_user_can( apply_filters( 'ss_user_capability', 'manage_network', 'cron' ) );
+                    },
+            ) );
         }
 
 		register_rest_route( 'simplystatic/v1', '/post-types', array(
@@ -491,13 +499,6 @@ class Admin_Settings {
 			},
 		) );
 
-		register_rest_route( 'simplystatic/v1', '/trigger-cron', array(
-			'methods'             => 'POST',
-			'callback'            => [ $this, 'trigger_cron' ],
-			'permission_callback' => function () {
-				return current_user_can( apply_filters( 'ss_user_capability', 'manage_network', 'cron' ) );
-			},
-		) );
 	}
 
 	/**

--- a/src/admin/inc/class-ss-admin-settings.php
+++ b/src/admin/inc/class-ss-admin-settings.php
@@ -1143,12 +1143,14 @@ class Admin_Settings {
             $job->set_options( $options );
 
             $sites[] = [
-                'id'       => $site->blog_id,
-                'name'     => $site->blogname,
-                'url'      => $site->siteurl,
-                'path'     => $site->path,
-                'running'  => $job->is_running(),
-                'paused'   => $job->is_paused(),
+                'id'               => $site->blog_id,
+                'name'             => $site->blogname,
+                'url'              => $site->siteurl,
+                'path'             => $site->path,
+                'running'          => $job->is_running(),
+                'paused'           => $job->is_paused(),
+                'settings_url'     => esc_url( get_admin_url( $site->blog_id ) . 'admin.php?page=simply-static-settings' ),
+                'activity_log_url' => esc_url( get_admin_url( $site->blog_id ) . 'admin.php?page=simply-static-generate' )
             ];
 
             restore_current_blog();

--- a/src/admin/src/settings/components/GenerateButtons.jsx
+++ b/src/admin/src/settings/components/GenerateButtons.jsx
@@ -1,0 +1,54 @@
+import {Button, Dashicon} from "@wordpress/components";
+const {__} = wp.i18n;
+function GenerateButtons(props) {
+    const { canGenerate, isPaused, isDelayed, startExport, cancelExport, pauseExport, resumeExport } = props;
+    const hasPauseFeature = typeof pauseExport === 'function';
+    const hasCancelFeature = typeof cancelExport === 'function';
+    const hasResumeFeature = typeof resumeExport === 'function';
+
+    return <div className="generate-buttons-container">
+        {canGenerate && <Button
+            onClick={() => {
+                startExport();
+            }}
+            disabled={!canGenerate || isDelayed}
+            className={'generate'}
+        >
+            {canGenerate && [<Dashicon icon="update"/>,
+                __('Generate', 'simply-static')
+            ]}
+
+            {canGenerate && isDelayed>0 && <> {isDelayed}s</>}
+
+            {!canGenerate && <Dashicon icon="update spin"/>}
+        </Button>}
+        {!canGenerate && <>
+            {!isPaused && hasPauseFeature && <Button
+                label={__('Pause', 'simply-static')}
+                className={"ss-generate-media-button"}
+                showToolTip={true}
+                onClick={() => pauseExport()}>
+                <Dashicon icon={"controls-pause"}/>
+            </Button>
+            }
+            {isPaused && hasResumeFeature && <Button
+                label={__('Resume', 'simply-static')}
+                className={"ss-generate-media-button"}
+                showToolTip={true}
+                onClick={() => resumeExport()}>
+                <Dashicon icon={"controls-play"}/>
+            </Button>
+            }
+            { hasCancelFeature && <Button
+                onClick={() => cancelExport()}
+                label={__('Cancel', 'simply-static')}
+                className={"ss-generate-cancel-button"}
+                showToolTip={true}
+            >
+                <Dashicon icon={'no'}/>
+            </Button> }
+        </>}
+    </div>
+}
+
+export default GenerateButtons;

--- a/src/admin/src/settings/components/GenerateButtons.jsx
+++ b/src/admin/src/settings/components/GenerateButtons.jsx
@@ -1,7 +1,7 @@
 import {Button, Dashicon} from "@wordpress/components";
 const {__} = wp.i18n;
 function GenerateButtons(props) {
-    const { canGenerate, isPaused, isDelayed, startExport, cancelExport, pauseExport, resumeExport } = props;
+    const { children, canGenerate, isPaused, isDelayed, startExport, cancelExport, pauseExport, resumeExport } = props;
     const hasPauseFeature = typeof pauseExport === 'function';
     const hasCancelFeature = typeof cancelExport === 'function';
     const hasResumeFeature = typeof resumeExport === 'function';
@@ -48,6 +48,7 @@ function GenerateButtons(props) {
                 <Dashicon icon={'no'}/>
             </Button> }
         </>}
+        {children}
     </div>
 }
 

--- a/src/admin/src/settings/components/LogButtons.jsx
+++ b/src/admin/src/settings/components/LogButtons.jsx
@@ -1,6 +1,6 @@
 import {Animate, Button, Notice} from "@wordpress/components";
-import {useState} from "@wordpress/element";
 import apiFetch from "@wordpress/api-fetch";
+import {useState} from "@wordpress/element";
 const {__} = wp.i18n;
 
 function LogButtons() {

--- a/src/admin/src/settings/components/SettingsPage.jsx
+++ b/src/admin/src/settings/components/SettingsPage.jsx
@@ -29,6 +29,7 @@ import {SettingsContext} from "../context/SettingsContext";
 import apiFetch from "@wordpress/api-fetch";
 import EnvironmentSidebar from "./EnvironmentSidebar";
 import SidebarMultisite from "./SidebarMultisite";
+import GenerateButtons from "./GenerateButtons";
 
 const {__} = wp.i18n;
 
@@ -250,48 +251,17 @@ function SettingsPage() {
                                         }
                                         {buildOptions}
                                     </SelectControl>
-                                    <div className="generate-buttons-container">
-                                        {!disabledButton && <Button onClick={() => {
-                                            startExport();
-                                        }}
-                                                                    disabled={disabledButton || isDelayed}
-                                                                    className={activeItem === '/' ? 'is-active-item generate' : 'generate'}
-                                        >
-                                            {!disabledButton && [<Dashicon icon="update"/>,
-                                                __('Generate', 'simply-static')
-                                            ]}
-
-                                            {!disabledButton && isDelayed>0 && <> {isDelayed}s</>}
-
-                                            {disabledButton && <Dashicon icon="update spin"/>}
-                                        </Button>}
-                                        {disabledButton && <>
-                                            {!isPaused && <Button
-                                                label={__('Pause', 'simply-static')}
-                                                className={"ss-generate-media-button"}
-                                                showToolTip={true}
-                                                onClick={() => pauseExport()}>
-                                                <Dashicon icon={"controls-pause"}/>
-                                            </Button>
-                                            }
-                                            {isPaused && <Button
-                                                label={__('Resume', 'simply-static')}
-                                                className={"ss-generate-media-button"}
-                                                showToolTip={true}
-                                                onClick={() => resumeExport()}>
-                                                <Dashicon icon={"controls-play"}/>
-                                            </Button>
-                                            }
-                                            <Button
-                                                onClick={() => cancelExport()}
-                                                label={__('Cancel', 'simply-static')}
-                                                className={"ss-generate-cancel-button"}
-                                                showToolTip={true}
-                                            >
-                                                <Dashicon icon={'no'}/>
-                                            </Button>
-                                        </>}
-                                    </div>
+                                    <GenerateButtons
+                                        canGenerate={!disabledButton}
+                                        startExport={startExport}
+                                         cancelExport={cancelExport}
+                                         pauseExport={pauseExport}
+                                         resumeExport={resumeExport}
+                                         isRunning={isRunning}
+                                         isPaused={isPaused}
+                                         isResumed={isResumed}
+                                         isDelayed={isDelayed}
+                                    />
                                 </div>
                                 <CardBody>
                                     {'pro' === options.plan && isPro() &&

--- a/src/admin/src/settings/components/SettingsPage.jsx
+++ b/src/admin/src/settings/components/SettingsPage.jsx
@@ -28,6 +28,7 @@ import Optimize from "../pages/Optimize";
 import {SettingsContext} from "../context/SettingsContext";
 import apiFetch from "@wordpress/api-fetch";
 import EnvironmentSidebar from "./EnvironmentSidebar";
+import SidebarMultisite from "./SidebarMultisite";
 
 const {__} = wp.i18n;
 
@@ -201,35 +202,7 @@ function SettingsPage() {
                     }} className={"show-nav"}><Dashicon icon="align-center"/> {__('Toggle menu', 'simply-static')}</a>
                     <FlexItem className={showMobileNav ? 'toggle-nav sidebar' : 'sidebar'}>
                         {options.is_network ?
-                            <Card className={"plugin-nav"}>
-                                <div className={"plugin-logo"}>
-                                    <img alt="Logo"
-                                         src={options.logo}/>
-                                </div>
-                                {'pro' === options.plan && isPro() ?
-                                    <p className={"version-number"}>
-                                        Free: <b>{options.version}</b><br></br>
-                                        Pro: <b>{options.version_pro}</b>
-                                    </p>
-                                    :
-                                    <p className={"version-number"}>Version: <b>{options.version}</b></p>
-                                }
-
-                                <Spacer margin={5}/>
-                                <Spacer margin={5}/>
-                                <Button href="https://simplystatic.com/changelogs/" target="_blank">
-                                    <Dashicon icon="editor-ul"/> {__('Changelog', 'simply-static')}
-                                </Button>
-                                <Button href="https://docs.simplystatic.com" target="_blank">
-                                    <Dashicon icon="admin-links"/> {__('Documentation', 'simply-static')}
-                                </Button>
-                                {'free' === options.plan &&
-                                    <Button href="https://simplystatic.com" target="_blank">
-                                        <Dashicon
-                                            icon="admin-site-alt3"/>Simply Static Pro
-                                    </Button>
-                                }
-                            </Card>
+                             <SidebarMultisite />
                             :
                             <Card className={"plugin-nav"}>
                                 <div className={"plugin-logo"}>

--- a/src/admin/src/settings/components/SettingsPage.jsx
+++ b/src/admin/src/settings/components/SettingsPage.jsx
@@ -188,9 +188,13 @@ function SettingsPage() {
         </optgroup>
     }
 
+    const minHeight = () => {
+        return window.innerHeight - ( wpadminbar ? wpadminbar.clientHeight : 0 ) - 1;
+    }
+
     return (
-        <div className={"plugin-settings-container"}>
-            <NavigatorProvider initialPath={initialPage}>
+        <div className={"plugin-settings-container"} >
+            <NavigatorProvider initialPath={initialPage} style={{minHeight: minHeight() + "px"}}>
                 <Flex>
                     <a onClick={() => {
                         setShowMobileNav(!showMobileNav);

--- a/src/admin/src/settings/components/SettingsPage.jsx
+++ b/src/admin/src/settings/components/SettingsPage.jsx
@@ -30,6 +30,7 @@ import apiFetch from "@wordpress/api-fetch";
 import EnvironmentSidebar from "./EnvironmentSidebar";
 import SidebarMultisite from "./SidebarMultisite";
 import GenerateButtons from "./GenerateButtons";
+import VersionInfo from "./VersionInfo";
 
 const {__} = wp.i18n;
 
@@ -210,24 +211,7 @@ function SettingsPage() {
                                     <img alt="Logo"
                                          src={options.logo}/>
                                 </div>
-                                {'pro' === options.plan && isPro() ?
-                                    <>
-                                        {isStudio() ?
-                                            <p className={"version-number"}>
-                                                Free: <b>{options.version}</b><br></br>
-                                                Pro: <b>{options.version_pro}</b><br></br>
-                                                Studio: <b>{options.version_studio}</b>
-                                            </p>
-                                            :
-                                            <p className={"version-number"}>
-                                                Free: <b>{options.version}</b><br></br>
-                                                Pro: <b>{options.version_pro}</b>
-                                            </p>
-                                        }
-                                    </>
-                                    :
-                                    <p className={"version-number"}>Version: <b>{options.version}</b></p>
-                                }
+                                <VersionInfo/>
 
                                 <div className={`generate-container ${disabledButton ? 'generating' : ''}`}>
                                     <SelectControl

--- a/src/admin/src/settings/components/SettingsPage.jsx
+++ b/src/admin/src/settings/components/SettingsPage.jsx
@@ -122,7 +122,7 @@ function SettingsPage() {
             }
         }).then(resp => {
             var json = JSON.parse(resp);
-            if (json.status === 500 ) {
+            if (json.status === 500) {
                 alert(json.message);
                 setDisabledButton(false);
                 return;
@@ -211,52 +211,6 @@ function SettingsPage() {
                                     <p className={"version-number"}>Version: <b>{options.version}</b></p>
                                 }
 
-                                <div className={`generate-container ${disabledButton ? 'generating' : ''}`}>
-                                    {!disabledButton && <Button onClick={() => {
-                                        setSelectedExportType('export');
-                                        startExport();
-                                    }}
-                                    disabled={disabledButton || isDelayed}
-                                    className={activeItem === '/' ? 'is-active-item generate' : 'generate'}
-                                    >
-                                        {!disabledButton && [<Dashicon icon="update"/>,
-                                            __('Generate', 'simply-static')
-                                        ]}
-
-                                        {!disabledButton && isDelayed>0 && <>{isDelayed}s</>}
-
-                                        {disabledButton && [<Dashicon icon="update spin"/>,
-                                            __('Generating...', 'simply-static'),
-                                        ]}
-                                    </Button>}
-                                    {disabledButton && <>
-                                        {!isPaused && <Button
-                                            label={__('Pause', 'simply-static')}
-                                            showToolTip={true}
-                                            className={"ss-generate-media-button"}
-                                            onClick={() => pauseExport()}>
-                                            <Dashicon icon={"controls-pause"}/>
-                                        </Button>
-                                        }
-                                        {isPaused && <Button
-                                            label={__('Resume', 'simply-static')}
-                                            showToolTip={true}
-                                            className={"ss-generate-media-button"}
-                                            onClick={() => resumeExport()}>
-                                            <Dashicon icon={"controls-play"}/>
-                                        </Button>
-                                        }
-                                        <Button
-                                            onClick={() => cancelExport()}
-                                            label={__('Cancel', 'simply-static')}
-                                            className={"ss-generate-cancel-button"}
-                                            showToolTip={true}
-                                        >
-                                            <Dashicon icon={'no'}/>
-                                        </Button>
-                                    </>}
-
-                                </div>
                                 <Spacer margin={5}/>
                                 <Spacer margin={5}/>
                                 <Button href="https://simplystatic.com/changelogs/" target="_blank">

--- a/src/admin/src/settings/components/SidebarMultisite.jsx
+++ b/src/admin/src/settings/components/SidebarMultisite.jsx
@@ -1,0 +1,40 @@
+import {__experimentalSpacer as Spacer, Button, Card, Dashicon} from "@wordpress/components";
+import {useContext} from "@wordpress/element";
+import {SettingsContext} from "../context/SettingsContext";
+
+const {__} = wp.i18n;
+function SidebarMultisite( props = null ) {
+    const { isPro } = useContext(SettingsContext);
+
+    return (<Card className={"plugin-nav"}>
+        <div className={"plugin-logo"}>
+            <img alt="Logo"
+                 src={options.logo}/>
+        </div>
+        {'pro' === options.plan && isPro() ?
+            <p className={"version-number"}>
+                Free: <b>{options.version}</b><br></br>
+                Pro: <b>{options.version_pro}</b>
+            </p>
+            :
+            <p className={"version-number"}>Version: <b>{options.version}</b></p>
+        }
+
+        <Spacer margin={5}/>
+        <Spacer margin={5}/>
+        <Button href="https://simplystatic.com/changelogs/" target="_blank">
+            <Dashicon icon="editor-ul"/> {__('Changelog', 'simply-static')}
+        </Button>
+        <Button href="https://docs.simplystatic.com" target="_blank">
+            <Dashicon icon="admin-links"/> {__('Documentation', 'simply-static')}
+        </Button>
+        {'free' === options.plan &&
+            <Button href="https://simplystatic.com" target="_blank">
+                <Dashicon
+                    icon="admin-site-alt3"/>Simply Static Pro
+            </Button>
+        }
+    </Card>);
+}
+
+export default SidebarMultisite;

--- a/src/admin/src/settings/components/SidebarMultisite.jsx
+++ b/src/admin/src/settings/components/SidebarMultisite.jsx
@@ -1,6 +1,7 @@
 import {__experimentalSpacer as Spacer, Button, Card, Dashicon} from "@wordpress/components";
 import {useContext} from "@wordpress/element";
 import {SettingsContext} from "../context/SettingsContext";
+import VersionInfo from "./VersionInfo";
 
 const {__} = wp.i18n;
 function SidebarMultisite( props = null ) {
@@ -11,14 +12,7 @@ function SidebarMultisite( props = null ) {
             <img alt="Logo"
                  src={options.logo}/>
         </div>
-        {'pro' === options.plan && isPro() ?
-            <p className={"version-number"}>
-                Free: <b>{options.version}</b><br></br>
-                Pro: <b>{options.version_pro}</b>
-            </p>
-            :
-            <p className={"version-number"}>Version: <b>{options.version}</b></p>
-        }
+        <VersionInfo/>
 
         <Spacer margin={5}/>
         <Spacer margin={5}/>

--- a/src/admin/src/settings/components/Site.jsx
+++ b/src/admin/src/settings/components/Site.jsx
@@ -14,7 +14,13 @@ function Site( props ) {
         if ( isRunning ) {
             setAnyRunning(true);
         }
-    }, [isRunning])
+    }, [isRunning]);
+
+    useEffect(() => {
+        setIsPaused(site.paused);
+        setIsRunning(site.running);
+        setCanGenerate(!site.running && !site.paused);
+    }, [site]);
 
     const startExport = () => {
         setCanGenerate(false);
@@ -80,15 +86,13 @@ function Site( props ) {
     return (
         <tr>
             <td>
-                {site.name}
+                {site.name}<br/>
+                <a href={site.url}>{site.url}</a>
             </td>
             <td>
-                {site.url}
+                {isRunning ? 'Running' : ( isPaused ? 'Paused' : 'Idle' ) }
             </td>
-            <td>
-                {isRunning ? 'Running' : 'Idle'}
-            </td>
-            <td>
+            <td className={'generate-container'}>
                 <Buttons
                     site={site}
                     canGenerate={canGenerate}

--- a/src/admin/src/settings/components/Site.jsx
+++ b/src/admin/src/settings/components/Site.jsx
@@ -2,6 +2,8 @@ import apiFetch from "@wordpress/api-fetch";
 import Buttons from "./GenerateButtons";
 import {useState} from "@wordpress/element";
 import {useEffect} from "react";
+import {Button, Dashicon} from "@wordpress/components";
+const {__} = wp.i18n;
 
 function Site( props ) {
     const { site, setAnyRunning } = props;
@@ -102,7 +104,15 @@ function Site( props ) {
                     cancelExport={cancelExport}
                     pauseExport={pauseExport}
                     resumeExport={resumeExport}
-                />
+                >
+                    <Button
+
+                        onClick={() => window.location = site.settings_url}>
+                        <Dashicon icon="admin-generic"/>
+                    </Button>
+
+                </Buttons>
+
             </td>
         </tr>
     )

--- a/src/admin/src/settings/components/Site.jsx
+++ b/src/admin/src/settings/components/Site.jsx
@@ -33,7 +33,8 @@ function Site( props ) {
             method: 'POST',
             data: {
                 'blog_id': blogId,
-                'type': 'export'
+                'type': 'export',
+                'is_network_admin': options.is_network
             }
         }).then(resp => {
             var json = JSON.parse(resp);
@@ -51,6 +52,7 @@ function Site( props ) {
             method: 'POST',
             data: {
                 'blog_id': blogId,
+                'is_network_admin': options.is_network
             }
         }).then(resp => {
             setIsPaused(false)
@@ -65,6 +67,7 @@ function Site( props ) {
             method: 'POST',
             data: {
                 'blog_id': blogId,
+                'is_network_admin': options.is_network
             }
         }).then(resp => {
             setIsRunning(false);
@@ -78,6 +81,7 @@ function Site( props ) {
             method: 'POST',
             data: {
                 'blog_id': blogId,
+                'is_network_admin': options.is_network
             }
         }).then(resp => {
             setIsPaused(false);

--- a/src/admin/src/settings/components/Site.jsx
+++ b/src/admin/src/settings/components/Site.jsx
@@ -1,0 +1,107 @@
+import apiFetch from "@wordpress/api-fetch";
+import Buttons from "./GenerateButtons";
+import {useState} from "@wordpress/element";
+import {useEffect} from "react";
+
+function Site( props ) {
+    const { site, setAnyRunning } = props;
+    const blogId   = site.id;
+    const [canGenerate, setCanGenerate] = useState(!site.running && !site.paused);
+    const [isRunning, setIsRunning] = useState(site.running);
+    const [isPaused, setIsPaused] = useState(site.paused);
+
+    useEffect(() => {
+        if ( isRunning ) {
+            setAnyRunning(true);
+        }
+    }, [isRunning])
+
+    const startExport = () => {
+        setCanGenerate(false);
+        setIsPaused(false);
+
+        apiFetch({
+            path: '/simplystatic/v1/start-export',
+            method: 'POST',
+            data: {
+                'blog_id': blogId,
+                'type': 'export'
+            }
+        }).then(resp => {
+            var json = JSON.parse(resp);
+            if (json.status === 500 ) {
+                setCanGenerate(true);
+                return;
+            }
+            setIsRunning(true);
+        });
+    }
+
+    const cancelExport = () => {
+        apiFetch({
+            path: '/simplystatic/v1/cancel-export',
+            method: 'POST',
+            data: {
+                'blog_id': blogId,
+            }
+        }).then(resp => {
+            setIsPaused(false)
+            setIsRunning(false);
+            setCanGenerate(true);
+        });
+    }
+
+    const pauseExport = () => {
+        apiFetch({
+            path: '/simplystatic/v1/pause-export',
+            method: 'POST',
+            data: {
+                'blog_id': blogId,
+            }
+        }).then(resp => {
+            setIsRunning(false);
+            setIsPaused(true);
+        });
+    }
+
+    const resumeExport = () => {
+        apiFetch({
+            path: '/simplystatic/v1/resume-export',
+            method: 'POST',
+            data: {
+                'blog_id': blogId,
+            }
+        }).then(resp => {
+            setIsPaused(false);
+            setIsRunning(true);
+        });
+    }
+
+    return (
+        <tr>
+            <td>
+                {site.name}
+            </td>
+            <td>
+                {site.url}
+            </td>
+            <td>
+                {isRunning ? 'Running' : 'Idle'}
+            </td>
+            <td>
+                <Buttons
+                    site={site}
+                    canGenerate={canGenerate}
+                    startExport={startExport}
+                    isPaused={isPaused}
+                    isRunning={isRunning}
+                    cancelExport={cancelExport}
+                    pauseExport={pauseExport}
+                    resumeExport={resumeExport}
+                />
+            </td>
+        </tr>
+    )
+}
+
+export default Site;

--- a/src/admin/src/settings/components/Sites.jsx
+++ b/src/admin/src/settings/components/Sites.jsx
@@ -36,7 +36,7 @@ function Sites (props) {
 
     useInterval(() => {
         refreshSites();
-    }, anyRunning ? 2500 : null);
+    }, anyRunning ? 2500 : 300000); // Any running, check every 2-3secs. Not running, check every 5 mins.
 
     useEffect(() => {
         refreshSites();

--- a/src/admin/src/settings/components/Sites.jsx
+++ b/src/admin/src/settings/components/Sites.jsx
@@ -1,0 +1,66 @@
+import {Animate, Button, Notice} from "@wordpress/components";
+import apiFetch from "@wordpress/api-fetch";
+import {useState} from "@wordpress/element";
+import {TerminalOutput} from "react-terminal-ui";
+import useInterval from "../../hooks/useInterval";
+import {useEffect} from "react";
+import Site from "./Site";
+const {__} = wp.i18n;
+
+function Sites (props) {
+    const [sites, setSites] = useState([]);
+    const [anyRunning, setAnyRunning] = useState(false);
+
+    function refreshSites() {
+        apiFetch({
+            path: '/simplystatic/v1/sites',
+            method: 'GET',
+        }).then(resp => {
+            console.log(resp);
+            let sitesObjects = [];
+            let haveRunningSite     = false;
+            resp.data.forEach(function (site) {
+                console.log(site);
+
+                sitesObjects.push(site);
+
+                if ( site.running ) {
+                    haveRunningSite = true;
+                }
+            });
+
+            setSites(sitesObjects);
+
+            setAnyRunning(haveRunningSite);
+        } );
+    }
+
+    useInterval(() => {
+        refreshSites();
+    }, anyRunning ? 2500 : null);
+
+    useEffect(() => {
+        refreshSites();
+    }, []);
+
+    return (
+        <>
+            <table>
+                <thead>
+                    <tr>
+                        <th>{__('Name', 'simply-static')}</th>
+                        <th>{__('URL', 'simply-static')}</th>
+                        <th>{__('Status', 'simply-static')}</th>
+                        <th>{__('Actions', 'simply-static')}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    { sites.map( (site) => { return <Site setAnyRunning={setAnyRunning} site={site} key={site.blog_id} /> } ) }
+                </tbody>
+            </table>
+
+        </>
+    )
+}
+
+export default Sites;

--- a/src/admin/src/settings/components/Sites.jsx
+++ b/src/admin/src/settings/components/Sites.jsx
@@ -10,6 +10,57 @@ const {__} = wp.i18n;
 function Sites (props) {
     const [sites, setSites] = useState([]);
     const [anyRunning, setAnyRunning] = useState(false);
+    const [siteToTriggerCron, setSiteToTriggerCron] = useState(0);
+
+    const triggerCron = (blogId) => {
+        apiFetch({
+            path: '/simplystatic/v1/trigger-cron',
+            method: 'POST',
+            data: {
+                'blog_id': blogId,
+            }
+        }).then(resp => {
+            var json = JSON.parse(resp);
+            if (json.status === 200) {
+                // Show success message or update UI
+                console.log('CRON triggered successfully for site ' + blogId);
+            } else {
+                console.error('Failed to trigger CRON:', json.message);
+            }
+            let id = getNextSiteId(blogId);
+            setSiteToTriggerCron(id);
+
+        }).catch(error => {
+            console.error('Error triggering CRON:', error);
+        });
+    }
+
+    function getNextSiteId(siteId) {
+        let ids = getSiteIds();
+
+        if ( ids.length === 0 ) {
+            return 0;
+        }
+
+        let index = ids.indexOf(siteId);
+        if ( index === -1 ) {
+            return ids[0];
+        }
+
+        index++;
+        let id = ids[index] || ids[0];
+
+        return id;
+    }
+
+    function getSiteIds() {
+        let siteIds = [];
+        sites.forEach(function (site) {
+            siteIds.push(site.id);
+        });
+
+        return siteIds;
+    }
 
     function refreshSites() {
         apiFetch({
@@ -37,6 +88,20 @@ function Sites (props) {
     useInterval(() => {
         refreshSites();
     }, anyRunning ? 2500 : 300000); // Any running, check every 2-3secs. Not running, check every 5 mins.
+
+    useInterval(() => {
+
+        if ( ! siteToTriggerCron && sites.length > 0 ) {
+            setSiteToTriggerCron(sites[0].id);
+        }
+
+        if ( ! siteToTriggerCron ) {
+            return;
+        }
+
+        triggerCron(siteToTriggerCron);
+
+    }, anyRunning ? 150000 : null); // Run Cron every 2.5mins. 1 site per iteration.
 
     useEffect(() => {
         refreshSites();

--- a/src/admin/src/settings/components/Sites.jsx
+++ b/src/admin/src/settings/components/Sites.jsx
@@ -1,7 +1,5 @@
-import {Animate, Button, Notice} from "@wordpress/components";
 import apiFetch from "@wordpress/api-fetch";
 import {useState} from "@wordpress/element";
-import {TerminalOutput} from "react-terminal-ui";
 import useInterval from "../../hooks/useInterval";
 import {useEffect} from "react";
 import Site from "./Site";

--- a/src/admin/src/settings/components/Sites.jsx
+++ b/src/admin/src/settings/components/Sites.jsx
@@ -16,9 +16,8 @@ function Sites (props) {
             path: '/simplystatic/v1/sites',
             method: 'GET',
         }).then(resp => {
-            console.log(resp);
             let sitesObjects = [];
-            let haveRunningSite     = false;
+            let haveRunningSite= false;
             resp.data.forEach(function (site) {
                 console.log(site);
 
@@ -45,17 +44,16 @@ function Sites (props) {
 
     return (
         <>
-            <table>
+            <table className={'wp-list-table widefat fixed striped posts simple-static-sites'}>
                 <thead>
                     <tr>
                         <th>{__('Name', 'simply-static')}</th>
-                        <th>{__('URL', 'simply-static')}</th>
                         <th>{__('Status', 'simply-static')}</th>
                         <th>{__('Actions', 'simply-static')}</th>
                     </tr>
                 </thead>
                 <tbody>
-                    { sites.map( (site) => { return <Site setAnyRunning={setAnyRunning} site={site} key={site.blog_id} /> } ) }
+                    { sites.map( (site) => { return <Site setAnyRunning={setAnyRunning} site={site} key={site.id} /> } ) }
                 </tbody>
             </table>
 

--- a/src/admin/src/settings/components/VersionInfo.jsx
+++ b/src/admin/src/settings/components/VersionInfo.jsx
@@ -1,0 +1,33 @@
+
+import {SettingsContext} from "../context/SettingsContext";
+import {useContext} from "@wordpress/element";
+
+function VersionInfo(){
+    const {
+        isPro,
+        isStudio
+    } = useContext(SettingsContext);
+
+    return (<>
+        {'pro' === options.plan && isPro() ?
+            <>
+                {isStudio() ?
+                    <p className={"version-number"}>
+                        Free: <b>{options.version}</b><br></br>
+                        Pro: <b>{options.version_pro}</b><br></br>
+                        Studio: <b>{options.version_studio}</b>
+                    </p>
+                    :
+                    <p className={"version-number"}>
+                        Free: <b>{options.version}</b><br></br>
+                        Pro: <b>{options.version_pro}</b>
+                    </p>
+                }
+            </>
+            :
+            <p className={"version-number"}>Version: <b>{options.version}</b></p>
+        }
+        </>)
+}
+
+export default VersionInfo;

--- a/src/admin/src/settings/pages/Generate.jsx
+++ b/src/admin/src/settings/pages/Generate.jsx
@@ -10,6 +10,7 @@ import {SettingsContext} from "../context/SettingsContext";
 import ActivityLog from "../components/ActivityLog";
 import ExportLog from "../components/ExportLog";
 import LogButtons from "../components/LogButtons";
+import Sites from "../components/Sites";
 
 const {__} = wp.i18n;
 
@@ -28,6 +29,12 @@ function Generate() {
         <Flex align={"top"}>
             {options.is_network &&
                 <FlexItem isBlock={true}>
+                    <Card>
+                        <CardBody>
+                            <Sites />
+                        </CardBody>
+
+                    </Card>
                     <Card>
                         <CardHeader>
                             <b>{__('Multisite', 'simply-static')}</b>

--- a/src/admin/src/settings/pages/Generate.jsx
+++ b/src/admin/src/settings/pages/Generate.jsx
@@ -16,8 +16,6 @@ const {__} = wp.i18n;
 
 function Generate() {
     const {settings, blogId, setBlogId} = useContext(SettingsContext);
-    const [selectedSiteUrl, setSelectedSiteURL] = useState('');
-    const [selectedSiteActivityUrl, setSelectedSiteActivityUrl] = useState('');
 
     return (<div className={"inner-settings"}>
         {!options.is_network &&
@@ -35,38 +33,6 @@ function Generate() {
                         </CardBody>
 
                     </Card>
-                    <Card>
-                        <CardHeader>
-                            <b>{__('Multisite', 'simply-static')}</b>
-                        </CardHeader>
-                        <CardBody>
-                            <SelectControl
-                                label={__('Choose a site to export', 'simply-static')}
-                                value={blogId}
-                                options={options.sites.map(function (site) {
-                                    return {label: `${site.name} (${site.url})`, value: site.blog_id}
-                                })}
-                                onChange={(blog_id) => {
-                                    setBlogId(blog_id);
-
-                                    // Update admin edit URL:
-                                    options.sites.some(item => {
-                                        if (item.blog_id === blog_id) {
-                                            setSelectedSiteURL(item.settings_url);
-                                            setSelectedSiteActivityUrl(item.activity_log_url);
-                                        }
-                                    });
-                                }}
-                            />
-                            {selectedSiteUrl &&
-                                <p>
-                                    <Button isPrimary href={selectedSiteUrl}>Switch to Site settings</Button>
-                                    <Button style={{marginLeft: "5px"}} isSecondary href={selectedSiteActivityUrl}>Check
-                                        progress</Button>
-                                </p>
-                            }
-                        </CardBody>
-                    </Card>
                 </FlexItem>
             }
             {settings.debugging_mode && options.log_file && !options.is_network &&
@@ -82,15 +48,18 @@ function Generate() {
                 </FlexItem>
             }
         </Flex>
-        <Spacer margin={5}/>
-        <Card>
-            <CardHeader>
-                <b>{__('Export Log', 'simply-static')}</b>
-            </CardHeader>
-            <CardBody>
-                <ExportLog/>
-            </CardBody>
-        </Card>
+        {!options.is_network && <>
+            <Spacer margin={5}/>
+            <Card>
+                <CardHeader>
+                    <b>{__('Export Log', 'simply-static')}</b>
+                </CardHeader>
+                <CardBody>
+                    <ExportLog/>
+                </CardBody>
+            </Card>
+        </>
+        }
     </div>)
 }
 

--- a/src/admin/src/settings/settings.scss
+++ b/src/admin/src/settings/settings.scss
@@ -123,18 +123,9 @@ toplevel_page_simply-static img {
 
   /* Navigation */
 
+  .simple-static-sites,
   .plugin-nav {
-    height: 100%;
-    box-shadow: none;
-
-    button:focus, button:focus-visible, button:hover {
-      box-shadow: none;
-      color: rgb(104, 4, 204);
-    }
-
     .generate-container {
-      margin-top: 30px;
-
       .generate-type {
         height: 40px;
         line-height: 40px;
@@ -182,6 +173,21 @@ toplevel_page_simply-static img {
         color: rgb(104, 4, 204);
         text-decoration: underline;
       }
+    }
+  }
+
+  .plugin-nav {
+    height: 100%;
+    box-shadow: none;
+
+    button:focus, button:focus-visible, button:hover {
+      box-shadow: none;
+      color: rgb(104, 4, 204);
+    }
+
+    .generate-container {
+      margin-top: 30px;
+
     }
 
     .environment-container {

--- a/src/background/class-ss-background-process.php
+++ b/src/background/class-ss-background-process.php
@@ -571,6 +571,7 @@ abstract class Background_Process extends Async_Request {
 		$key_column   = 'option_id';
 		$value_column = 'option_value';
 
+
 		if ( is_multisite() ) {
 			$table        = $wpdb->sitemeta;
 			$column       = 'meta_key';

--- a/src/background/class-ss-background-process.php
+++ b/src/background/class-ss-background-process.php
@@ -378,6 +378,9 @@ abstract class Background_Process extends Async_Request {
 	protected function get_status() {
 		global $wpdb;
 
+		/*
+		 * Still using status per site within their options to allow multiple exports.
+		 *
 		if ( is_multisite() ) {
 			$status = $wpdb->get_var(
 				$wpdb->prepare(
@@ -393,7 +396,14 @@ abstract class Background_Process extends Async_Request {
 					$this->get_status_key()
 				)
 			);
-		}
+		}*/
+
+		$status = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1",
+				$this->get_status_key()
+			)
+		);
 
 		return absint( $status );
 	}
@@ -579,12 +589,15 @@ abstract class Background_Process extends Async_Request {
 		$value_column = 'option_value';
 
 
+		/*
+		 * Still using batches on site level.
 		if ( is_multisite() ) {
 			$table        = $wpdb->sitemeta;
 			$column       = 'meta_key';
 			$key_column   = 'meta_id';
 			$value_column = 'meta_value';
 		}
+		*/
 
 		if( !is_null( $for_site_id ) ) {
 			$key = $wpdb->esc_like( $this->identifier . '_batch_' . $for_site_id ) . '%';

--- a/src/class-ss-archive-creation-job.php
+++ b/src/class-ss-archive-creation-job.php
@@ -219,6 +219,8 @@ class Archive_Creation_Job extends Background_Process {
 		try {
 			Util::debug_log( 'Performing task: ' . $task_name );
 			$is_done = $task->perform();
+
+			Util::debug_log( 'Task performed: ' . (bool)$is_done );
 		} catch (Pause_Exception $e ) {
 			// If it's a pause execption, just return task since we've paused the execution of tha tasks.
 			return $task_name;

--- a/src/class-ss-archive-creation-job.php
+++ b/src/class-ss-archive-creation-job.php
@@ -146,6 +146,9 @@ class Archive_Creation_Job extends Background_Process {
 
 			Util::debug_log( "Pushing first task to queue: " . $first_task );
 
+			// Set the current site ID for multisite support
+			$this->set_current_site_id( $blog_id );
+
 			$this->push_to_queue( $first_task )
 			     ->save()
 			     ->dispatch();

--- a/src/class-ss-archive-creation-job.php
+++ b/src/class-ss-archive-creation-job.php
@@ -103,6 +103,15 @@ class Archive_Creation_Job extends Background_Process {
 	}
 
 	/**
+	 * @param Options $options
+	 *
+	 * @return void
+	 */
+	public function set_options( Options $options ) {
+		$this->options = $options;
+	}
+
+	/**
 	 * Helper method for starting the Archive_Creation_Job
 	 * @return boolean true if we were able to successfully start generating an archive
 	 */

--- a/src/class-ss-multisite.php
+++ b/src/class-ss-multisite.php
@@ -45,15 +45,45 @@ class Multisite {
         add_action( 'ss_before_perform_archive_running_check', [ $this, 'before_running_check' ], 1, 2 );
 		add_action( 'ss_before_render_activity_log', [ $this, 'before_rendering_activity_log' ], 1 );;
 		add_action( 'ss_before_render_export_log', [ $this, 'switch_to_blog' ] );
-		add_action( 'ss_after_render_export_log', [ $this, 'restore_blog' ] );
+		add_action( 'ss_after_render_export_log', [ $this, 'restore_blog' ], 99, 2 );
 		add_action( 'ss_before_sending_response_for_static_archive', [ $this, 'restore_blog' ] );
-		add_action( 'ss_after_render_activity_log', [ $this, 'restore_blog' ] );
-		add_action( 'ss_archive_creation_job_after_start_queue', [ $this, 'restore_blog' ] );
-		add_action( 'ss_archive_creation_job_already_running', [ $this, 'restore_blog' ] );
+		add_action( 'ss_after_render_activity_log', [ $this, 'restore_blog' ], 99, 2 );
+		add_action( 'ss_archive_creation_job_after_start_queue', [ $this, 'restore_blog' ], 99, 2 );
+		add_action( 'ss_archive_creation_job_already_running', [ $this, 'restore_blog' ], 99, 2 );
 		add_filter( 'ss_can_delete_file', [ $this, 'can_delete_file' ], 20, 3 );
 		add_action( 'admin_footer', [ $this, 'hide_top_menu' ] );
 		add_action( 'network_admin_menu', array( Admin_Settings::get_instance(), 'add_menu' ), 2 );
+        add_action( 'ss_after_cleanup', [ $this, 'remove_from_queue' ], 10, 1 );
+        add_action( 'ss_before_static_export', [ $this, 'add_to_queue' ], 10, 1 );
+        add_action( 'ss_archive_creation_job_before_start_queue', [ $this, 'add_site_to_queue' ], 1 );
+        add_filter( 'simplystatic.archive_creation_job.task_list', [ $this, 'filter_task_list' ], PHP_INT_MAX );
 	}
+
+    public function filter_task_list( $task_list ) {
+        $multisite_task = [ 'multisite_queue' ];
+
+        return array_merge( $multisite_task, $task_list );
+    }
+
+    public function add_site_to_queue( $blog_id ) {
+        if ( ! self::is_queue_enabled() ) {
+            return;
+        }
+
+        self::queue_export( $blog_id );
+    }
+
+    public function add_to_queue() {
+        if ( ! self::is_queue_enabled() ) {
+            return;
+        }
+        
+        self::queue_export( get_current_blog_id() );
+    }
+
+    public function remove_from_queue() {
+        self::dequeue_export( get_current_blog_id() );
+    }
 
 	public function after_perform_action( $blog_id, $action, $archive_creation_job ) {
 		if ( 'start' !== $action ) {
@@ -64,10 +94,7 @@ class Multisite {
 			return;
 		}
 
-		$this->restore_blog();
-
-        $options = Options::reinstance();
-        $archive_creation_job->set_options( $options );
+		$this->restore_blog( $blog_id, $archive_creation_job );
 	}
 
     public function before_running_check( $blog_id, $archive_creation_job ) {
@@ -170,15 +197,20 @@ class Multisite {
 
 		switch_to_blog( $blog_id );
         $this->switched = $blog_id;
-		Util::debug_log( "Switched to blog: " . get_current_blog_id() );
 	}
 
 	/**
 	 * Restore the blog.
+     *
+     * @param Archive_Creation_Job $archive_job
 	 *
 	 * @return void
 	 */
-	public function restore_blog() {
+	public function restore_blog( $blog_id = 0,  $archive_job = null) {
+        if ( ! $this->switched ) {
+            return;
+        }
+
 		if ( get_current_blog_id() !== $this->switched ) {
 			return;
 		}
@@ -186,5 +218,159 @@ class Multisite {
 		restore_current_blog();
 		Util::debug_log( "Restored to blog: " . get_current_blog_id() );
 		$this->switched = get_current_blog_id();
+
+        if ( $archive_job ) {
+            $options = Options::reinstance();
+            $archive_job->set_options( $options );
+        }
 	}
+
+    /**
+     * Check if the queue is enabled.
+     *
+     * @return bool
+     */
+    public static function is_queue_enabled() {
+        return is_multisite() && apply_filters( 'ss_multisite_queue_enabled', true );
+    }
+
+    /**
+     * Get the export queue to find out which sites are queued for export.
+     * Format:
+     *  [
+     *      blog_id => [
+     *          'site_id' => blog_id,
+     *          'time' => time(),
+     *          'status' => 'queued' || 'running'
+     *      ]
+     *  ]
+     * @return false|mixed
+     */
+    public static function get_export_queue() {
+        return get_site_option( Plugin::SLUG . 'multisite_export_queue', [] );
+    }
+
+    /**
+     * Save the export queue.
+     *
+     * @param array $queue Queue of exports.
+     *
+     * @return void
+     */
+    public static function update_export_queue( $queue ) {
+        update_site_option( Plugin::SLUG . 'multisite_export_queue', $queue );
+    }
+
+    /**
+     * Set a site to the export queue as running.
+     * If the site is not in the queue at all, it is added and updated.
+     *
+     * @param integer $blog_id Site ID.
+     *
+     * @return void
+     */
+    public static function set_queued_export_as_running( $blog_id ) {
+        $queue = self::get_export_queue();
+
+        if ( ! isset( $queue[ $blog_id ] ) ) {
+            $export_data = [
+                    'site_id' => $blog_id,
+                    'time' => time(),
+                    'status' => 'running'
+            ];
+        } else {
+            $export_data = $queue[ $blog_id ];
+        }
+
+        $export_data['status'] = 'running';
+        $queue[ $blog_id ] = $export_data;
+
+        self::update_export_queue( $queue );
+    }
+
+    /**
+     * Queue a site for export.
+     * If the site is already in the queue, it is overwritten..
+     * If the site is not in the queue at all, it is added and updated.
+     *
+     * @param integer $blog_id Site ID.
+     *
+     * @return void
+     */
+    public static function queue_export( $blog_id ) {
+        $queue = self::get_export_queue();
+
+        $export_data = [
+            'site_id' => $blog_id,
+            'time' => time(),
+            'status' => 'queued'
+        ];
+
+        $queue[ $blog_id ] = $export_data;
+
+        self::update_export_queue( $queue );
+    }
+
+    /**
+     * Remove a site from the export queue.
+     *
+     * @param integer $blog_id Site ID.
+     *
+     * @return void
+     */
+    public static function dequeue_export( $blog_id ) {
+        $queue = self::get_export_queue();
+        unset( $queue[ $blog_id ] );
+        self::update_export_queue( $queue );
+    }
+
+    /**
+     * Check if the site can run the export.
+     * If the next export is the current site, it can run.
+     * If the next export is 0, it can run (no site queued).
+     *
+     * @param integer $blog_id Site ID.
+     *
+     * @return bool
+     */
+    public static function can_run_export( $blog_id ) {
+        return in_array( self::get_next_export(), [ 0, $blog_id ], true );
+    }
+
+    /**
+     * Return if the queue is empty.
+     *
+     * @return bool
+     */
+    public static function is_queue_empty() {
+        $queue = self::get_export_queue();
+        return empty( $queue );
+    }
+
+    /**
+     * Get the next site to export.
+     *
+     * @return int Site ID or 0 if the queue is empty.
+     */
+    public static function get_next_export() {
+        if ( self::is_queue_empty() ) {
+            return 0;
+        }
+        $queue = self::get_export_queue();
+
+        uasort( $queue, function ( $a, $b ) {
+            return $a['time'] - $b['time'];
+        } );
+
+        $statuses = wp_list_pluck( $queue, 'status' );
+        $running_site_id = array_search( 'running', $statuses );
+
+        if ( $running_site_id ) {
+            return absint( $running_site_id );
+        }
+
+        $next_site = current( $queue );
+
+        return absint( $next_site['site_id'] );
+    }
 }

--- a/src/class-ss-multisite.php
+++ b/src/class-ss-multisite.php
@@ -86,10 +86,6 @@ class Multisite {
     }
 
 	public function after_perform_action( $blog_id, $action, $archive_creation_job ) {
-		if ( 'start' !== $action ) {
-			return;
-		}
-
 		if ( ! isset( $_REQUEST['blog_id'] ) || ! isset( $_REQUEST['is_network_admin'] ) ) {
 			return;
 		}
@@ -116,10 +112,6 @@ class Multisite {
 	 * @return void
 	 */
 	public function before_perform_action( $blog_id, $action, $archive_creation_job ) {
-		if ( 'start' !== $action ) {
-			return;
-		}
-
 		if ( ! isset( $_REQUEST['blog_id'] ) || ! isset( $_REQUEST['is_network_admin'] ) ) {
 			return;
 		}

--- a/src/class-ss-plugin.php
+++ b/src/class-ss-plugin.php
@@ -173,6 +173,7 @@ class Plugin {
 		require_once $path . 'src/tasks/class-ss-wrapup-task.php';
 		require_once $path . 'src/tasks/class-ss-cancel-task.php';
 		require_once $path . 'src/tasks/class-ss-generate-404-task.php';
+		require_once $path . 'src/tasks/class-ss-multisite-queue.php';
 		require_once $path . 'src/handlers/class-ss-page-handler.php';
 		require_once $path . 'src/class-ss-query.php';
 		require_once $path . 'src/models/class-ss-model.php';
@@ -336,7 +337,7 @@ class Plugin {
 
 		$log = $this->options->get( 'archive_status_messages' );
 
-		do_action( 'ss_after_render_activity_log', $blog_id );
+		do_action( 'ss_after_render_activity_log', $blog_id, $this->get_archive_creation_job() );
 
 		return $log;
 	}
@@ -354,7 +355,7 @@ class Plugin {
 
 		$blog_id = $blog_id ?: get_current_blog_id();
 
-		do_action( 'ss_before_render_export_log', $blog_id );
+		do_action( 'ss_before_render_export_log', $blog_id, $this->get_archive_creation_job() );
 
 		$per_page = $per_page ?: 25;
 		$offset   = ( intval( $current_page ) - 1 ) * intval( $per_page );
@@ -372,7 +373,7 @@ class Plugin {
 		$total_static_pages = apply_filters( 'ss_total_pages', array_sum( array_values( $http_status_codes ) ) );
 		$total_pages        = ceil( $total_static_pages / $per_page );
 
-		do_action( 'ss_after_render_export_log', $blog_id );
+		do_action( 'ss_after_render_export_log', $blog_id, $this->get_archive_creation_job() );
 
 		$static_pages_formatted = [];
 

--- a/src/class-ss-util.php
+++ b/src/class-ss-util.php
@@ -91,6 +91,10 @@ class Util {
 
 		$debug_file = self::get_debug_log_filename();
 
+		if ( ! file_exists( $debug_file ) ) {
+			wp_mkdir_p( dirname( $debug_file ) );
+		}
+
 		// add timestamp and newline
 		$message = '[' . date( 'Y-m-d H:i:s' ) . '] ';
 

--- a/src/class-ss-util.php
+++ b/src/class-ss-util.php
@@ -376,6 +376,10 @@ class Util {
 	 * @return array            Converted array
 	 */
 	public static function string_to_array( $textarea ) {
+		if ( ! is_string( $textarea ) ) {
+			return array();
+		}
+
 		// using preg_split to intelligently break at newlines
 		// see: http://stackoverflow.com/questions/1483497/how-to-put-string-in-array-split-by-new-line
 		$lines = preg_split( "/\r\n|\n|\r/", $textarea );

--- a/src/models/class-ss-model.php
+++ b/src/models/class-ss-model.php
@@ -110,7 +110,7 @@ class Model {
 	public static function table_name() {
 		global $wpdb;
 
-		return $wpdb->prefix . 'simply_static_' . static::$table_name;
+		return $wpdb->get_blog_prefix() . 'simply_static_' . static::$table_name;
 	}
 
 	/**

--- a/src/tasks/class-ss-fetch-urls-task.php
+++ b/src/tasks/class-ss-fetch-urls-task.php
@@ -314,11 +314,16 @@ class Fetch_Urls_Task extends Task {
 		}
 
 		if ( ! empty( $this->options->get( 'urls_to_exclude' ) ) ) {
-			$excluded_by_option = explode( "\n", $this->options->get( 'urls_to_exclude' ) );
+			if ( is_array( $this->options->get( 'urls_to_exclude' ) ) ) {
+				$excluded_by_option = wp_list_pluck( $this->options->get( 'urls_to_exclude' ), 'url' );
+			} else {
+				$excluded_by_option = explode( "\n", $this->options->get( 'urls_to_exclude' ) );
+			}
 
 			if ( is_array( $excluded_by_option ) ) {
 				$excluded = array_merge( $excluded, $excluded_by_option );
 			}
+
 		}
 
 		if ( apply_filters( 'simply_static_exclude_temp_dir', true ) ) {

--- a/src/tasks/class-ss-multisite-queue.php
+++ b/src/tasks/class-ss-multisite-queue.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Simply_Static;
+
+/**
+ * Class to handle setup task.
+ */
+class Multisite_Queue_Task extends Task {
+
+	/**
+	 * Task name.
+	 *
+	 * @var string
+	 */
+	protected static $task_name = 'multisite_queue';
+
+	/**
+	 * Do the initial setup for generating a static archive
+	 *
+	 * @return boolean true this always completes in one run, so returns true.
+	 */
+	public function perform() {
+		$message = __( 'Waiting in queue...', 'simply-static' );
+		$this->save_status_message( $message, 'setup' );
+
+		if ( Multisite::can_run_export( get_current_blog_id() ) || Multisite::is_queue_empty() ) {
+			$message = __( 'Starting soon...', 'simply-static' );
+			$this->save_status_message( $message, 'setup' );
+
+			// Making sure it's set just in case.
+			Multisite::set_queued_export_as_running( get_current_blog_id() );
+			return true;
+		}
+
+
+		return false;
+	}
+}

--- a/src/tasks/class-ss-setup-task.php
+++ b/src/tasks/class-ss-setup-task.php
@@ -33,7 +33,7 @@ class Setup_Task extends Task {
 			Util::debug_log( 'Creating archive directory: ' . $archive_dir );
 			$create_dir = wp_mkdir_p( $archive_dir );
 			if ( $create_dir === false ) {
-				return new \WP_Error( 'cannot_create_archive_dir', sprintf( __( 'Cannot create archive directory %s' ), $archive_dir ) );
+				throw new \Exception( sprintf( __( 'Cannot create archive directory %s' ), $archive_dir ) );
 			}
 		}
 
@@ -214,6 +214,10 @@ class Setup_Task extends Task {
 		}
 
 		if ( false === file_exists( $dir ) || 'update' === $options->get( 'generate_type' ) ) {
+			return false;
+		}
+
+		if ( ! is_dir( $dir ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Improvement on Multisiite:

- Changed multisite dashboard
- Refactored repeating code into components
- Refactored BackgroundProcessing to use each site options separately instead of using site_option (uses only main site)
- Added Multisite Queue export - no parallel export, but1 site per export. 
- Added filter to disable queue - if server can handle multiple at once (PHP fpm workers, PHP max children processes configuration etc...)

<img width="1309" height="368" alt="Screenshot 2025-10-07 at 02 00 41" src="https://github.com/user-attachments/assets/2eb0bde2-0083-4783-bddd-2e81da88cd85" />

@patrickposner to be tested on more servers (Queue). For now, worked on a Local site and a simple server with configured max children
