### PR TITLE
Generate plugin redirects without origin HTTP requests

### DIFF
--- a/src/integrations/class-ss-rank-math-integration.php
+++ b/src/integrations/class-ss-rank-math-integration.php
@@ -5,12 +5,22 @@ namespace Simply_Static;
 use RankMath\Sitemap\Router;
 
 class Rank_Math_Integration extends Integration {
+	const REDIRECT_JSON_KEY = 'rank_math_static_redirect';
+	const LEGACY_REDIRECT_EXPORT_JSON_KEY = 'rank_math_static_redirect_export_started_at';
+
 	/**
 	 * Given plugin handler ID.
 	 *
 	 * @var string Handler ID.
 	 */
 	protected $id = 'rank-math';
+
+	/**
+	 * Exportable redirects keyed by their WordPress source URL.
+	 *
+	 * @var array|null
+	 */
+	protected $static_redirects = null;
 
 	public function __construct() {
 		$this->name        = __( 'Rank Math', 'simply-static' );
@@ -25,6 +35,7 @@ class Rank_Math_Integration extends Integration {
 	public function run() {
 		add_action( 'ss_after_setup_task', [ $this, 'register_sitemap_page' ] );
 		add_action( 'ss_after_setup_task', [ $this, 'register_redirections' ] );
+		add_filter( 'simply_static_registered_redirect', [ $this, 'get_registered_redirect' ], 10, 2 );
 		add_action( 'ss_dom_before_save', [ $this, 'replace_json_schema' ], 10, 2 );
 		add_filter( 'ss_additional_files', [ $this, 'maybe_add_text_files' ] );
 
@@ -186,15 +197,19 @@ class Rank_Math_Integration extends Integration {
 	protected function get_redirects() {
 		global $wpdb;
 
-		$results = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}rank_math_redirections", ARRAY_A );
+		$results = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}rank_math_redirections WHERE status = 'active' ORDER BY updated DESC", ARRAY_A );
 
 
-		if ( empty( $results ) ) {
+		if ( null === $results ) {
 			return null;
 		}
 
+		if ( empty( $results ) ) {
+			return array();
+		}
+
 		$results = array_map( function ( $item ) {
-			$item["sources"] = maybe_unserialize( $item["sources"] );
+			$item['sources'] = maybe_unserialize( $item['sources'] );
 
 			return $item;
 		}, $results );
@@ -216,34 +231,270 @@ class Rank_Math_Integration extends Integration {
 			return;
 		}
 
-		$redirections = $this->get_redirects();
+		$redirections = $this->get_static_redirects();
+
+		// Do not clear stored metadata when the redirect table could not be read.
+		if ( null === $redirections ) {
+			return;
+		}
+
+		$this->clear_stale_static_redirects( $redirections );
 
 		if ( ! $redirections ) {
 			return;
 		}
 
-		foreach ( $redirections as $redirection ) {
+		foreach ( $redirections as $url => $redirection ) {
+			Util::debug_log( 'Adding Rank Math redirection URL to queue: ' . $url );
+			/** @var \Simply_Static\Page $static_page */
+			$static_page = Page::query()->find_or_initialize_by( 'url', $url );
+			$static_page->set_status_message( __( 'RankMath Redirection URL', 'simply-static' ) );
 
-			if ( empty( $redirection['sources'] ) ) {
+			// wpdb hydrates numeric columns as strings. Avoid dirtying an unchanged
+			// redirect page by assigning integer 0 over an existing string "0".
+			if ( null === $static_page->found_on_id || 0 !== (int) $static_page->found_on_id ) {
+				$static_page->found_on_id = 0;
+			}
+
+			$this->set_static_page_redirect( $static_page, $redirection );
+			$static_page->save();
+		}
+	}
+
+	/**
+	 * Return a redirect registered for the current static page.
+	 *
+	 * @param mixed $redirect Existing redirect supplied by another integration.
+	 * @param mixed $static_page Static page being processed.
+	 *
+	 * @return mixed
+	 */
+	public function get_registered_redirect( $redirect, $static_page ) {
+		if (
+			! is_object( $static_page )
+			|| ! method_exists( $static_page, 'get_json_data_by_key' )
+		) {
+			return $redirect;
+		}
+
+		// Single and build exports do not refresh registered redirect metadata.
+		$use_single = get_option( 'simply-static-use-single' );
+		$use_build  = get_option( 'simply-static-use-build' );
+
+		if ( ! empty( $use_build ) || ! empty( $use_single ) ) {
+			return $redirect;
+		}
+
+		$registered_redirect = $static_page->get_json_data_by_key( self::REDIRECT_JSON_KEY );
+
+		return is_array( $registered_redirect ) && ! empty( $registered_redirect['url'] )
+			? $registered_redirect
+			: $redirect;
+	}
+
+	/**
+	 * Get exact, active Rank Math redirects that can be represented by a static file.
+	 *
+	 * @return array<string,array{url:string,status_code:int}>|null
+	 */
+	protected function get_static_redirects() {
+		if ( null !== $this->static_redirects ) {
+			return $this->static_redirects;
+		}
+
+		$redirections = $this->get_redirects();
+
+		if ( ! is_array( $redirections ) ) {
+			return null;
+		}
+
+		$this->static_redirects = array();
+
+		foreach ( $redirections as $redirection ) {
+			$status_code      = isset( $redirection['header_code'] ) ? (int) $redirection['header_code'] : 301;
+			$target_url       = $this->prepare_redirection_url( isset( $redirection['url_to'] ) ? $redirection['url_to'] : '' );
+			$add_query_string = true === apply_filters( 'rank_math/redirection/add_query_string', true, $redirection );
+
+			if (
+				! $target_url
+				|| ! in_array( $status_code, array( 301, 302, 303, 307, 308 ), true )
+				|| empty( $redirection['sources'] )
+				|| ! is_array( $redirection['sources'] )
+			) {
 				continue;
 			}
 
 			foreach ( $redirection['sources'] as $source ) {
-
-				if ( $source['comparison'] !== 'exact' ) {
+				if (
+					! is_array( $source )
+					|| 'exact' !== ( $source['comparison'] ?? '' )
+					|| empty( $source['pattern'] )
+				) {
 					continue;
 				}
 
-				$url = home_url( $source['pattern'] );
-				/** @var \Simply_Static\Page $static_page */
-				$static_page = Page::query()->find_or_initialize_by( 'url', $url );
-				$static_page->set_status_message( __( 'RankMath Redirection URL', 'simply-static' ) );
-				$static_page->found_on_id = 0;
-				$static_page->save();
-			}
+				$source_url = $this->prepare_redirection_url( $source['pattern'] );
+				if ( ! $source_url || isset( $this->static_redirects[ $source_url ] ) ) {
+					continue;
+				}
 
+				$this->static_redirects[ $source_url ] = array(
+					'url'         => $add_query_string ? $this->add_source_query_to_target( $target_url, $source_url ) : $target_url,
+					'status_code' => $status_code,
+				);
+			}
 		}
 
+		return $this->static_redirects;
+	}
+
+	/**
+	 * Normalize a Rank Math source or target against the configured WordPress origin.
+	 *
+	 * @param mixed $url URL or path.
+	 *
+	 * @return string
+	 */
+	protected function prepare_redirection_url( $url ) {
+		$url = is_string( $url ) ? trim( html_entity_decode( $url, ENT_QUOTES ) ) : '';
+
+		if ( '' === $url ) {
+			return '';
+		}
+
+		if ( 0 === strpos( $url, '//' ) ) {
+			$origin_scheme = wp_parse_url( Util::origin_url(), PHP_URL_SCHEME );
+			$url = ( $origin_scheme ? $origin_scheme : 'https' ) . ':' . $url;
+		} elseif ( ! preg_match( '#^https?://#i', $url ) ) {
+			$url = untrailingslashit( Util::origin_url() ) . '/' . ltrim( $url, '/' );
+		}
+
+		return remove_query_arg( 'simply_static_page', $url );
+	}
+
+	/**
+	 * Preserve an exact source rule's query string in its redirect target.
+	 *
+	 * Rank Math appends the incoming query string to the configured target by default.
+	 * Registered redirects bypass Rank Math's HTTP response, so reproduce that behavior
+	 * for query-specific source rules before storing the redirect metadata.
+	 *
+	 * @param string $target_url Redirect target.
+	 * @param string $source_url Exact source URL.
+	 *
+	 * @return string
+	 */
+	protected function add_source_query_to_target( $target_url, $source_url ) {
+		$source_query = wp_parse_url( $source_url, PHP_URL_QUERY );
+
+		if ( ! is_string( $source_query ) || '' === $source_query ) {
+			return $target_url;
+		}
+
+		$fragment = '';
+		$fragment_position = strpos( $target_url, '#' );
+		if ( false !== $fragment_position ) {
+			$fragment   = substr( $target_url, $fragment_position );
+			$target_url = substr( $target_url, 0, $fragment_position );
+		}
+
+		if ( false === strpos( $target_url, '?' ) ) {
+			$separator = '?';
+		} elseif ( in_array( substr( $target_url, -1 ), array( '?', '&' ), true ) ) {
+			$separator = '';
+		} else {
+			$separator = '&';
+		}
+
+		return $target_url . $separator . $source_query . $fragment;
+	}
+
+	/**
+	 * Store redirect metadata and invalidate an existing page when the rule changed.
+	 *
+	 * @param Page  $static_page Static page.
+	 * @param array $redirection Redirect data.
+	 *
+	 * @return void
+	 */
+	protected function set_static_page_redirect( $static_page, $redirection ) {
+		$json = $static_page->get_json();
+		$json = is_array( $json ) ? $json : array();
+		$current = array_key_exists( self::REDIRECT_JSON_KEY, $json ) ? $json[ self::REDIRECT_JSON_KEY ] : null;
+
+		if ( $current !== $redirection ) {
+			$json[ self::REDIRECT_JSON_KEY ] = $redirection;
+			unset( $json[ self::LEGACY_REDIRECT_EXPORT_JSON_KEY ] );
+			$static_page->set_json( $json );
+			$static_page->last_modified_at = Util::formatted_datetime();
+		}
+	}
+
+	/**
+	 * Clear redirect metadata for rules that are no longer exportable.
+	 *
+	 * This is done once during setup in ID-based batches so fetch workers can use
+	 * page-local metadata without loading the complete Rank Math redirect table.
+	 *
+	 * @param array<string,array{url:string,status_code:int}> $redirections Current redirects.
+	 *
+	 * @return void
+	 */
+	protected function clear_stale_static_redirects( $redirections ) {
+		$batch_size = max( 1, (int) apply_filters( 'simply_static_rank_math_redirect_cleanup_batch_size', 500 ) );
+		$last_id    = 0;
+
+		do {
+			$static_pages = Page::query()
+				->where( 'id > ?', $last_id )
+				->where( 'json LIKE ?', '%"' . self::REDIRECT_JSON_KEY . '"%' )
+				->order( 'id ASC' )
+				->limit( $batch_size )
+				->find();
+
+			if ( ! is_array( $static_pages ) || empty( $static_pages ) ) {
+				return;
+			}
+
+			$previous_last_id = $last_id;
+
+			foreach ( $static_pages as $static_page ) {
+				$last_id = max( $last_id, (int) $static_page->id );
+
+				if ( ! empty( $static_page->url ) && array_key_exists( $static_page->url, $redirections ) ) {
+					continue;
+				}
+
+				if ( $this->clear_static_page_redirect( $static_page ) ) {
+					$static_page->save();
+				}
+			}
+
+			if ( $last_id <= $previous_last_id ) {
+				return;
+			}
+		} while ( count( $static_pages ) === $batch_size );
+	}
+
+	/**
+	 * Remove Rank Math redirect metadata from a static page.
+	 *
+	 * @param Page $static_page Static page.
+	 *
+	 * @return bool Whether metadata was removed.
+	 */
+	protected function clear_static_page_redirect( $static_page ) {
+		$json = $static_page->get_json();
+
+		if ( ! is_array( $json ) || ! array_key_exists( self::REDIRECT_JSON_KEY, $json ) ) {
+			return false;
+		}
+
+		unset( $json[ self::REDIRECT_JSON_KEY ], $json[ self::LEGACY_REDIRECT_EXPORT_JSON_KEY ] );
+		$static_page->set_json( $json );
+		$static_page->last_modified_at = Util::formatted_datetime();
+
+		return true;
 	}
 
 	/**

--- a/src/tasks/class-ss-fetch-urls-task.php
+++ b/src/tasks/class-ss-fetch-urls-task.php
@@ -73,6 +73,10 @@ class Fetch_Urls_Task extends Task {
 			$static_page->save();
 			return;
 		} else {
+			if ( $this->maybe_handle_registered_redirect( $static_page, $save_file, $follow_urls ) ) {
+				return;
+			}
+
 			$success = Url_Fetcher::instance()->fetch( $static_page );
 		}
 
@@ -108,6 +112,57 @@ class Fetch_Urls_Task extends Task {
 			$this
 		);
 
+	}
+
+	/**
+	 * Generate a redirect page directly from redirect metadata registered by an integration.
+	 *
+	 * Redirect plugins already store the source and target in WordPress. Asking WordPress to
+	 * resolve the source over HTTP adds an unnecessary failure point, especially when the
+	 * configured public URL and the WordPress origin differ. Integrations can return an array
+	 * containing a URL and optional status code to bypass that request.
+	 *
+	 * @param Page $static_page Static page being processed.
+	 * @param bool $save_file Whether to save a static redirect page.
+	 * @param bool $follow_urls Whether to queue a local redirect target.
+	 *
+	 * @return bool Whether a registered redirect was handled.
+	 */
+	protected function maybe_handle_registered_redirect( $static_page, $save_file, $follow_urls ) {
+		/**
+		 * Filter a redirect registered by an integration before its source URL is fetched.
+		 *
+		 * @param null|array{url:string,status_code?:int} $redirect Redirect data or null.
+		 * @param Page                                  $static_page Static page being processed.
+		 */
+		$redirect = apply_filters( 'simply_static_registered_redirect', null, $static_page );
+
+		if ( ! is_array( $redirect ) || empty( $redirect['url'] ) || ! is_string( $redirect['url'] ) ) {
+			return false;
+		}
+
+		$redirect_url = trim( $redirect['url'] );
+		if ( '' === $redirect_url ) {
+			return false;
+		}
+
+		$status_code = isset( $redirect['status_code'] ) ? (int) $redirect['status_code'] : 301;
+		if ( ! in_array( $status_code, array( 301, 302, 303, 307, 308 ), true ) ) {
+			return false;
+		}
+
+		$static_page->clear_error_message();
+		$static_page->last_checked_at  = Util::formatted_datetime();
+		$static_page->http_status_code = $status_code;
+		$static_page->redirect_url     = $redirect_url;
+
+		Util::debug_log( 'Using registered redirect target for URL: ' . $static_page->url );
+		$this->handle_30x_redirect( $static_page, $save_file, $follow_urls );
+		// Some redirect-handler branches only queue the normalized target because
+		// an HTTP fetch normally persists the source page before they run.
+		$static_page->save();
+
+		return true;
 	}
 
 	/**

--- a/tests/Unit/RankMathRedirectIntegrationTest.php
+++ b/tests/Unit/RankMathRedirectIntegrationTest.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Simply_Static\Tests\Unit;
+
+use Simply_Static\Options;
+use Simply_Static\Rank_Math_Integration;
+use Simply_Static\Tests\Support\UnitTestCase;
+
+$simply_static_root = dirname( __DIR__, 2 );
+require_once $simply_static_root . '/src/class-ss-plugin.php';
+require_once $simply_static_root . '/src/class-ss-options.php';
+require_once $simply_static_root . '/src/class-ss-util.php';
+require_once $simply_static_root . '/src/integrations/class-ss-integration.php';
+require_once $simply_static_root . '/src/integrations/class-ss-rank-math-integration.php';
+
+final class RankMathRedirectPage {
+	/** @var string */
+	public $url;
+
+	/** @var string|null */
+	public $last_modified_at;
+
+	/** @var int */
+	public $json_writes = 0;
+
+	/** @var mixed */
+	private $json_data = array();
+
+	/** @param mixed $redirect_data Redirect metadata. */
+	public function __construct( string $url, $redirect_data = null ) {
+		$this->url = $url;
+
+		if ( null !== $redirect_data ) {
+			$this->json_data['rank_math_static_redirect'] = $redirect_data;
+		}
+	}
+
+	/** @return array<string,mixed> */
+	public function get_json(): array {
+		return $this->json_data;
+	}
+
+	/** @param array<string,mixed> $data */
+	public function set_json( array $data ): void {
+		$this->json_data = $data;
+		$this->json_writes++;
+	}
+
+	/** @return mixed */
+	public function get_json_data_by_key( string $key ) {
+		return array_key_exists( $key, $this->json_data ) ? $this->json_data[ $key ] : null;
+	}
+
+	/** @param mixed $data */
+	public function set_json_data_by_key( string $key, $data ): void {
+		$this->json_data[ $key ] = $data;
+	}
+
+	/** @return mixed */
+	public function redirectData() {
+		return $this->get_json_data_by_key( 'rank_math_static_redirect' );
+	}
+}
+
+final class TestableRankMathRedirectIntegration extends Rank_Math_Integration {
+	/** @var mixed */
+	private $rows;
+
+	/** @var int */
+	public $redirect_reads = 0;
+
+	/** @param mixed $rows */
+	public function __construct( $rows ) {
+		parent::__construct();
+		$this->rows = $rows;
+	}
+
+	protected function get_redirects() {
+		$this->redirect_reads++;
+
+		return $this->rows;
+	}
+
+	/** @return array<string,array{url:string,status_code:int}>|null */
+	public function staticRedirects() {
+		return $this->get_static_redirects();
+	}
+
+	/** @param array<string,mixed> $redirect */
+	public function storeRedirect( $page, array $redirect ): void {
+		$this->set_static_page_redirect( $page, $redirect );
+	}
+
+	public function clearRedirect( $page ): bool {
+		return $this->clear_static_page_redirect( $page );
+	}
+
+	/** @param mixed $redirect */
+	public function registeredRedirect( $redirect, $page ) {
+		return $this->get_registered_redirect( $redirect, $page );
+	}
+}
+
+final class RankMathRedirectIntegrationTest extends UnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Options::instance()->set( 'origin_url', 'https://wordpress.internal/site' );
+		Options::instance()->set( 'archive_start_time', '2026-08-17 12:00:00' );
+	}
+
+	public function test_exact_redirects_are_resolved_from_the_configured_origin(): void {
+		$integration = new TestableRankMathRedirectIntegration(
+			array(
+				array(
+					'header_code' => '302',
+					'url_to'      => '/new-page',
+					'sources'     => array(
+						array( 'pattern' => 'old-page', 'comparison' => 'exact' ),
+					),
+				),
+				array(
+					'header_code' => '301',
+					'url_to'      => 'https://external.example/landing',
+					'sources'     => array(
+						array( 'pattern' => '/external-offer', 'comparison' => 'exact' ),
+					),
+				),
+			)
+		);
+
+		self::assertSame(
+			array(
+				'https://wordpress.internal/site/old-page' => array(
+					'url'         => 'https://wordpress.internal/site/new-page',
+					'status_code' => 302,
+				),
+				'https://wordpress.internal/site/external-offer' => array(
+					'url'         => 'https://external.example/landing',
+					'status_code' => 301,
+				),
+			),
+			$integration->staticRedirects()
+		);
+	}
+
+	public function test_non_exact_and_non_redirect_rules_keep_the_http_fallback(): void {
+		$integration = new TestableRankMathRedirectIntegration(
+			array(
+				array(
+					'header_code' => '301',
+					'url_to'      => '/new-page',
+					'sources'     => array(
+						array( 'pattern' => 'old-*', 'comparison' => 'regex' ),
+					),
+				),
+				array(
+					'header_code' => '410',
+					'url_to'      => '/gone',
+					'sources'     => array(
+						array( 'pattern' => 'old-page', 'comparison' => 'exact' ),
+					),
+				),
+			)
+		);
+
+		self::assertSame( array(), $integration->staticRedirects() );
+	}
+
+	public function test_redirect_query_failures_are_not_treated_as_an_empty_rule_set(): void {
+		$integration = new TestableRankMathRedirectIntegration( null );
+
+		self::assertNull( $integration->staticRedirects() );
+	}
+
+	public function test_query_specific_redirects_preserve_the_source_query_on_the_target(): void {
+		$integration = new TestableRankMathRedirectIntegration(
+			array(
+				array(
+					'header_code' => '301',
+					'url_to'      => '/new-page?existing=1#details',
+					'sources'     => array(
+						array( 'pattern' => 'old-page?campaign=summer&lang=en', 'comparison' => 'exact' ),
+					),
+				),
+			)
+		);
+
+		self::assertSame(
+			array(
+				'https://wordpress.internal/site/old-page?campaign=summer&lang=en' => array(
+					'url'         => 'https://wordpress.internal/site/new-page?existing=1&campaign=summer&lang=en#details',
+					'status_code' => 301,
+				),
+			),
+			$integration->staticRedirects()
+		);
+	}
+
+	public function test_query_specific_redirects_honor_rank_math_query_string_filter(): void {
+		add_filter(
+			'rank_math/redirection/add_query_string',
+			static function () {
+				return false;
+			},
+			10,
+			2
+		);
+
+		$integration = new TestableRankMathRedirectIntegration(
+			array(
+				array(
+					'header_code' => '301',
+					'url_to'      => '/new-page?existing=1#details',
+					'sources'     => array(
+						array( 'pattern' => 'old-page?campaign=summer', 'comparison' => 'exact' ),
+					),
+				),
+			)
+		);
+
+		self::assertSame(
+			array(
+				'https://wordpress.internal/site/old-page?campaign=summer' => array(
+					'url'         => 'https://wordpress.internal/site/new-page?existing=1#details',
+					'status_code' => 301,
+				),
+			),
+			$integration->staticRedirects()
+		);
+	}
+
+	public function test_registered_redirect_uses_page_metadata_without_loading_all_rules(): void {
+		$redirect = array(
+			'url'         => 'https://wordpress.internal/site/new-target',
+			'status_code' => 302,
+		);
+		$page = new RankMathRedirectPage( 'https://wordpress.internal/site/source', $redirect );
+		$integration = new TestableRankMathRedirectIntegration(
+			array(
+				array(
+					'header_code' => '301',
+					'url_to'      => '/unused',
+					'sources'     => array(
+						array( 'pattern' => 'unused', 'comparison' => 'exact' ),
+					),
+				),
+			)
+		);
+
+		self::assertSame( $redirect, $integration->registeredRedirect( null, $page ) );
+		self::assertSame( 0, $integration->redirect_reads );
+	}
+
+	public function test_registered_redirect_uses_http_fallback_for_single_exports(): void {
+		$redirect = array(
+			'url'         => 'https://wordpress.internal/site/new-target',
+			'status_code' => 302,
+		);
+		$page = new RankMathRedirectPage( 'https://wordpress.internal/site/source', $redirect );
+		$integration = new TestableRankMathRedirectIntegration( array() );
+		update_option( 'simply-static-use-single', '42' );
+
+		self::assertSame( 'existing-redirect', $integration->registeredRedirect( 'existing-redirect', $page ) );
+		self::assertSame( 0, $integration->redirect_reads );
+	}
+
+	public function test_changed_redirect_metadata_marks_an_existing_page_for_changes_only(): void {
+		$old_redirect = array(
+			'url'         => 'https://wordpress.internal/site/old-target',
+			'status_code' => 301,
+		);
+		$new_redirect = array(
+			'url'         => 'https://wordpress.internal/site/new-target',
+			'status_code' => 301,
+		);
+		$page = new RankMathRedirectPage( 'https://wordpress.internal/site/source', $old_redirect );
+		$page->last_modified_at = '2026-08-01 08:00:00';
+		$integration = new TestableRankMathRedirectIntegration( array() );
+
+		$integration->storeRedirect( $page, $old_redirect );
+		self::assertSame( '2026-08-01 08:00:00', $page->last_modified_at );
+		self::assertSame( 0, $page->json_writes );
+
+		$integration->storeRedirect( $page, $new_redirect );
+		self::assertSame( $new_redirect, $page->redirectData() );
+		self::assertSame( '2026-07-12 12:00:00', $page->last_modified_at );
+		self::assertSame( 1, $page->json_writes );
+	}
+
+	public function test_clearing_stale_redirect_metadata_preserves_other_page_data(): void {
+		$redirect = array(
+			'url'         => 'https://wordpress.internal/site/old-target',
+			'status_code' => 301,
+		);
+		$page = new RankMathRedirectPage( 'https://wordpress.internal/site/source', $redirect );
+		$page->set_json_data_by_key( 'rank_math_static_redirect_export_started_at', '2026-08-16 12:00:00' );
+		$page->set_json_data_by_key( 'unrelated_data', 'keep-me' );
+		$integration = new TestableRankMathRedirectIntegration( array() );
+
+		self::assertTrue( $integration->clearRedirect( $page ) );
+		self::assertNull( $page->redirectData() );
+		self::assertNull( $page->get_json_data_by_key( 'rank_math_static_redirect_export_started_at' ) );
+		self::assertSame( 'keep-me', $page->get_json_data_by_key( 'unrelated_data' ) );
+		self::assertSame( '2026-07-12 12:00:00', $page->last_modified_at );
+		self::assertFalse( $integration->clearRedirect( $page ) );
+	}
+}

--- a/tests/Unit/RegisteredRedirectFetchTest.php
+++ b/tests/Unit/RegisteredRedirectFetchTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Simply_Static\Tests\Unit;
+
+use Simply_Static\Fetch_Urls_Task;
+use Simply_Static\Options;
+use Simply_Static\Tests\Support\UnitTestCase;
+
+$simply_static_root = dirname( __DIR__, 2 );
+require_once $simply_static_root . '/src/class-ss-plugin.php';
+require_once $simply_static_root . '/src/class-ss-options.php';
+require_once $simply_static_root . '/src/class-ss-util.php';
+require_once $simply_static_root . '/src/tasks/class-ss-task.php';
+require_once $simply_static_root . '/src/tasks/traits/class-ss-skip-further-processing-exception.php';
+require_once $simply_static_root . '/src/tasks/traits/trait-ss-can-process-pages.php';
+require_once $simply_static_root . '/src/tasks/class-ss-fetch-urls-task.php';
+
+final class RegisteredRedirectPage {
+	/** @var string */
+	public $url = 'https://origin.example/old-page';
+
+	/** @var string|null */
+	public $last_checked_at;
+
+	/** @var int|null */
+	public $http_status_code;
+
+	/** @var string|null */
+	public $redirect_url;
+
+	/** @var bool */
+	public $error_cleared = false;
+
+	/** @var int */
+	public $save_calls = 0;
+
+	public function clear_error_message(): void {
+		$this->error_cleared = true;
+	}
+
+	public function save(): void {
+		$this->save_calls++;
+	}
+}
+
+final class RegisteredRedirectFetchTask extends Fetch_Urls_Task {
+	/** @var array<int,mixed>|null */
+	public $handled_redirect;
+
+	public function handleRegisteredRedirect( $page ): bool {
+		return $this->maybe_handle_registered_redirect( $page, true, true );
+	}
+
+	public function handle_30x_redirect( $static_page, $save_file, $follow_urls ) {
+		$this->handled_redirect = array( $static_page, $save_file, $follow_urls );
+	}
+}
+
+final class RegisteredRedirectFetchTest extends UnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Options::instance()->set( 'archive_start_time', '2026-08-17 12:00:00' );
+	}
+
+	public function test_registered_redirect_bypasses_the_http_fetch_path(): void {
+		add_filter(
+			'simply_static_registered_redirect',
+			static function () {
+				return array(
+					'url'         => 'https://origin.example/new-page',
+					'status_code' => 307,
+				);
+			},
+			10,
+			2
+		);
+
+		$page = new RegisteredRedirectPage();
+		$task = new RegisteredRedirectFetchTask();
+
+		self::assertTrue( $task->handleRegisteredRedirect( $page ) );
+		self::assertTrue( $page->error_cleared );
+		self::assertSame( '2026-07-12 12:00:00', $page->last_checked_at );
+		self::assertSame( 307, $page->http_status_code );
+		self::assertSame( 'https://origin.example/new-page', $page->redirect_url );
+		self::assertSame( array( $page, true, true ), $task->handled_redirect );
+		self::assertSame( 1, $page->save_calls );
+	}
+
+	public function test_invalid_registered_redirect_falls_back_to_normal_fetching(): void {
+		add_filter(
+			'simply_static_registered_redirect',
+			static function () {
+				return array(
+					'url'         => 'https://origin.example/gone',
+					'status_code' => 410,
+				);
+			},
+			10,
+			2
+		);
+
+		$page = new RegisteredRedirectPage();
+		$task = new RegisteredRedirectFetchTask();
+
+		self::assertFalse( $task->handleRegisteredRedirect( $page ) );
+		self::assertFalse( $page->error_cleared );
+		self::assertNull( $task->handled_redirect );
+	}
+}


### PR DESCRIPTION
## Summary
- add a shared registered-redirect path that generates redirect pages without fetching WordPress
- persist Rank Math redirect metadata only when rules change and clean stale metadata in setup batches
- preserve Rank Math query-string behavior, including its opt-out filter
- avoid redirect-table reads in fetch workers and unnecessary writes for unchanged redirects

## Tests
- `vendor/bin/phpunit` (372 tests, 4,589 assertions)
- PHP syntax checks
- `git diff --check`