### PR TITLE
Fix AIOSEO sitemap stylesheet exports

### DIFF
--- a/src/handlers/class-ss-aio-seo-sitemap-handler.php
+++ b/src/handlers/class-ss-aio-seo-sitemap-handler.php
@@ -2,234 +2,225 @@
 
 namespace Simply_Static;
 
-use Simply_Static\Options;
-
 class AIO_SEO_Sitemap_Handler extends Page_Handler {
 
 	/**
-	 * Run hooks on page request.
+	 * Serve the static stylesheet while Simply Static fetches its queued page.
 	 *
-	 * Useful in case a type of page requires different hooks to be ran before the static page is generated.
+	 * AIOSEO 5.x hard-codes default-sitemap.xsl in generated sitemap XML and no
+	 * longer exposes the old stylesheet filter. Simply Static therefore provides
+	 * one stable stylesheet endpoint of its own and rewrites every exported
+	 * sitemap to reference it.
 	 *
 	 * @return void
 	 */
 	public function run_hooks() {
 		parent::run_hooks();
 
-		// Filter XSL.
-		add_filter( 'aioseo_sitemap_stylesheet', [ $this, 'stylesheet_url' ] );
+		$page_url = isset( $this->page->url ) ? (string) $this->page->url : '';
+		$page_path = wp_parse_url( $page_url, PHP_URL_PATH );
+
+		if ( 'main-sitemap.xsl' !== basename( (string) $page_path ) ) {
+			return;
+		}
+
+		add_action( 'template_redirect', array( $this, 'output_stylesheet' ), 0 );
 	}
 
 	/**
-	 * Get Stylesheet URL for XSL.
-	 *
-	 * @param string $xsl_string given XSL string.
-	 *
-	 * @return string
-	 */
-	public function stylesheet_url( $xsl_string ) {
-		// Using Origin URL to make sure the URL gets swapped correctly with destination url.
-		return '<?xml-stylesheet type="text/xsl" href="' . trailingslashit( Util::origin_url() ) . 'main-sitemap.xsl' . '"?>';
-	}
-
-	/**
-	 * Add file to destination directory.
-	 *
-	 * @param string $destination_dir given destination dir.
+	 * Output the generated stylesheet endpoint.
 	 *
 	 * @return void
 	 */
-	public function after_file_fetch( $destination_dir ) {
-        $this->save_xsl( $destination_dir );
-        $this->fix_sitemap_xsl_references( $destination_dir );
-        $this->replace_urls_in_sitemaps( $destination_dir );
+	public function output_stylesheet() {
+		if ( ! headers_sent() ) {
+			status_header( 200 );
+			header( 'Content-Type: text/xsl; charset=UTF-8' );
+		}
+
+		echo self::stylesheet_content(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		exit;
 	}
 
-    /**
-     * Save XSL.
-     *
-     * @param string $destination_dir Dir path.
-     * @return void
-     */
-    protected function save_xsl( $destination_dir ) {
-        // Generate XSL content once
-        Util::debug_log( 'Getting content for main-sitemap.xsl' );
-        ob_start();
-        $this->generate_xsl();
-        $xsl_content = ob_get_clean();
-        $temp_filename = wp_tempnam();
-        file_put_contents( $temp_filename, $xsl_content );
+	/**
+	 * Update sitemap files after each fetch.
+	 *
+	 * The stylesheet page is registered after all known sitemap pages, so its
+	 * final handler pass also catches indexes or paginated sitemap files that
+	 * were fetched after an earlier sitemap handler ran.
+	 *
+	 * @param string $destination_dir Destination directory.
+	 * @return void
+	 */
+	public function after_file_fetch( $destination_dir ) {
+		$this->fix_sitemap_xsl_references( $destination_dir );
+		$this->replace_urls_in_sitemaps( $destination_dir );
+	}
 
-        // Copy to the root directory (original behavior)
-        $destination_path = Util::combine_path( $destination_dir, '/main-sitemap.xsl' );
-        if ( ! file_exists( $destination_path ) ) {
-            $rename = rename( $temp_filename, $destination_path );
-            if ( $rename === false ) {
-                Util::debug_log( 'Cannot create ' . $destination_path );
-                // Create a new temp file for the second copy
-                $temp_filename = wp_tempnam();
-                file_put_contents( $temp_filename, $xsl_content );
-            } else {
-                Util::debug_log( 'Created ' . $destination_path );
-                // Create a new temp file for the second copy
-                $temp_filename = wp_tempnam();
-                file_put_contents( $temp_filename, $xsl_content );
-            }
-        }
+	/**
+	 * Return a browser-compatible stylesheet for sitemap indexes and URL sets.
+	 *
+	 * @return string
+	 */
+	public static function stylesheet_content() {
+		return <<<'XSL'
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9"
+	xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+	exclude-result-prefixes="sitemap image">
+	<xsl:output method="html" encoding="UTF-8" indent="yes"/>
 
-        // Also copy to any potential path referenced in the sitemap XML
-        // For All in One SEO, we'll create a common location
-        $plugin_dir = Util::combine_path( $destination_dir, '/wp-content/plugins/all-in-one-seo-pack/app/Common/Sitemap' );
+	<xsl:template match="/">
+		<html>
+			<head>
+				<meta name="viewport" content="width=device-width, initial-scale=1"/>
+				<title>XML Sitemap</title>
+				<style>
+					body{margin:0;background:#f7f8fa;color:#24292f;font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
+					main{max-width:1100px;margin:48px auto;padding:0 24px}
+					h1{margin:0 0 8px;font-size:28px;font-weight:600}
+					p{margin:0 0 24px;color:#57606a}
+					.table-wrap{overflow-x:auto;border:1px solid #d0d7de;border-radius:8px;background:#fff}
+					table{width:100%;border-collapse:collapse}
+					th,td{padding:12px 16px;border-bottom:1px solid #d8dee4;text-align:left;vertical-align:top}
+					th{background:#f6f8fa;font-weight:600;white-space:nowrap}
+					tr:last-child td{border-bottom:0}
+					a{color:#0969da;text-decoration:none;overflow-wrap:anywhere}
+					a:hover{text-decoration:underline}
+					.number{text-align:right;white-space:nowrap}
+				</style>
+			</head>
+			<body>
+				<main>
+					<h1>XML Sitemap</h1>
+					<xsl:choose>
+						<xsl:when test="sitemap:sitemapindex">
+							<p>This sitemap index contains <xsl:value-of select="count(sitemap:sitemapindex/sitemap:sitemap)"/> sitemaps.</p>
+							<div class="table-wrap">
+								<table>
+									<thead><tr><th>URL</th><th>Last modified</th></tr></thead>
+									<tbody>
+										<xsl:for-each select="sitemap:sitemapindex/sitemap:sitemap">
+											<tr>
+												<td><a href="{sitemap:loc}"><xsl:value-of select="sitemap:loc"/></a></td>
+												<td><xsl:value-of select="sitemap:lastmod"/></td>
+											</tr>
+										</xsl:for-each>
+									</tbody>
+								</table>
+							</div>
+						</xsl:when>
+						<xsl:otherwise>
+							<p>This sitemap contains <xsl:value-of select="count(sitemap:urlset/sitemap:url)"/> URLs.</p>
+							<div class="table-wrap">
+								<table>
+									<thead><tr><th>URL</th><th class="number">Images</th><th>Last modified</th></tr></thead>
+									<tbody>
+										<xsl:for-each select="sitemap:urlset/sitemap:url">
+											<tr>
+												<td><a href="{sitemap:loc}"><xsl:value-of select="sitemap:loc"/></a></td>
+												<td class="number"><xsl:value-of select="count(image:image)"/></td>
+												<td><xsl:value-of select="sitemap:lastmod"/></td>
+											</tr>
+										</xsl:for-each>
+									</tbody>
+								</table>
+							</div>
+						</xsl:otherwise>
+					</xsl:choose>
+				</main>
+			</body>
+		</html>
+	</xsl:template>
+</xsl:stylesheet>
+XSL;
+	}
 
-        // Create directory structure if it doesn't exist
-        if ( ! file_exists( $plugin_dir ) ) {
-            wp_mkdir_p( $plugin_dir );
-        }
+	/**
+	 * Point all exported sitemap documents at the queued static stylesheet.
+	 *
+	 * @param string $destination_dir Destination directory.
+	 * @return void
+	 */
+	protected function fix_sitemap_xsl_references( $destination_dir ) {
+		$stylesheet_url = trailingslashit( Options::instance()->get_destination_url() ) . 'main-sitemap.xsl';
+		$replacement    = '<?xml-stylesheet type="text/xsl" href="' . $stylesheet_url . '"?>';
 
-        $plugin_xsl_path = Util::combine_path( $plugin_dir, '/main-sitemap.xsl' );
+		foreach ( $this->get_sitemap_files( $destination_dir ) as $sitemap_file ) {
+			$content = @file_get_contents( $sitemap_file );
+			if ( ! is_string( $content ) || '' === $content ) {
+				continue;
+			}
 
-        if ( ! file_exists( $plugin_xsl_path ) ) {
-            $rename = rename( $temp_filename, $plugin_xsl_path );
-            if ( $rename === false ) {
-                Util::debug_log( 'Cannot create ' . $plugin_xsl_path );
-            } else {
-                Util::debug_log( 'Created ' . $plugin_xsl_path );
-            }
-        }
-    }
+			$updated = preg_replace(
+				'/<\?xml-stylesheet\b[^?]*\bhref\s*=\s*(["\']).*?\1[^?]*\?>/i',
+				$replacement,
+				$content
+			);
 
-    /**
-     * Generate XSL
-     *
-     * @return void
-     */
-    public function generate_xsl() {
-        if ( class_exists( 'AIOSEO\Plugin\Common\Sitemap\Xsl' ) && method_exists( 'AIOSEO\Plugin\Common\Sitemap\Xsl', 'output' ) ) {
-            // Try to use the AIOSEO XSL class if available
-            $xsl = new \AIOSEO\Plugin\Common\Sitemap\Xsl();
-            $xsl->output();
-        } else {
-            // Fallback to a basic XSL if the class doesn't exist
-            echo '<?xml version="1.0" encoding="UTF-8"?>';
-            echo '<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9">';
-            echo '<xsl:output method="html" encoding="UTF-8" indent="yes"/>';
-            echo '<xsl:template match="/">';
-            echo '<html><head><title>XML Sitemap</title>';
-            echo '<style>body{font-family:Arial,sans-serif;font-size:14px;color:#333}h1{font-size:24px;font-weight:normal;margin:10px 0}table{border-collapse:collapse;width:100%;margin:20px 0}th,td{padding:10px;text-align:left}th{background-color:#f2f2f2}tr:nth-child(even){background-color:#f9f9f9}a{color:#337ab7;text-decoration:none}a:hover{text-decoration:underline}</style>';
-            echo '</head><body>';
-            echo '<h1>XML Sitemap</h1>';
-            echo '<table>';
-            echo '<tr><th>URL</th><th>Last Modified</th></tr>';
-            echo '<xsl:for-each select="sitemap:urlset/sitemap:url">';
-            echo '<tr>';
-            echo '<td><a href="{sitemap:loc}"><xsl:value-of select="sitemap:loc"/></a></td>';
-            echo '<td><xsl:value-of select="sitemap:lastmod"/></td>';
-            echo '</tr>';
-            echo '</xsl:for-each>';
-            echo '</table>';
-            echo '</body></html>';
-            echo '</xsl:template>';
-            echo '</xsl:stylesheet>';
-        }
-    }
+			if ( is_string( $updated ) && $updated !== $content ) {
+				if ( false === @file_put_contents( $sitemap_file, $updated ) ) {
+					Util::debug_log( 'Cannot update AIOSEO XSL reference in ' . $sitemap_file );
+					continue;
+				}
 
-    /**
-     * Fix XSL references in sitemap XML files
-     *
-     * @param string $destination_dir Destination directory.
-     * @return void
-     */
-    protected function fix_sitemap_xsl_references( $destination_dir ) {
-        // List of sitemap files to check
-        $sitemap_files = [
-            Util::combine_path( $destination_dir, '/sitemap.xml' ),
-            Util::combine_path( $destination_dir, '/sitemap_index.xml' ),
-            // Add other sitemap files if needed
-        ];
+				Util::debug_log( 'Updated AIOSEO XSL reference in ' . $sitemap_file );
+			}
+		}
+	}
 
-        // Find all XML files that might be sitemaps
-        $xml_files = glob( Util::combine_path( $destination_dir, '/*-sitemap.xml' ) );
-        if ( is_array( $xml_files ) ) {
-            $sitemap_files = array_merge( $sitemap_files, $xml_files );
-        }
+	/**
+	 * Replace origin URLs in every exported sitemap document.
+	 *
+	 * @param string $destination_dir Destination directory.
+	 * @return void
+	 */
+	protected function replace_urls_in_sitemaps( $destination_dir ) {
+		$destination_url = rtrim( (string) Options::instance()->get_destination_url(), '/' );
+		if ( '' === $destination_url ) {
+			return;
+		}
 
-        foreach ( $sitemap_files as $sitemap_file ) {
-            if ( file_exists( $sitemap_file ) ) {
-                $content = file_get_contents( $sitemap_file );
+		$pattern = '/(?:(https?:)?\/\/)' . Util::origin_host_pattern() . '/i';
 
-                // Replace the XSL reference with the one pointing to the root directory
-                $content = preg_replace(
-                    '/<\?xml-stylesheet type="text\/xsl" href="[^"]*"\?>/',
-                    '<?xml-stylesheet type="text/xsl" href="' . trailingslashit( Options::instance()->get_destination_url() ) . 'main-sitemap.xsl"?>',
-                    $content
-                );
+		foreach ( $this->get_sitemap_files( $destination_dir ) as $sitemap_file ) {
+			$content = @file_get_contents( $sitemap_file );
+			if ( ! is_string( $content ) || '' === $content ) {
+				continue;
+			}
 
-                file_put_contents( $sitemap_file, $content );
-                Util::debug_log( 'Fixed XSL reference in ' . $sitemap_file );
-            }
-        }
-    }
+			$updated = preg_replace( $pattern, $destination_url, $content );
+			if ( is_string( $updated ) && $updated !== $content ) {
+				if ( false === @file_put_contents( $sitemap_file, $updated ) ) {
+					Util::debug_log( 'Cannot replace URLs in AIOSEO sitemap ' . $sitemap_file );
+					continue;
+				}
 
-    /**
-     * Perform generic URL replacements in sitemap XML files for All in One SEO.
-     *
-     * @param string $destination_dir Destination directory.
-     * @return void
-     */
-    protected function replace_urls_in_sitemaps( $destination_dir ) {
-        try {
-            $options         = Options::instance();
-            $destination_url = trailingslashit( $options->get_destination_url() );
-            $origin_host     = Util::origin_host();
+				Util::debug_log( 'Updated URLs in AIOSEO sitemap ' . $sitemap_file );
+			}
+		}
+	}
 
-            // Collect sitemap files to process
-            $sitemap_files = [
-                Util::combine_path( $destination_dir, '/sitemap.xml' ),
-                Util::combine_path( $destination_dir, '/sitemap_index.xml' ),
-            ];
+	/**
+	 * Return all root-level sitemap XML files, including paginated names such as
+	 * post-sitemap2.xml.
+	 *
+	 * @param string $destination_dir Destination directory.
+	 * @return string[]
+	 */
+	private function get_sitemap_files( $destination_dir ) {
+		$sitemap_files = array(
+			Util::combine_path( $destination_dir, '/sitemap.xml' ),
+			Util::combine_path( $destination_dir, '/sitemap_index.xml' ),
+		);
+		$xml_files = glob( Util::combine_path( $destination_dir, '/*-sitemap*.xml' ) );
 
-            $xml_files = glob( Util::combine_path( $destination_dir, '/*-sitemap.xml' ) );
-            if ( is_array( $xml_files ) ) {
-                $sitemap_files = array_merge( $sitemap_files, $xml_files );
-            }
+		if ( is_array( $xml_files ) ) {
+			$sitemap_files = array_merge( $sitemap_files, $xml_files );
+		}
 
-            $sitemap_files = array_unique( array_filter( $sitemap_files, 'file_exists' ) );
-            if ( empty( $sitemap_files ) ) {
-                return;
-            }
-
-            foreach ( $sitemap_files as $file ) {
-                $content = @file_get_contents( $file );
-                if ( false === $content || '' === $content ) {
-                    continue;
-                }
-
-                $updated = $this->replace_all_origin_urls_with_destination( $content, $destination_url, $origin_host );
-
-                if ( is_string( $updated ) && $updated !== $content ) {
-                    file_put_contents( $file, $updated );
-                    Util::debug_log( 'Updated URLs in sitemap (generic replace): ' . $file );
-                }
-            }
-        } catch ( \Throwable $e ) {
-            Util::debug_log( 'Error updating AIOSEO sitemap URLs: ' . $e->getMessage() );
-        }
-    }
-
-    /**
-     * Generic, tag-agnostic replacement for origin host URLs.
-     *
-     * @param string $xml
-     * @param string $destination_url
-     * @param string $origin_host
-     * @return string
-     */
-    private function replace_all_origin_urls_with_destination( $xml, $destination_url, $origin_host ) {
-        if ( ! is_string( $xml ) || $xml === '' ) {
-            return $xml;
-        }
-        $dest = rtrim( $destination_url, '/' );
-        $pattern = '/(?:(https?:)?\\/\\/)' . Util::origin_host_pattern() . '/i';
-        return preg_replace( $pattern, $dest, $xml );
-    }
+		return array_values( array_unique( array_filter( $sitemap_files, 'is_file' ) ) );
+	}
 }

--- a/src/integrations/class-ss-aio-seo-integration.php
+++ b/src/integrations/class-ss-aio-seo-integration.php
@@ -22,8 +22,9 @@ class AIO_SEO_Integration extends Integration {
 	 * @return void
 	 */
 	public function run() {
-        add_filter( 'aioseo_unrecognized_allowed_query_args', [ $this, 'allowed_query_args' ] );
+		add_filter( 'aioseo_unrecognized_allowed_query_args', [ $this, 'allowed_query_args' ] );
 		add_action( 'ss_after_setup_task', [ $this, 'register_sitemap_pages' ] );
+		add_action( 'ss_finished_fetching_pages', [ $this, 'finalize_sitemap_files' ] );
 		add_filter( 'ssp_single_export_additional_urls', [ $this, 'add_sitemap_url' ] );
 		add_filter( 'ss_additional_files', [ $this, 'maybe_add_text_files' ] );
 
@@ -41,8 +42,11 @@ class AIO_SEO_Integration extends Integration {
             $args = [];
         }
 
-        $args[] = 'simply_static_page';
-        return $args;
+		if ( ! in_array( 'simply_static_page', $args, true ) ) {
+			$args[] = 'simply_static_page';
+		}
+
+		return $args;
     }
 
 	/**
@@ -72,6 +76,71 @@ class AIO_SEO_Integration extends Integration {
 
 		// Extract and add individual sitemap URLs from sitemap.xml
 		$this->extract_sitemap_urls_from_index();
+
+		// Queue the generated endpoint last. Its handler performs one final pass
+		// over all sitemap XML files after the stylesheet itself is fetched.
+		$this->register_stylesheet_page();
+	}
+
+	/**
+	 * Register the stable stylesheet endpoint as a normal Page record so every
+	 * delivery method transfers it alongside the sitemap XML files.
+	 *
+	 * @return void
+	 */
+	public function register_stylesheet_page() {
+		$url = home_url( 'main-sitemap.xsl' );
+
+		Util::debug_log( 'Adding AIOSEO sitemap stylesheet to queue: ' . $url );
+		/** @var \Simply_Static\Page $static_page */
+		$static_page = Page::query()->find_or_initialize_by( 'url', $url );
+		$static_page->set_status_message( __( 'Sitemap Stylesheet', 'simply-static' ) );
+		$static_page->found_on_id = 0;
+		$static_page->handler     = AIO_SEO_Sitemap_Handler::class;
+		$static_page->save();
+	}
+
+	/**
+	 * Apply one deterministic post-fetch pass after every sitemap and stylesheet
+	 * page has been written. Refresh content hashes for files changed by the pass
+	 * so incremental delivery methods transfer the corrected XML.
+	 *
+	 * @return void
+	 */
+	public function finalize_sitemap_files() {
+		$archive_dir = Options::instance()->get_archive_dir();
+		if ( ! is_dir( $archive_dir ) ) {
+			return;
+		}
+
+		try {
+			$page = Page::initialize( array() );
+			( new AIO_SEO_Sitemap_Handler( $page ) )->after_file_fetch( $archive_dir );
+
+			$sitemap_files = array(
+				Util::combine_path( $archive_dir, '/sitemap.xml' ),
+				Util::combine_path( $archive_dir, '/sitemap_index.xml' ),
+			);
+			$xml_files = glob( Util::combine_path( $archive_dir, '/*-sitemap*.xml' ) );
+			if ( is_array( $xml_files ) ) {
+				$sitemap_files = array_merge( $sitemap_files, $xml_files );
+			}
+
+			foreach ( array_unique( array_filter( $sitemap_files, 'is_file' ) ) as $sitemap_file ) {
+				$relative_path = ltrim( substr( $sitemap_file, strlen( untrailingslashit( $archive_dir ) ) ), '/\\' );
+				$static_page   = Page::query()->find_by( 'file_path', $relative_path );
+				$hash          = sha1_file( $sitemap_file, true );
+
+				if ( ! $static_page || false === $hash || $static_page->is_content_identical( $hash ) ) {
+					continue;
+				}
+
+				$static_page->set_content_hash( $hash );
+				$static_page->save();
+			}
+		} catch ( \Throwable $e ) {
+			Util::debug_log( 'Unable to finalize AIOSEO sitemap files: ' . $e->getMessage() );
+		}
 	}
 
 	/**

--- a/tests/Unit/AioSeoSitemapHandlerTest.php
+++ b/tests/Unit/AioSeoSitemapHandlerTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Simply_Static\Tests\Unit;
+
+use DOMDocument;
+use Simply_Static\AIO_SEO_Integration;
+use Simply_Static\AIO_SEO_Sitemap_Handler;
+use Simply_Static\Options;
+use Simply_Static\Page;
+use Simply_Static\Tests\Support\UnitTestCase;
+use Simply_Static\Tests\Support\WpTestEnvironment as WpEnv;
+use XSLTProcessor;
+
+$simply_static_root = dirname( __DIR__, 2 );
+require_once $simply_static_root . '/src/class-ss-plugin.php';
+require_once $simply_static_root . '/src/class-ss-options.php';
+require_once $simply_static_root . '/src/class-ss-util.php';
+require_once $simply_static_root . '/src/class-ss-query.php';
+require_once $simply_static_root . '/src/models/class-ss-model.php';
+require_once $simply_static_root . '/src/models/class-ss-page.php';
+require_once $simply_static_root . '/src/handlers/class-ss-page-handler.php';
+require_once $simply_static_root . '/src/integrations/class-ss-integration.php';
+require_once $simply_static_root . '/src/handlers/class-ss-aio-seo-sitemap-handler.php';
+require_once $simply_static_root . '/src/integrations/class-ss-aio-seo-integration.php';
+
+final class AioSeoSitemapWpdb {
+
+	/** @var int */
+	public $insert_id = 0;
+
+	/** @var array<int,array<string,mixed>> */
+	public $inserted_rows = array();
+
+	public function get_blog_prefix(): string {
+		return 'wp_';
+	}
+
+	/** @return null */
+	public function get_row( string $query, string $output_type ) {
+		return null;
+	}
+
+	/** @param array<string,mixed> $fields */
+	public function insert( string $table, array $fields ): int {
+		$this->insert_id++;
+		$this->inserted_rows[] = $fields;
+
+		return 1;
+	}
+}
+
+final class AioSeoSitemapHandlerTest extends UnitTestCase {
+
+	/** @var string */
+	private $archive_dir;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->archive_dir = sys_get_temp_dir() . '/simply-static-aioseo-' . str_replace( '.', '', uniqid( '', true ) );
+		mkdir( $this->archive_dir, 0777, true );
+
+		Options::instance()
+			->set( 'origin_url', 'https://wordpress.internal' )
+			->set( 'destination_url_type', 'absolute' )
+			->set( 'destination_scheme', 'https://' )
+			->set( 'destination_host', 'static.example' );
+	}
+
+	protected function tearDown(): void {
+		unset( $GLOBALS['wpdb'] );
+
+		foreach ( glob( $this->archive_dir . '/*' ) ?: array() as $file ) {
+			if ( is_file( $file ) ) {
+				unlink( $file );
+			}
+		}
+
+		if ( is_dir( $this->archive_dir ) ) {
+			rmdir( $this->archive_dir );
+		}
+
+		parent::tearDown();
+	}
+
+	public function test_it_rewrites_root_and_paginated_sitemap_stylesheets(): void {
+		$root_file      = $this->archive_dir . '/sitemap.xml';
+		$paginated_file = $this->archive_dir . '/tribe_events-sitemap2.xml';
+
+		file_put_contents(
+			$root_file,
+			'<?xml version="1.0"?>' . "\n"
+			. '<?xml-stylesheet type="text/xsl" href="https://wordpress.internal/default-sitemap.xsl?sitemap=root"?>' . "\n"
+			. '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><sitemap><loc>https://wordpress.internal/page-sitemap.xml</loc></sitemap></sitemapindex>'
+		);
+		file_put_contents(
+			$paginated_file,
+			'<?xml version="1.0"?>' . "\n"
+			. "<?xml-stylesheet href='https://wordpress.internal/default-sitemap.xsl?sitemap=tribe_events' type='text/xsl'?>" . "\n"
+			. '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://wordpress.internal/event/</loc></url></urlset>'
+		);
+
+		$this->handler( 'https://wordpress.internal/main-sitemap.xsl' )->after_file_fetch( $this->archive_dir );
+
+		$root       = (string) file_get_contents( $root_file );
+		$paginated  = (string) file_get_contents( $paginated_file );
+		$stylesheet = '<?xml-stylesheet type="text/xsl" href="https://static.example/main-sitemap.xsl"?>';
+
+		self::assertStringContainsString( $stylesheet, $root );
+		self::assertStringContainsString( $stylesheet, $paginated );
+		self::assertStringContainsString( '<loc>https://static.example/page-sitemap.xml</loc>', $root );
+		self::assertStringContainsString( '<loc>https://static.example/event/</loc>', $paginated );
+		self::assertStringNotContainsString( 'default-sitemap.xsl', $root . $paginated );
+	}
+
+	public function test_the_static_stylesheet_transforms_indexes_and_url_sets(): void {
+		$stylesheet = new DOMDocument();
+		self::assertTrue( $stylesheet->loadXML( AIO_SEO_Sitemap_Handler::stylesheet_content() ) );
+
+		$processor = new XSLTProcessor();
+		self::assertTrue( $processor->importStylesheet( $stylesheet ) );
+
+		$index = new DOMDocument();
+		$index->loadXML(
+			'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+			. '<sitemap><loc>https://static.example/page-sitemap.xml</loc><lastmod>2026-08-17</lastmod></sitemap>'
+			. '</sitemapindex>'
+		);
+		$index_html = $processor->transformToXML( $index );
+
+		self::assertIsString( $index_html );
+		self::assertStringContainsString( 'contains 1 sitemaps', $index_html );
+		self::assertStringContainsString( 'https://static.example/page-sitemap.xml', $index_html );
+
+		$url_set = new DOMDocument();
+		$url_set->loadXML(
+			'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">'
+			. '<url><loc>https://static.example/page/</loc><image:image><image:loc>https://static.example/image.jpg</image:loc></image:image></url>'
+			. '</urlset>'
+		);
+		$url_set_html = $processor->transformToXML( $url_set );
+
+		self::assertIsString( $url_set_html );
+		self::assertStringContainsString( 'contains 1 URLs', $url_set_html );
+		self::assertStringContainsString( 'https://static.example/page/', $url_set_html );
+	}
+
+	public function test_only_the_stylesheet_page_registers_the_virtual_endpoint(): void {
+		$this->handler( 'https://wordpress.internal/sitemap.xml' )->run_hooks();
+		self::assertArrayNotHasKey( 'template_redirect', WpEnv::$filters );
+
+		$this->handler( 'https://wordpress.internal/main-sitemap.xsl' )->run_hooks();
+		self::assertArrayHasKey( 'template_redirect', WpEnv::$filters );
+	}
+
+	public function test_single_exports_include_the_generated_stylesheet_url(): void {
+		$urls = ( new AIO_SEO_Integration() )->add_sitemap_url( array() );
+
+		self::assertContains( 'https://example.test/sitemap.xml', $urls );
+		self::assertContains( 'https://example.test/main-sitemap.xsl', $urls );
+	}
+
+	public function test_the_generated_stylesheet_is_registered_as_a_deployable_page(): void {
+		$wpdb             = new AioSeoSitemapWpdb();
+		$GLOBALS['wpdb'] = $wpdb;
+
+		( new AIO_SEO_Integration() )->register_stylesheet_page();
+
+		self::assertCount( 1, $wpdb->inserted_rows );
+		self::assertSame( 'https://example.test/main-sitemap.xsl', $wpdb->inserted_rows[0]['url'] );
+		self::assertSame( AIO_SEO_Sitemap_Handler::class, $wpdb->inserted_rows[0]['handler'] );
+		self::assertSame( 0, $wpdb->inserted_rows[0]['found_on_id'] );
+	}
+
+	public function test_allowed_query_argument_is_not_duplicated(): void {
+		$integration = new AIO_SEO_Integration();
+
+		self::assertSame(
+			array( 'existing', 'simply_static_page' ),
+			$integration->allowed_query_args( array( 'existing', 'simply_static_page' ) )
+		);
+	}
+
+	private function handler( string $url ): AIO_SEO_Sitemap_Handler {
+		$page = Page::initialize( array( 'url' => $url ) );
+
+		return new AIO_SEO_Sitemap_Handler( $page );
+	}
+}


### PR DESCRIPTION
## Summary
- Export `main-sitemap.xsl` as a queued, deployable page and rewrite AIOSEO sitemap references to it.
- Cover root, child, and paginated sitemap files while refreshing hashes for incremental deployments.
- Add regression coverage for XSL transformation, URL rewriting, and stylesheet page registration.

## Tests
- `vendor/bin/phpunit --configuration phpunit.xml.dist` (378 tests, 4,611 assertions)