### PR TITLE
Resume uploads discovery across background requests

### DIFF
--- a/src/crawler/class-ss-crawler.php
+++ b/src/crawler/class-ss-crawler.php
@@ -82,6 +82,28 @@ abstract class Crawler {
 	abstract public function detect() : array;
 
 	/**
+	 * Whether this crawler finished its current discovery pass.
+	 *
+	 * Most crawlers complete in one call. Large filesystem crawlers can
+	 * override this and persist a cursor so the background job can yield before
+	 * the request time limit and resume in the next worker request.
+	 *
+	 * @return bool
+	 */
+	public function is_complete() : bool {
+		return true;
+	}
+
+	/**
+	 * Return optional progress for a resumable crawler.
+	 *
+	 * @return array<string,int>
+	 */
+	public function get_progress() : array {
+		return array();
+	}
+
+	/**
 	 * Add detected URLs to the Simply Static page queue.
 	 *
 	 * @return int Number of URLs added

--- a/src/crawler/class-ss-uploads-crawler.php
+++ b/src/crawler/class-ss-uploads-crawler.php
@@ -14,6 +14,15 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Uploads_Crawler extends Crawler {
 
+	/** @var bool */
+	protected $complete = true;
+
+	/** @var array<string,int> */
+	protected $progress = array(
+		'added'   => 0,
+		'scanned' => 0,
+	);
+
 	/**
 	 * Crawler ID.
 	 * @var string
@@ -85,156 +94,311 @@ class Uploads_Crawler extends Crawler {
 	}
 
 	/**
-	 * Override add_urls_to_queue to stream URLs directly into the queue in batches.
-	 * This avoids building a massive array in memory for large media libraries.
+	 * Stream one bounded batch of upload URLs into the queue.
+	 *
+	 * The previous implementation traversed the complete uploads tree in one
+	 * request. Large libraries could outlive the background-process request and
+	 * leave the export lock behind. Persist a directory/entry cursor instead so
+	 * Discover_Urls_Task can yield and resume in the next worker request.
 	 *
 	 * @return int Number of URLs added
 	 */
 	public function add_urls_to_queue(): int {
-		$count = 0;
+		$this->complete = true;
+		$scan_dirs      = $this->get_scan_directories();
+		$signature      = $this->get_state_signature( $scan_dirs );
+		$state          = $this->load_state( $signature );
+		$extensions     = (array) apply_filters( 'ss_uploads_media_extensions', $this->get_media_extensions() );
+		$skip_dirs      = (array) apply_filters( 'ss_skip_crawl_uploads_directories', array( '.git', 'node_modules', 'cache', 'tmp', 'temp' ) );
+		$queue_batch    = max( 1, min( 1000, (int) apply_filters( 'simply_static_crawler_batch_size', 100 ) ) );
+		$entry_limit    = max( 1, min( 10000, (int) apply_filters( 'simply_static_uploads_crawler_max_entries_per_batch', 500 ) ) );
+		$seconds        = (float) apply_filters( 'simply_static_uploads_crawler_max_batch_seconds', 10 );
+		$deadline       = microtime( true ) + max( 0.5, min( 15, $seconds ) );
+		$processed        = 0;
+		$invocation_added = 0;
+		$buffer           = array();
 
-		$uploads_dir = wp_upload_dir();
-		$base_dir    = $uploads_dir['basedir'];
-		$base_url    = $uploads_dir['baseurl'];
-
-		$additional_dirs = [
-			[
-				'basedir' => WP_CONTENT_DIR . '/webp-express/webp-images/uploads',
-				'baseurl' => content_url( 'webp-express/webp-images/uploads' ),
-			],
-			[
-				'basedir' => WP_CONTENT_DIR . '/compressx-nextgen/uploads',
-				'baseurl' => content_url( 'compressx-nextgen/uploads' ),
-			],
-		];
-
-		$additional_dirs = apply_filters( 'ss_uploads_additional_directories', $additional_dirs );
-
-		$scan_dirs = [
-			[
-				'basedir' => $base_dir,
-				'baseurl' => $base_url,
-			],
-		];
-
-		foreach ( $additional_dirs as $additional_dir ) {
-			if ( is_dir( $additional_dir['basedir'] ) ) {
-				$scan_dirs[] = $additional_dir;
+		while ( $state['scan_index'] < count( $scan_dirs ) ) {
+			$scan = $scan_dirs[ $state['scan_index'] ];
+			if ( null === $state['current_dir'] ) {
+				if ( empty( $state['pending_dirs'] ) ) {
+					$state['scan_index']++;
+					if ( $state['scan_index'] < count( $scan_dirs ) ) {
+						$state['pending_dirs'] = array( '' );
+					}
+					continue;
+				}
+				$state['current_dir']  = array_pop( $state['pending_dirs'] );
+				$state['entry_offset'] = 0;
 			}
-		}
 
-		if ( ! is_dir( $base_dir ) ) {
-			\Simply_Static\Util::debug_log( "Uploads directory does not exist: " . $base_dir );
-
-			return 0;
-		}
-
-		// Media file extensions to look for
-		$media_extensions = [
-			'jpg',
-			'jpeg',
-			'png',
-			'gif',
-			'webp',
-			'avif',
-			'tiff',
-			'heic',
-			'svg',
-			'ico',
-			'css',
-			'js',
-			'woff',
-			'woff2',
-			'ttf',
-			'otf',
-			'eot',
-			'pdf',
-			'mp3',
-			'mp4',
-			'webm',
-			'ogg',
-			'wav',
-			'mov',
-			'avi',
-			'wmv',
-			'zip',
-			'doc',
-			'docx',
-			'xls',
-			'xlsx',
-			'ppt',
-			'pptx',
-			'json'
-		];
-		$media_extensions = apply_filters( 'ss_uploads_media_extensions', $media_extensions );
-
-		// Directories to skip
-		$skip_dirs = [ '.git', 'node_modules', 'cache', 'tmp', 'temp' ];
-		$skip_dirs = apply_filters( 'ss_skip_crawl_uploads_directories', $skip_dirs );
-
-		$batch_size = (int) apply_filters( 'simply_static_crawler_batch_size', 100 );
-		$buffer     = [];
-
-		foreach ( $scan_dirs as $scan_dir ) {
-			$base_dir = $scan_dir['basedir'];
-			$base_url = $scan_dir['baseurl'];
+			$directory = $this->resolve_scan_directory( $scan['basedir'], $state['current_dir'] );
+			if ( false === $directory ) {
+				\Simply_Static\Util::debug_log( 'Uploads crawler skipped a missing or unsafe directory cursor.' );
+				$state['current_dir']  = null;
+				$state['entry_offset'] = 0;
+				continue;
+			}
 
 			try {
-				$iterator = new \RecursiveIteratorIterator(
-					new \RecursiveDirectoryIterator( $base_dir, \RecursiveDirectoryIterator::SKIP_DOTS ),
-					\RecursiveIteratorIterator::SELF_FIRST
-				);
+				$iterator = $this->get_directory_iterator( $directory );
+				if ( $state['entry_offset'] > 0 ) {
+					$iterator->seek( $state['entry_offset'] );
+				}
+			} catch ( \UnexpectedValueException $exception ) {
+				\Simply_Static\Util::debug_log( 'Uploads crawler could not read directory: ' . $exception->getMessage() );
+				$state['current_dir']  = null;
+				$state['entry_offset'] = 0;
+				continue;
+			} catch ( \OutOfBoundsException $exception ) {
+				// The directory became shorter between worker requests. Everything
+				// before the persisted cursor was already handled, so move on safely.
+				$state['current_dir']  = null;
+				$state['entry_offset'] = 0;
+				continue;
+			}
 
-				foreach ( $iterator as $file ) {
+			while ( $iterator->valid() ) {
+				$file = $iterator->current();
+				$state['entry_offset']++;
+				$state['scanned']++;
+				$processed++;
+
+				if ( $file instanceof \SplFileInfo && ! $file->isLink() ) {
+					$relative_path = ltrim( \Simply_Static\Util::safe_relative_path( $scan['basedir'], $file->getPathname() ), '/' );
 					if ( $file->isDir() ) {
-						continue;
-					}
-
-					$relative_path = \Simply_Static\Util::safe_relative_path( $base_dir, $file->getPathname() );
-					if ( \Simply_Static\Util::is_private_backup_path( $relative_path ) ) {
-						continue;
-					}
-
-					// Skip files in ignored directories
-					$skip = false;
-					foreach ( (array) $skip_dirs as $skip_dir ) {
-						if ( $skip_dir && strpos( $relative_path, '/' . trim( $skip_dir, '/' ) . '/' ) !== false ) {
-							$skip = true;
-							break;
+						if ( ! $this->should_skip_path( $relative_path, $skip_dirs ) ) {
+							if ( count( $state['pending_dirs'] ) >= 50000 ) {
+								throw new \RuntimeException( 'Uploads crawler directory queue exceeded its safety limit.' );
+							}
+							$state['pending_dirs'][] = $relative_path;
+						}
+					} elseif ( $file->isFile() && ! $this->should_skip_path( $relative_path, $skip_dirs ) ) {
+						$extension = strtolower( pathinfo( $relative_path, PATHINFO_EXTENSION ) );
+						if ( in_array( $extension, $extensions, true ) ) {
+							$buffer[] = \Simply_Static\Util::safe_join_url( $scan['baseurl'], $relative_path );
+							if ( count( $buffer ) >= $queue_batch ) {
+								$added             = $this->enqueue_urls_batch( $buffer );
+								$invocation_added += $added;
+								$state['added']    += $added;
+								$buffer             = array();
+							}
 						}
 					}
-					if ( $skip ) {
-						continue;
-					}
-
-					$ext = strtolower( pathinfo( $relative_path, PATHINFO_EXTENSION ) );
-					if ( ! in_array( $ext, (array) $media_extensions, true ) ) {
-						continue;
-					}
-
-					$url      = \Simply_Static\Util::safe_join_url( $base_url, $relative_path );
-					$buffer[] = $url;
-
-					if ( count( $buffer ) >= $batch_size ) {
-						$count  += $this->enqueue_urls_batch( $buffer );
-						$buffer = [];
-						// Yield to allow other processes to run
-						usleep( 100000 );
-					}
 				}
-			} catch ( \Exception $e ) {
-				\Simply_Static\Util::debug_log( 'Error streaming uploads crawl: ' . $e->getMessage() );
+				$iterator->next();
+
+				if ( $processed >= $entry_limit || microtime( true ) >= $deadline ) {
+					break;
+				}
+			}
+
+			if ( ! empty( $buffer ) ) {
+				$added             = $this->enqueue_urls_batch( $buffer );
+				$invocation_added += $added;
+				$state['added']    += $added;
+				$buffer             = array();
+			}
+
+			if ( $iterator->valid() ) {
+				$this->complete = false;
+				$this->progress = array(
+					'added'   => $state['added'],
+					'scanned' => $state['scanned'],
+				);
+				$this->save_state( $state );
+				\Simply_Static\Util::debug_log( sprintf( 'Uploads crawler checkpointed after %d entries with %d URLs queued.', $state['scanned'], $state['added'] ) );
+
+				return $invocation_added;
+			}
+
+			$state['current_dir']  = null;
+			$state['entry_offset'] = 0;
+			if ( $processed >= $entry_limit || microtime( true ) >= $deadline ) {
+				$this->complete = false;
+				$this->progress = array(
+					'added'   => $state['added'],
+					'scanned' => $state['scanned'],
+				);
+				$this->save_state( $state );
+
+				return $invocation_added;
 			}
 		}
 
-		// Process remaining
-		if ( ! empty( $buffer ) ) {
-			$count += $this->enqueue_urls_batch( $buffer );
+		$this->progress = array(
+			'added'   => $state['added'],
+			'scanned' => $state['scanned'],
+		);
+		$this->clear_state();
+		\Simply_Static\Util::debug_log( sprintf( 'Uploads crawler added %d URLs across resumable batches.', $state['added'] ) );
+
+		return $invocation_added;
+	}
+
+	public function is_complete() : bool {
+		return $this->complete;
+	}
+
+	public function get_progress() : array {
+		return $this->progress;
+	}
+
+	/** @return array<int,array{basedir:string,baseurl:string}> */
+	protected function get_scan_directories() : array {
+		$uploads = wp_upload_dir();
+		$dirs    = array();
+		if ( isset( $uploads['basedir'], $uploads['baseurl'] ) && is_string( $uploads['basedir'] ) && is_string( $uploads['baseurl'] ) ) {
+			$canonical = realpath( $uploads['basedir'] );
+			$dirs[]    = array(
+				'basedir' => false === $canonical ? $uploads['basedir'] : $canonical,
+				'baseurl' => $uploads['baseurl'],
+			);
+		}
+		$additional = apply_filters( 'ss_uploads_additional_directories', array(
+			array(
+				'basedir' => WP_CONTENT_DIR . '/webp-express/webp-images/uploads',
+				'baseurl' => content_url( 'webp-express/webp-images/uploads' ),
+			),
+			array(
+				'basedir' => WP_CONTENT_DIR . '/compressx-nextgen/uploads',
+				'baseurl' => content_url( 'compressx-nextgen/uploads' ),
+			),
+		) );
+		foreach ( (array) $additional as $candidate ) {
+			if ( is_array( $candidate ) && isset( $candidate['basedir'], $candidate['baseurl'] ) && is_string( $candidate['basedir'] ) && is_string( $candidate['baseurl'] ) && is_dir( $candidate['basedir'] ) ) {
+				$canonical = realpath( $candidate['basedir'] );
+				$dirs[]    = array(
+					'basedir' => false === $canonical ? $candidate['basedir'] : $canonical,
+					'baseurl' => $candidate['baseurl'],
+				);
+			}
 		}
 
-		\Simply_Static\Util::debug_log( sprintf( 'Uploads crawler added %d URLs (streamed)', $count ) );
+		return $dirs;
+	}
 
-		return $count;
+	/** @return string[] */
+	protected function get_media_extensions() : array {
+		return array( 'jpg', 'jpeg', 'png', 'gif', 'webp', 'avif', 'tiff', 'heic', 'svg', 'ico', 'css', 'js', 'woff', 'woff2', 'ttf', 'otf', 'eot', 'pdf', 'mp3', 'mp4', 'webm', 'ogg', 'wav', 'mov', 'avi', 'wmv', 'zip', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'json' );
+	}
+
+	protected function get_directory_iterator( string $directory ) : \FilesystemIterator {
+		return new \FilesystemIterator( $directory, \FilesystemIterator::SKIP_DOTS );
+	}
+
+	/** @param string[] $skip_dirs */
+	protected function should_skip_path( string $relative_path, array $skip_dirs ) : bool {
+		$path = trim( str_replace( '\\', '/', $relative_path ), '/' );
+		if ( \Simply_Static\Util::is_private_backup_path( $path ) ) {
+			return true;
+		}
+		foreach ( $skip_dirs as $skip_dir ) {
+			$skip = is_string( $skip_dir ) ? trim( str_replace( '\\', '/', $skip_dir ), '/' ) : '';
+			if ( '' !== $skip && ( $path === $skip || 0 === strpos( $path, $skip . '/' ) || false !== strpos( '/' . $path . '/', '/' . $skip . '/' ) ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/** @return string|false */
+	protected function resolve_scan_directory( string $base_dir, $relative_dir ) {
+		if ( ! is_string( $relative_dir ) || ! $this->is_safe_relative_directory( $relative_dir ) ) {
+			return false;
+		}
+		$root      = realpath( $base_dir );
+		$candidate = realpath( rtrim( $base_dir, '/\\' ) . ( '' === $relative_dir ? '' : '/' . $relative_dir ) );
+		if ( false === $root || false === $candidate || ! is_dir( $candidate ) ) {
+			return false;
+		}
+		$root = rtrim( str_replace( '\\', '/', $root ), '/' );
+		$path = str_replace( '\\', '/', $candidate );
+		if ( $path !== $root && 0 !== strpos( $path, $root . '/' ) ) {
+			return false;
+		}
+
+		return $candidate;
+	}
+
+	protected function is_safe_relative_directory( string $path ) : bool {
+		if ( false !== strpos( $path, "\0" ) || 0 === strpos( str_replace( '\\', '/', $path ), '/' ) ) {
+			return false;
+		}
+		foreach ( explode( '/', str_replace( '\\', '/', $path ) ) as $segment ) {
+			if ( '.' === $segment || '..' === $segment ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/** @param array<int,array{basedir:string,baseurl:string}> $scan_dirs */
+	protected function get_state_signature( array $scan_dirs ) : string {
+		return hash( 'sha256', serialize( array(
+			'archive_start_time' => \Simply_Static\Options::instance()->get( 'archive_start_time' ),
+			'scan_dirs'          => $scan_dirs,
+		) ) );
+	}
+
+	/** @return array<string,mixed> */
+	protected function load_state( string $signature ) : array {
+		$state = \Simply_Static\Options::instance()->get( 'uploads_crawler_state' );
+		if ( ! is_array( $state ) || 1 !== ( $state['version'] ?? null ) || $signature !== ( $state['signature'] ?? null ) ) {
+			return $this->new_state( $signature );
+		}
+		if ( ! isset( $state['scan_index'], $state['entry_offset'], $state['pending_dirs'], $state['added'], $state['scanned'] ) || ! is_array( $state['pending_dirs'] ) ) {
+			return $this->new_state( $signature );
+		}
+		if ( count( $state['pending_dirs'] ) > 50000 || ! is_int( $state['scan_index'] ) || $state['scan_index'] < 0 || ! is_int( $state['entry_offset'] ) || $state['entry_offset'] < 0 ) {
+			return $this->new_state( $signature );
+		}
+		if ( ! is_int( $state['added'] ) || $state['added'] < 0 || ! is_int( $state['scanned'] ) || $state['scanned'] < 0 ) {
+			return $this->new_state( $signature );
+		}
+
+		$current_dir = $state['current_dir'] ?? null;
+		if ( null !== $current_dir && ( ! is_string( $current_dir ) || ! $this->is_safe_relative_directory( $current_dir ) ) ) {
+			return $this->new_state( $signature );
+		}
+		foreach ( $state['pending_dirs'] as $directory ) {
+			if ( ! is_string( $directory ) || ! $this->is_safe_relative_directory( $directory ) ) {
+				return $this->new_state( $signature );
+			}
+		}
+
+		return $state;
+	}
+
+	/** @return array<string,mixed> */
+	protected function new_state( string $signature ) : array {
+		return array(
+			'version'      => 1,
+			'signature'    => $signature,
+			'scan_index'   => 0,
+			'current_dir'  => null,
+			'entry_offset' => 0,
+			'pending_dirs' => array( '' ),
+			'added'        => 0,
+			'scanned'      => 0,
+		);
+	}
+
+	/** @param array<string,mixed> $state */
+	protected function save_state( array $state ) : void {
+		if ( ! \Simply_Static\Options::instance()->set( 'uploads_crawler_state', $state )->save() ) {
+			throw new \RuntimeException( 'Unable to save the uploads crawler checkpoint.' );
+		}
+	}
+
+	protected function clear_state() : void {
+		$options = \Simply_Static\Options::instance();
+		$options->destroy( 'uploads_crawler_state' );
+		if ( ! $options->save() ) {
+			throw new \RuntimeException( 'Unable to clear the uploads crawler checkpoint.' );
+		}
 	}
 
 	/**
@@ -250,7 +414,7 @@ class Uploads_Crawler extends Crawler {
 
 		foreach ( $urls as $url ) {
 			// Skip URLs that are excluded by settings/patterns to avoid adding them to the DB at all
-   if ( \Simply_Static\Util::is_url_excluded( $url ) ) {
+			if ( \Simply_Static\Util::is_url_excluded( $url ) ) {
 				\Simply_Static\Util::debug_log( sprintf( 'Uploads crawler skipping excluded URL: %s', $url ) );
 				continue;
 			}

--- a/src/tasks/class-ss-discover-urls-task.php
+++ b/src/tasks/class-ss-discover-urls-task.php
@@ -100,17 +100,41 @@ class Discover_Urls_Task extends Task {
 		// Run the current crawler.
 		$urls_added       = $crawler->add_urls_to_queue();
 		$total_urls_added = (int) $this->options->get( $this->total_added_option ) + $urls_added;
-		$this->options->set( $this->total_added_option, $total_urls_added );
+		$this->options->set( $this->total_added_option, $total_urls_added )->save();
+		$crawler_complete = ! method_exists( $crawler, 'is_complete' ) || $crawler->is_complete();
+		$crawler_progress = method_exists( $crawler, 'get_progress' ) ? $crawler->get_progress() : array();
+		$crawler_total    = isset( $crawler_progress['added'] )
+			? max( 0, (int) $crawler_progress['added'] )
+			: $urls_added;
 
 		// Log the number of URLs added.
-		Util::debug_log( "Added $urls_added URLs via " . $crawler_name . " Crawler" );
+		Util::debug_log( "Added $urls_added URLs in this " . $crawler_name . " Crawler batch" );
+
+		if ( ! $crawler_complete ) {
+			$scanned = isset( $crawler_progress['scanned'] )
+				? max( 0, (int) $crawler_progress['scanned'] )
+				: 0;
+			$this->save_status_message(
+				sprintf(
+					__( 'Discovering URLs with %1$s Crawler (%2$d of %3$d): %4$d files queued, %5$d entries scanned', 'simply-static' ),
+					$crawler_name,
+					$crawler_number,
+					$crawler_count,
+					$crawler_total,
+					$scanned
+				)
+			);
+			$this->yield_after_current_crawler();
+
+			return false;
+		}
 
 		// Only show individual crawler messages for full exports.
 		$generate_type = $this->options->get( 'generate_type' );
 		if ( $generate_type === 'export' ) {
 			$message = sprintf(
-				_n( 'Added %d URL via %s Crawler', 'Added %d URLs via %s Crawler', $urls_added, 'simply-static' ),
-				$urls_added,
+				_n( 'Added %d URL via %s Crawler', 'Added %d URLs via %s Crawler', $crawler_total, 'simply-static' ),
+				$crawler_total,
 				$crawler_name
 			);
 			$this->save_status_message( $message );

--- a/tests/Support/wordpress-stubs.php
+++ b/tests/Support/wordpress-stubs.php
@@ -569,6 +569,10 @@ function wp_upload_dir() {
 	return WpEnv::$upload_dir;
 }
 
+function content_url( $path = '' ) {
+	return rtrim( WpEnv::$home_url, '/' ) . '/wp-content/' . ltrim( (string) $path, '/' );
+}
+
 function wp_is_stream( $path ) {
 	return (bool) preg_match( '#^[a-z][a-z0-9+.-]*://#i', (string) $path );
 }

--- a/tests/Unit/CrawlerQueueTest.php
+++ b/tests/Unit/CrawlerQueueTest.php
@@ -100,4 +100,9 @@ final class CrawlerQueueTest extends UnitTestCase {
 			array_column( array_column( $this->wpdb->inserts, 'data' ), 'url' )
 		);
 	}
+
+	public function test_crawlers_complete_in_one_call_by_default(): void {
+		self::assertTrue( ( new FragmentCrawler( array() ) )->is_complete() );
+		self::assertSame( array(), ( new FragmentCrawler( array() ) )->get_progress() );
+	}
 }

--- a/tests/Unit/UploadsCrawlerTest.php
+++ b/tests/Unit/UploadsCrawlerTest.php
@@ -6,7 +6,38 @@ namespace Simply_Static\Tests\Unit;
 
 use ReflectionMethod;
 use Simply_Static\Crawler\Uploads_Crawler;
+use Simply_Static\Options;
 use Simply_Static\Tests\Support\UnitTestCase;
+use Simply_Static\Tests\Support\WpTestEnvironment;
+
+final class UploadsCrawlerWpdb {
+
+	/** @var array<int,array<string,mixed>> */
+	public $inserts = array();
+
+	/** @var int */
+	public $insert_id = 1;
+
+	public function get_blog_prefix(): string {
+		return 'wp_';
+	}
+
+	/** @return null */
+	public function get_row( string $query, $output = null ) {
+		return null;
+	}
+
+	/** @param array<string,mixed> $data */
+	public function insert( string $table, array $data ): int {
+		$this->inserts[] = array(
+			'table' => $table,
+			'data'  => $data,
+		);
+		++$this->insert_id;
+
+		return 1;
+	}
+}
 
 final class UploadsCrawlerTest extends UnitTestCase {
 
@@ -15,8 +46,79 @@ final class UploadsCrawlerTest extends UnitTestCase {
 		$this->requireSource( 'src/class-ss-plugin.php' );
 		$this->requireSource( 'src/class-ss-options.php' );
 		$this->requireSource( 'src/class-ss-util.php' );
+		$this->requireSource( 'src/class-ss-query.php' );
+		$this->requireSource( 'src/models/class-ss-model.php' );
+		$this->requireSource( 'src/models/class-ss-page.php' );
 		$this->requireSource( 'src/crawler/class-ss-crawler.php' );
 		$this->requireSource( 'src/crawler/class-ss-uploads-crawler.php' );
+	}
+
+	public function test_large_upload_tree_resumes_from_persisted_checkpoints(): void {
+		$root = sys_get_temp_dir() . '/ss-uploads-resume-' . bin2hex( random_bytes( 8 ) );
+		wp_mkdir_p( $root . '/2026/deep' );
+		wp_mkdir_p( $root . '/cache' );
+		file_put_contents( $root . '/photo.jpg', 'image' );
+		file_put_contents( $root . '/notes.txt', 'ignore' );
+		file_put_contents( $root . '/2026/one.png', 'image' );
+		file_put_contents( $root . '/2026/deep/two.pdf', 'document' );
+		file_put_contents( $root . '/cache/hidden.jpg', 'cache' );
+
+		WpTestEnvironment::$upload_dir = array(
+			'basedir' => $root,
+			'baseurl' => 'https://example.test/wp-content/uploads',
+		);
+		$GLOBALS['wpdb'] = new UploadsCrawlerWpdb();
+		Options::instance()->set( 'archive_start_time', '2026-08-19 10:00:00' )->save();
+		add_filter( 'ss_uploads_additional_directories', static function () {
+			return array();
+		} );
+		add_filter( 'simply_static_uploads_crawler_max_entries_per_batch', static function () {
+			return 2;
+		} );
+
+		$total_added = 0;
+		$complete    = false;
+		$progress    = array();
+		$history     = array();
+
+		try {
+			for ( $attempt = 0; $attempt < 20; $attempt++ ) {
+				$crawler      = new Uploads_Crawler();
+				$batch_added  = $crawler->add_urls_to_queue();
+				$total_added += $batch_added;
+				$complete     = $crawler->is_complete();
+				$progress     = $crawler->get_progress();
+				$history[]    = array(
+					'batch_added' => $batch_added,
+					'complete'    => $complete,
+					'progress'    => $progress,
+					'state'       => Options::instance()->get( 'uploads_crawler_state' ),
+				);
+				if ( $complete ) {
+					break;
+				}
+				self::assertIsArray( Options::instance()->get( 'uploads_crawler_state' ) );
+			}
+
+			self::assertTrue( $complete );
+			self::assertSame( 3, $total_added, wp_json_encode( $history ) );
+			self::assertSame( 3, $progress['added'] );
+			self::assertGreaterThan( 3, $progress['scanned'] );
+			self::assertNull( Options::instance()->get( 'uploads_crawler_state' ) );
+
+			$urls = array_column( array_column( $GLOBALS['wpdb']->inserts, 'data' ), 'url' );
+			sort( $urls );
+			self::assertSame(
+				array(
+					'https://example.test/wp-content/uploads/2026/deep/two.pdf',
+					'https://example.test/wp-content/uploads/2026/one.png',
+					'https://example.test/wp-content/uploads/photo.jpg',
+				),
+				$urls
+			);
+		} finally {
+			$this->remove_tree( $root );
+		}
 	}
 
 	public function test_private_backup_files_are_removed_before_upload_urls_are_built(): void {
@@ -52,5 +154,23 @@ final class UploadsCrawlerTest extends UnitTestCase {
 			@rmdir( dirname( $backup_dir ) );
 			@rmdir( $root );
 		}
+	}
+
+	private function remove_tree( string $root ): void {
+		if ( ! is_dir( $root ) ) {
+			return;
+		}
+		$iterator = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $root, \FilesystemIterator::SKIP_DOTS ),
+			\RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ( $iterator as $item ) {
+			if ( $item->isDir() && ! $item->isLink() ) {
+				@rmdir( $item->getPathname() );
+			} else {
+				@unlink( $item->getPathname() );
+			}
+		}
+		@rmdir( $root );
 	}
 }


### PR DESCRIPTION
## Summary

- checkpoint uploads-directory traversal and resume it across background worker requests
- bound each crawl invocation by entry count and elapsed time
- preserve cumulative URL and scan progress while keeping the current crawler active until complete
- validate persisted directory cursors and clear state after discovery

## Validation

- 380 PHPUnit tests passed with 4622 assertions
- changed PHP files pass syntax checks
- diff checks passed
