### PR TITLE
Resume large crawler discovery across requests

### DIFF
--- a/src/crawler/class-ss-archive-crawler.php
+++ b/src/crawler/class-ss-archive-crawler.php
@@ -42,6 +42,7 @@ class Archive_Crawler extends Crawler {
 	 */
 	public function detect() : array {
 		$archive_urls = [];
+		$max_archives = max( 1, min( 100000, (int) apply_filters( 'simply_static_archive_detection_limit', 1000 ) ) );
 
 		// Get yearly archives
 		$yearly_archives = wp_get_archives(
@@ -50,7 +51,8 @@ class Archive_Crawler extends Crawler {
 				'echo'   => 0,
 				'format' => 'custom',
 				'before' => '',
-				'after'  => '|'
+				'after'  => '|',
+				'limit'  => $max_archives,
 			]
 		);
 
@@ -61,7 +63,8 @@ class Archive_Crawler extends Crawler {
 				'echo'   => 0,
 				'format' => 'custom',
 				'before' => '',
-				'after'  => '|'
+				'after'  => '|',
+				'limit'  => $max_archives,
 			]
 		);
 
@@ -72,7 +75,8 @@ class Archive_Crawler extends Crawler {
 				'echo'   => 0,
 				'format' => 'custom',
 				'before' => '',
-				'after'  => '|'
+				'after'  => '|',
+				'limit'  => $max_archives,
 			]
 		);
 
@@ -87,5 +91,61 @@ class Archive_Crawler extends Crawler {
 		}
 
 		return $archive_urls;
+	}
+
+	/**
+	 * Build archive URLs from a bounded page of published post dates.
+	 *
+	 * @return int Number of URLs added by this invocation.
+	 */
+	public function add_urls_to_queue() : int {
+		global $wpdb;
+
+		$signature = hash( 'sha256', serialize( array(
+			'archive_start_time' => \Simply_Static\Options::instance()->get( 'archive_start_time' ),
+			'blog_id'            => get_current_blog_id(),
+		) ) );
+		$state = \Simply_Static\Options::instance()->get( 'archive_crawler_state' );
+		if ( ! is_array( $state ) || 1 !== ( $state['version'] ?? null ) || $signature !== ( $state['signature'] ?? null ) || ! is_int( $state['last_post_id'] ?? null ) || $state['last_post_id'] < 0 ) {
+			$state = array( 'version' => 1, 'signature' => $signature, 'last_post_id' => 0, 'added' => 0, 'scanned' => 0 );
+		}
+
+		$batch_size = max( 1, min( 500, (int) apply_filters( 'simply_static_archive_crawler_batch_size', 100 ) ) );
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT ID, post_date FROM {$wpdb->posts} WHERE post_type = 'post' AND post_status = 'publish' AND ID > %d ORDER BY ID ASC LIMIT %d",
+				$state['last_post_id'],
+				$batch_size
+			),
+			ARRAY_A
+		);
+		$rows = is_array( $rows ) ? $rows : array();
+		$urls = array();
+		foreach ( $rows as $row ) {
+			$state['last_post_id'] = max( $state['last_post_id'], (int) $row['ID'] );
+			$date = isset( $row['post_date'] ) ? (string) $row['post_date'] : '';
+			if ( ! preg_match( '/^(\d{4})-(\d{2})-(\d{2})/', $date, $parts ) ) {
+				continue;
+			}
+			$year  = (int) $parts[1];
+			$month = (int) $parts[2];
+			$day   = (int) $parts[3];
+			$urls[ get_year_link( $year ) ]               = get_year_link( $year );
+			$urls[ get_month_link( $year, $month ) ]       = get_month_link( $year, $month );
+			$urls[ get_day_link( $year, $month, $day ) ]   = get_day_link( $year, $month, $day );
+		}
+
+		$added             = $this->enqueue_urls( array_values( $urls ) );
+		$state['added']    += $added;
+		$state['scanned']  += count( $rows );
+		$this->progress     = array( 'added' => $state['added'], 'scanned' => $state['scanned'] );
+		$this->complete     = count( $rows ) < $batch_size;
+		if ( $this->complete ) {
+			$this->clear_crawler_state( 'archive_crawler_state' );
+		} else {
+			$this->save_crawler_state( 'archive_crawler_state', $state );
+		}
+
+		return $added;
 	}
 }

--- a/src/crawler/class-ss-author-crawler.php
+++ b/src/crawler/class-ss-author-crawler.php
@@ -35,7 +35,8 @@ class Author_Crawler extends Crawler {
 	 */
 	public function detect() : array {
 		$author_urls = [];
-		$users = get_users();
+		$max_users = max( 1, min( 100000, (int) apply_filters( 'simply_static_author_detection_limit', 1000 ) ) );
+		$users = get_users( array( 'number' => $max_users, 'orderby' => 'ID', 'order' => 'ASC' ) );
 
 		foreach ( $users as $author ) {
 			$author_link = get_author_posts_url( $author->ID );
@@ -49,5 +50,52 @@ class Author_Crawler extends Crawler {
 		}
 
 		return $author_urls;
+	}
+
+	/**
+	 * Traverse authors across bounded background requests.
+	 *
+	 * @return int Number of URLs added by this invocation.
+	 */
+	public function add_urls_to_queue() : int {
+		$signature = hash( 'sha256', serialize( array(
+			'archive_start_time' => \Simply_Static\Options::instance()->get( 'archive_start_time' ),
+			'blog_id'            => get_current_blog_id(),
+		) ) );
+		$state = \Simply_Static\Options::instance()->get( 'author_crawler_state' );
+		if ( ! is_array( $state ) || 1 !== ( $state['version'] ?? null ) || $signature !== ( $state['signature'] ?? null ) || ! is_int( $state['offset'] ?? null ) || $state['offset'] < 0 ) {
+			$state = array( 'version' => 1, 'signature' => $signature, 'offset' => 0, 'added' => 0, 'scanned' => 0 );
+		}
+
+		$batch_size = max( 1, min( 500, (int) apply_filters( 'simply_static_author_crawler_batch_size', 100 ) ) );
+		$user_ids   = get_users( array(
+			'fields'  => 'ID',
+			'number'  => $batch_size,
+			'offset'  => $state['offset'],
+			'orderby' => 'ID',
+			'order'   => 'ASC',
+		) );
+		$user_ids = is_array( $user_ids ) ? $user_ids : array();
+		$urls     = array();
+		foreach ( $user_ids as $user_id ) {
+			$url = get_author_posts_url( (int) $user_id );
+			if ( is_string( $url ) && '' !== trim( $url ) ) {
+				$urls[] = trim( $url );
+			}
+		}
+
+		$added            = $this->enqueue_urls( $urls );
+		$state['offset']  += count( $user_ids );
+		$state['scanned'] += count( $user_ids );
+		$state['added']   += $added;
+		$this->progress    = array( 'added' => $state['added'], 'scanned' => $state['scanned'] );
+		$this->complete    = count( $user_ids ) < $batch_size;
+		if ( $this->complete ) {
+			$this->clear_crawler_state( 'author_crawler_state' );
+		} else {
+			$this->save_crawler_state( 'author_crawler_state', $state );
+		}
+
+		return $added;
 	}
 }

--- a/src/crawler/class-ss-beaver-builder-crawler.php
+++ b/src/crawler/class-ss-beaver-builder-crawler.php
@@ -87,75 +87,17 @@ class Beaver_Builder_Crawler extends Crawler {
 			return 0;
 		}
 
-		$dir = trailingslashit( $uploads['basedir'] ) . 'bb-plugin/cache';
-		$base_url = trailingslashit( $uploads['baseurl'] ) . 'bb-plugin/cache';
-
-		if ( ! is_dir( $dir ) ) {
-			return 0;
-		}
-
-		$count    = 0;
-		$batch    = [];
-		$batch_sz = (int) apply_filters( 'simply_static_crawler_batch_size', 100 );
-
-		$extensions = [ 'css','js','png','jpg','jpeg','gif','svg','webp','woff','woff2','ttf','eot','otf','ico','mp4','webm','json','map' ];
-		$skip_dirs  = apply_filters( 'ss_skip_crawl_beaver_builder_directories', [ '.git','node_modules','vendor/bin','vendor/composer','tests' ] );
-
-		try {
-			$it = new \RecursiveIteratorIterator(
-				new \RecursiveDirectoryIterator( $dir, \RecursiveDirectoryIterator::SKIP_DOTS ),
-				\RecursiveIteratorIterator::SELF_FIRST
-			);
-			foreach ( $it as $file ) {
-				if ( $file->isDir() ) { continue; }
-				$rel = \Simply_Static\Util::safe_relative_path( $dir, $file->getPathname() );
-				$skip = false;
-				foreach ( (array) $skip_dirs as $sd ) {
-					if ( $sd && strpos( $rel, '/' . $sd . '/' ) !== false ) { $skip = true; break; }
-				}
-				if ( $skip ) { continue; }
-				$ext = strtolower( pathinfo( $rel, PATHINFO_EXTENSION ) );
-				if ( $ext && ! in_array( $ext, $extensions, true ) ) { continue; }
-				$batch[] = \Simply_Static\Util::safe_join_url( $base_url, $rel );
-				if ( count( $batch ) >= $batch_sz ) {
-					$count += $this->enqueue_urls_batch( $batch );
-					$batch = [];
-					usleep( 100000 );
-				}
-			}
-		} catch ( \Exception $e ) {
-			\Simply_Static\Util::debug_log( 'Error streaming Beaver Builder cache crawl: ' . $e->getMessage() );
-		}
-
-		if ( ! empty( $batch ) ) {
-			$count += $this->enqueue_urls_batch( $batch );
-		}
-
-		\Simply_Static\Util::debug_log( sprintf( 'Beaver Builder crawler added %d URLs (streamed)', $count ) );
-		return $count;
-	}
-
-	/**
-	 * Helper: enqueue a batch of URLs.
-	 *
-	 * @param array $urls
-	 * @return int
-	 */
-	protected function enqueue_urls_batch( array $urls ): int {
-		$added = 0;
-  foreach ( $urls as $url ) {
-			// Skip URLs that are excluded by settings/patterns
-			if ( \Simply_Static\Util::is_url_excluded( $url ) ) {
-				\Simply_Static\Util::debug_log( sprintf( 'Beaver Builder crawler skipping excluded URL: %s', $url ) );
-				continue;
-			}
-			$static_page = \Simply_Static\Page::query()->find_or_initialize_by( 'url', $url );
-			$static_page->set_status_message( __( 'Beaver Builder Cache', 'simply-static' ) );
-			$static_page->found_on_id = 0;
-			$static_page->save();
-			$added++;
-		}
-		return $added;
+		return $this->enqueue_directory_batch(
+			'beaver_builder_crawler_state',
+			array( array(
+				'basedir' => trailingslashit( $uploads['basedir'] ) . 'bb-plugin/cache',
+				'baseurl' => trailingslashit( $uploads['baseurl'] ) . 'bb-plugin/cache',
+			) ),
+			array( 'css', 'js', 'png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'woff', 'woff2', 'ttf', 'eot', 'otf', 'ico', 'mp4', 'webm', 'json', 'map' ),
+			(array) apply_filters( 'ss_skip_crawl_beaver_builder_directories', array( '.git', 'node_modules', 'vendor/bin', 'vendor/composer', 'tests' ) ),
+			'simply_static_beaver_builder_crawler_max_entries_per_batch',
+			'simply_static_beaver_builder_crawler_max_batch_seconds'
+		);
 	}
 
 	/**
@@ -167,6 +109,9 @@ class Beaver_Builder_Crawler extends Crawler {
 	 */
 	protected function scan_directory_for_assets( $dir_root, $url_base ) : array {
 		$urls = [];
+		$max_entries = max( 1, min( 100000, (int) apply_filters( 'simply_static_beaver_builder_detection_max_entries', 5000 ) ) );
+		$deadline    = microtime( true ) + max( 0.5, min( 15, (float) apply_filters( 'simply_static_beaver_builder_detection_max_seconds', 5 ) ) );
+		$scanned     = 0;
 		$extensions = [ 'css','js','png','jpg','jpeg','gif','svg','webp','woff','woff2','ttf','eot','otf','ico','mp4','webm','json','map' ];
 		$skip_dirs  = apply_filters( 'ss_skip_crawl_beaver_builder_directories', [ '.git','node_modules','vendor/bin','vendor/composer','tests' ] );
 
@@ -176,6 +121,10 @@ class Beaver_Builder_Crawler extends Crawler {
 				\RecursiveIteratorIterator::SELF_FIRST
 			);
 			foreach ( $it as $file ) {
+				$scanned++;
+				if ( $scanned > $max_entries || microtime( true ) >= $deadline ) {
+					break;
+				}
 				if ( $file->isDir() ) { continue; }
 				$rel = \Simply_Static\Util::safe_relative_path( $dir_root, $file->getPathname() );
 				$skip = false;

--- a/src/crawler/class-ss-config-files-crawler.php
+++ b/src/crawler/class-ss-config-files-crawler.php
@@ -63,20 +63,21 @@ class Config_Files_Crawler extends Crawler {
 			return $config_urls;
 		}
 
-		// Get all JSON and HTML files in the directory
-		$json_files = glob( $configs_dir . '*.json' );
-		$html_files = glob( $configs_dir . '*.html' );
-		$files = array_merge( $json_files ?: [], $html_files ?: [] );
-
-		foreach ( $files as $file ) {
-			// Get the filename
-			$filename = basename( $file );
-
-			// Create the URL
-			$url = $configs_url . $filename;
-
-			// Add to the list of URLs
-			$config_urls[] = $url;
+		$max_files = max( 1, min( 10000, (int) apply_filters( 'simply_static_config_files_max_files', 1000 ) ) );
+		try {
+			$files = new \FilesystemIterator( $configs_dir, \FilesystemIterator::SKIP_DOTS );
+			foreach ( $files as $file ) {
+				if ( count( $config_urls ) >= $max_files ) {
+					\Simply_Static\Util::debug_log( sprintf( 'Config files crawler stopped at its %d-file safety limit.', $max_files ) );
+					break;
+				}
+				if ( ! $file->isFile() || $file->isLink() || ! in_array( strtolower( $file->getExtension() ), array( 'json', 'html' ), true ) ) {
+					continue;
+				}
+				$config_urls[] = $configs_url . $file->getFilename();
+			}
+		} catch ( \UnexpectedValueException $exception ) {
+			\Simply_Static\Util::debug_log( 'Config files crawler could not read its directory: ' . $exception->getMessage() );
 		}
 
 		return $config_urls;

--- a/src/crawler/class-ss-crawler.php
+++ b/src/crawler/class-ss-crawler.php
@@ -41,6 +41,12 @@ abstract class Crawler {
 	 */
 	protected $active_by_default = true;
 
+	/** @var bool */
+	protected $complete = true;
+
+	/** @var array<string,int> */
+	protected $progress = array();
+
 	/**
 	 * Whether the crawler's external dependency is active (e.g., plugin/theme).
 	 * Crawler implementations can override this.
@@ -91,7 +97,7 @@ abstract class Crawler {
 	 * @return bool
 	 */
 	public function is_complete() : bool {
-		return true;
+		return $this->complete;
 	}
 
 	/**
@@ -100,7 +106,7 @@ abstract class Crawler {
 	 * @return array<string,int>
 	 */
 	public function get_progress() : array {
-		return array();
+		return $this->progress;
 	}
 
 	/**
@@ -109,9 +115,19 @@ abstract class Crawler {
 	 * @return int Number of URLs added
 	 */
 	public function add_urls_to_queue() : int {
-		$urls = $this->detect();
+		return $this->enqueue_urls( $this->detect() );
+	}
+
+	/**
+	 * Add one set of URLs to the page queue.
+	 *
+	 * @param array $urls URLs to enqueue.
+	 *
+	 * @return int Number of URLs handled.
+	 */
+	protected function enqueue_urls( array $urls ) : int {
 		$count = 0;
-		$batch_size = apply_filters( 'simply_static_crawler_batch_size', 100 );
+		$batch_size = max( 1, min( 1000, (int) apply_filters( 'simply_static_crawler_batch_size', 100 ) ) );
 
 		// Determine excluded URL if a custom 404 page is selected
 		$opts = \Simply_Static\Options::instance();
@@ -180,6 +196,296 @@ abstract class Crawler {
 		}
 
 		return $count;
+	}
+
+	/**
+	 * Traverse one bounded batch from a set of directory roots.
+	 *
+	 * The state stores relative directory names and entry offsets rather than
+	 * serializing iterator objects or absolute file names. This keeps the option
+	 * small and lets a background request resume without trusting stale paths.
+	 *
+	 * @param string $state_option       Option used for the crawler checkpoint.
+	 * @param array  $scan_directories   Directory roots with basedir/baseurl keys.
+	 * @param array  $extensions         Allowed lowercase file extensions.
+	 * @param array  $skip_directories   Directory names or relative paths to skip.
+	 * @param string $entry_limit_filter Filter controlling entries per request.
+	 * @param string $time_limit_filter  Filter controlling seconds per request.
+	 *
+	 * @return int URLs added by this invocation.
+	 */
+	protected function enqueue_directory_batch( $state_option, array $scan_directories, array $extensions, array $skip_directories, $entry_limit_filter, $time_limit_filter ) : int {
+		if ( ! is_string( $state_option ) || 1 !== preg_match( '/^[a-z0-9_]+$/D', $state_option ) ) {
+			throw new \InvalidArgumentException( 'A safe directory crawler state option is required.' );
+		}
+
+		$scan_directories = $this->normalize_scan_directories( $scan_directories );
+		$extensions       = array_values( array_unique( array_filter( array_map( static function ( $extension ) {
+			return is_string( $extension ) ? strtolower( ltrim( trim( $extension ), '.' ) ) : '';
+		}, $extensions ) ) ) );
+		$skip_directories = array_values( array_filter( array_map( static function ( $directory ) {
+			return is_string( $directory ) ? trim( str_replace( '\\', '/', $directory ), '/' ) : '';
+		}, $skip_directories ) ) );
+
+		$this->complete = true;
+		$signature      = hash( 'sha256', serialize( array(
+			'archive_start_time' => \Simply_Static\Options::instance()->get( 'archive_start_time' ),
+			'scan_directories'   => $scan_directories,
+			'extensions'         => $extensions,
+			'skip_directories'   => $skip_directories,
+		) ) );
+		$state          = $this->load_directory_crawler_state( $state_option, $signature );
+		$queue_batch    = max( 1, min( 1000, (int) apply_filters( 'simply_static_crawler_batch_size', 100 ) ) );
+		$entry_limit    = max( 1, min( 10000, (int) apply_filters( $entry_limit_filter, 500 ) ) );
+		$seconds        = (float) apply_filters( $time_limit_filter, 10 );
+		$deadline       = microtime( true ) + max( 0.5, min( 15, $seconds ) );
+		$processed      = 0;
+		$added_now      = 0;
+		$buffer         = array();
+
+		while ( $state['scan_index'] < count( $scan_directories ) ) {
+			$scan = $scan_directories[ $state['scan_index'] ];
+			if ( null === $state['current_dir'] ) {
+				if ( empty( $state['pending_dirs'] ) ) {
+					$state['scan_index']++;
+					if ( $state['scan_index'] < count( $scan_directories ) ) {
+						$state['pending_dirs'] = array( '' );
+					}
+					continue;
+				}
+				$state['current_dir']  = array_pop( $state['pending_dirs'] );
+				$state['entry_offset'] = 0;
+			}
+
+			$directory = $this->resolve_crawler_directory( $scan['basedir'], $state['current_dir'] );
+			if ( false === $directory ) {
+				\Simply_Static\Util::debug_log( sprintf( '%s crawler skipped a missing or unsafe directory cursor.', $this->name ) );
+				$state['current_dir']  = null;
+				$state['entry_offset'] = 0;
+				continue;
+			}
+
+			try {
+				$iterator = $this->get_crawler_directory_iterator( $directory );
+				if ( $state['entry_offset'] > 0 ) {
+					$iterator->seek( $state['entry_offset'] );
+				}
+			} catch ( \UnexpectedValueException $exception ) {
+				\Simply_Static\Util::debug_log( sprintf( '%s crawler could not read directory: %s', $this->name, $exception->getMessage() ) );
+				$state['current_dir']  = null;
+				$state['entry_offset'] = 0;
+				continue;
+			} catch ( \OutOfBoundsException $exception ) {
+				$state['current_dir']  = null;
+				$state['entry_offset'] = 0;
+				continue;
+			}
+
+			while ( $iterator->valid() ) {
+				$file = $iterator->current();
+				$state['entry_offset']++;
+				$state['scanned']++;
+				$processed++;
+
+				if ( $file instanceof \SplFileInfo && ! $file->isLink() ) {
+					$relative_path = ltrim( \Simply_Static\Util::safe_relative_path( $scan['basedir'], $file->getPathname() ), '/' );
+					if ( $file->isDir() ) {
+						if ( ! $this->should_skip_crawler_path( $relative_path, $skip_directories ) ) {
+							if ( count( $state['pending_dirs'] ) >= 50000 ) {
+								throw new \RuntimeException( sprintf( '%s crawler directory queue exceeded its safety limit.', $this->name ) );
+							}
+							$state['pending_dirs'][] = $relative_path;
+						}
+					} elseif ( $file->isFile() && ! $this->should_skip_crawler_path( $relative_path, $skip_directories ) ) {
+						$extension = strtolower( pathinfo( $relative_path, PATHINFO_EXTENSION ) );
+						if ( 'php' !== $extension && ( empty( $extensions ) || in_array( $extension, $extensions, true ) ) ) {
+							$buffer[] = \Simply_Static\Util::safe_join_url( $scan['baseurl'], $relative_path );
+							if ( count( $buffer ) >= $queue_batch ) {
+								$added          = $this->enqueue_urls( $buffer );
+								$added_now     += $added;
+								$state['added'] += $added;
+								$buffer          = array();
+							}
+						}
+					}
+				}
+				$iterator->next();
+
+				if ( $processed >= $entry_limit || microtime( true ) >= $deadline ) {
+					break;
+				}
+			}
+
+			if ( ! empty( $buffer ) ) {
+				$added          = $this->enqueue_urls( $buffer );
+				$added_now     += $added;
+				$state['added'] += $added;
+				$buffer          = array();
+			}
+
+			if ( $iterator->valid() ) {
+				return $this->checkpoint_directory_crawler( $state_option, $state, $added_now );
+			}
+
+			$state['current_dir']  = null;
+			$state['entry_offset'] = 0;
+			if ( $processed >= $entry_limit || microtime( true ) >= $deadline ) {
+				return $this->checkpoint_directory_crawler( $state_option, $state, $added_now );
+			}
+		}
+
+		$this->progress = array(
+			'added'   => $state['added'],
+			'scanned' => $state['scanned'],
+		);
+		$this->clear_crawler_state( $state_option );
+		\Simply_Static\Util::debug_log( sprintf( '%s crawler added %d URLs across resumable batches.', $this->name, $state['added'] ) );
+
+		return $added_now;
+	}
+
+	/** @return array<int,array{basedir:string,baseurl:string}> */
+	private function normalize_scan_directories( array $scan_directories ) : array {
+		$normalized = array();
+		$seen       = array();
+		foreach ( $scan_directories as $candidate ) {
+			if ( ! is_array( $candidate ) || ! isset( $candidate['basedir'], $candidate['baseurl'] ) || ! is_string( $candidate['basedir'] ) || ! is_string( $candidate['baseurl'] ) || ! is_dir( $candidate['basedir'] ) ) {
+				continue;
+			}
+			$canonical = realpath( $candidate['basedir'] );
+			if ( false === $canonical ) {
+				continue;
+			}
+			$key = $canonical . "\0" . rtrim( $candidate['baseurl'], '/' );
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+			$seen[ $key ] = true;
+			$normalized[] = array(
+				'basedir' => $canonical,
+				'baseurl' => rtrim( $candidate['baseurl'], '/' ),
+			);
+		}
+
+		return $normalized;
+	}
+
+	protected function get_crawler_directory_iterator( $directory ) : \FilesystemIterator {
+		return new \FilesystemIterator( $directory, \FilesystemIterator::SKIP_DOTS );
+	}
+
+	/** @param string[] $skip_directories */
+	private function should_skip_crawler_path( $relative_path, array $skip_directories ) : bool {
+		$path = trim( str_replace( '\\', '/', (string) $relative_path ), '/' );
+		if ( \Simply_Static\Util::is_private_backup_path( $path ) ) {
+			return true;
+		}
+		foreach ( $skip_directories as $skip_directory ) {
+			if ( $path === $skip_directory || 0 === strpos( $path, $skip_directory . '/' ) || false !== strpos( '/' . $path . '/', '/' . $skip_directory . '/' ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/** @return string|false */
+	private function resolve_crawler_directory( $base_directory, $relative_directory ) {
+		if ( ! is_string( $relative_directory ) || ! $this->is_safe_crawler_directory( $relative_directory ) ) {
+			return false;
+		}
+		$root      = realpath( $base_directory );
+		$candidate = realpath( rtrim( $base_directory, '/\\' ) . ( '' === $relative_directory ? '' : '/' . $relative_directory ) );
+		if ( false === $root || false === $candidate || ! is_dir( $candidate ) ) {
+			return false;
+		}
+		$root = rtrim( str_replace( '\\', '/', $root ), '/' );
+		$path = str_replace( '\\', '/', $candidate );
+
+		return $path === $root || 0 === strpos( $path, $root . '/' ) ? $candidate : false;
+	}
+
+	private function is_safe_crawler_directory( $path ) : bool {
+		if ( ! is_string( $path ) || false !== strpos( $path, "\0" ) || 0 === strpos( str_replace( '\\', '/', $path ), '/' ) ) {
+			return false;
+		}
+		foreach ( explode( '/', str_replace( '\\', '/', $path ) ) as $segment ) {
+			if ( '.' === $segment || '..' === $segment ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/** @return array<string,mixed> */
+	private function load_directory_crawler_state( $state_option, $signature ) : array {
+		$state = \Simply_Static\Options::instance()->get( $state_option );
+		if ( ! is_array( $state ) || 1 !== ( $state['version'] ?? null ) || $signature !== ( $state['signature'] ?? null ) ) {
+			return $this->new_directory_crawler_state( $signature );
+		}
+		if ( ! isset( $state['scan_index'], $state['entry_offset'], $state['pending_dirs'], $state['added'], $state['scanned'] ) || ! is_array( $state['pending_dirs'] ) ) {
+			return $this->new_directory_crawler_state( $signature );
+		}
+		if ( count( $state['pending_dirs'] ) > 50000 || ! is_int( $state['scan_index'] ) || $state['scan_index'] < 0 || ! is_int( $state['entry_offset'] ) || $state['entry_offset'] < 0 ) {
+			return $this->new_directory_crawler_state( $signature );
+		}
+		if ( ! is_int( $state['added'] ) || $state['added'] < 0 || ! is_int( $state['scanned'] ) || $state['scanned'] < 0 ) {
+			return $this->new_directory_crawler_state( $signature );
+		}
+		$current_directory = $state['current_dir'] ?? null;
+		if ( null !== $current_directory && ! $this->is_safe_crawler_directory( $current_directory ) ) {
+			return $this->new_directory_crawler_state( $signature );
+		}
+		foreach ( $state['pending_dirs'] as $directory ) {
+			if ( ! $this->is_safe_crawler_directory( $directory ) ) {
+				return $this->new_directory_crawler_state( $signature );
+			}
+		}
+
+		return $state;
+	}
+
+	/** @return array<string,mixed> */
+	private function new_directory_crawler_state( $signature ) : array {
+		return array(
+			'version'      => 1,
+			'signature'    => $signature,
+			'scan_index'   => 0,
+			'current_dir'  => null,
+			'entry_offset' => 0,
+			'pending_dirs' => array( '' ),
+			'added'        => 0,
+			'scanned'      => 0,
+		);
+	}
+
+	/** @param array<string,mixed> $state */
+	private function checkpoint_directory_crawler( $state_option, array $state, $added_now ) : int {
+		$this->complete = false;
+		$this->progress = array(
+			'added'   => $state['added'],
+			'scanned' => $state['scanned'],
+		);
+		$this->save_crawler_state( $state_option, $state );
+		\Simply_Static\Util::debug_log( sprintf( '%s crawler checkpointed after %d entries with %d URLs queued.', $this->name, $state['scanned'], $state['added'] ) );
+
+		return (int) $added_now;
+	}
+
+	/** @param array<string,mixed> $state */
+	protected function save_crawler_state( $state_option, array $state ) : void {
+		if ( ! \Simply_Static\Options::instance()->set( $state_option, $state )->save() ) {
+			throw new \RuntimeException( sprintf( 'Unable to save the %s crawler checkpoint.', $this->name ) );
+		}
+	}
+
+	protected function clear_crawler_state( $state_option ) : void {
+		$options = \Simply_Static\Options::instance();
+		$options->destroy( $state_option );
+		if ( ! $options->save() ) {
+			throw new \RuntimeException( sprintf( 'Unable to clear the %s crawler checkpoint.', $this->name ) );
+		}
 	}
 
 	/**

--- a/src/crawler/class-ss-divi-crawler.php
+++ b/src/crawler/class-ss-divi-crawler.php
@@ -139,83 +139,17 @@ class Divi_Crawler extends Crawler {
 	 * @return int Number of URLs added
 	 */
 	public function add_urls_to_queue(): int {
-		$count     = 0;
-		$batch     = [];
-		$batch_sz  = (int) apply_filters( 'simply_static_crawler_batch_size', 100 );
-
-		$site_url = site_url();
-		$wp_path  = ABSPATH;
-
-		$targets = [
-			'/wp-content/et-cache'   => $wp_path . 'wp-content/et-cache',
-			'/wp-content/themes/Divi' => $wp_path . 'wp-content/themes/Divi',
-		];
-
-		$extensions = [ 'css','js','png','jpg','jpeg','gif','svg','webp','woff','woff2','ttf','eot','otf','ico','mp4','webm' ];
-		$skip_dirs  = apply_filters( 'ss_skip_crawl_divi_directories', [ '.git','node_modules','vendor/bin','vendor/composer','tests' ] );
-
-		foreach ( $targets as $url_base => $dir_root ) {
-			if ( ! is_dir( $dir_root ) ) {
-				\Simply_Static\Util::debug_log( "Directory does not exist: $dir_root" );
-				continue;
-			}
-			try {
-				$it = new \RecursiveIteratorIterator(
-					new \RecursiveDirectoryIterator( $dir_root, \RecursiveDirectoryIterator::SKIP_DOTS ),
-					\RecursiveIteratorIterator::SELF_FIRST
-				);
-				foreach ( $it as $file ) {
-					if ( $file->isDir() ) { continue; }
-					$rel = \Simply_Static\Util::safe_relative_path( $dir_root, $file->getPathname() );
-					$skip = false;
-					foreach ( (array) $skip_dirs as $sd ) {
-						if ( $sd && strpos( $rel, '/' . $sd . '/' ) !== false ) { $skip = true; break; }
-					}
-					if ( $skip ) { continue; }
-					$ext = strtolower( pathinfo( $rel, PATHINFO_EXTENSION ) );
-					if ( $ext && ! in_array( $ext, $extensions, true ) ) { continue; }
-					$batch[] = \Simply_Static\Util::safe_join_url( $site_url . $url_base, $rel );
-					if ( count( $batch ) >= $batch_sz ) {
-						$count += $this->enqueue_urls_batch( $batch );
-						$batch = [];
-						usleep( 100000 );
-					}
-				}
-			} catch ( \Exception $e ) {
-				\Simply_Static\Util::debug_log( 'Error streaming Divi directory crawl: ' . $e->getMessage() );
-			}
-		}
-
-		if ( ! empty( $batch ) ) {
-			$count += $this->enqueue_urls_batch( $batch );
-		}
-
-		\Simply_Static\Util::debug_log( sprintf( 'Divi crawler added %d URLs (streamed)', $count ) );
-		return $count;
-	}
-
-	/**
-	 * Enqueue a batch of URLs and return how many were added.
-	 *
-	 * @param array $urls
-	 * @return int
-	 */
-	private function enqueue_urls_batch( array $urls ): int {
-		$added = 0;
-		\Simply_Static\Util::debug_log( sprintf( 'Processing batch of %d URLs for %s crawler', count( $urls ), $this->name ) );
-  foreach ( $urls as $url ) {
-  			// Skip URLs that are excluded by settings/patterns
-  			if ( \Simply_Static\Util::is_url_excluded( $url ) ) {
-  				\Simply_Static\Util::debug_log( sprintf( 'Divi crawler skipping excluded URL: %s', $url ) );
-  				continue;
-  			}
-			$static_page = \Simply_Static\Page::query()->find_or_initialize_by( 'url', $url );
-			$static_page->set_status_message( sprintf( __( 'Added by %s Crawler', 'simply-static' ), $this->name ) );
-			$static_page->found_on_id = 0;
-			$static_page->save();
-			$added++;
-		}
-		return $added;
+		return $this->enqueue_directory_batch(
+			'divi_crawler_state',
+			array(
+				array( 'basedir' => ABSPATH . 'wp-content/et-cache', 'baseurl' => site_url( '/wp-content/et-cache' ) ),
+				array( 'basedir' => ABSPATH . 'wp-content/themes/Divi', 'baseurl' => site_url( '/wp-content/themes/Divi' ) ),
+			),
+			array( 'css', 'js', 'png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'woff', 'woff2', 'ttf', 'eot', 'otf', 'ico', 'mp4', 'webm' ),
+			(array) apply_filters( 'ss_skip_crawl_divi_directories', array( '.git', 'node_modules', 'vendor/bin', 'vendor/composer', 'tests' ) ),
+			'simply_static_divi_crawler_max_entries_per_batch',
+			'simply_static_divi_crawler_max_batch_seconds'
+		);
 	}
 
 	/**
@@ -228,6 +162,9 @@ class Divi_Crawler extends Crawler {
 	 */
 	private function scan_directory_for_assets( $dir, $url_base ): array {
 		$urls = [];
+		$max_entries = max( 1, min( 100000, (int) apply_filters( 'simply_static_divi_detection_max_entries', 5000 ) ) );
+		$deadline    = microtime( true ) + max( 0.5, min( 15, (float) apply_filters( 'simply_static_divi_detection_max_seconds', 5 ) ) );
+		$scanned     = 0;
 
 		$asset_extensions = [
 			'css','js','png','jpg','jpeg','gif','svg','webp','woff','woff2','ttf','eot','otf','ico','mp4','webm'
@@ -246,6 +183,10 @@ class Divi_Crawler extends Crawler {
 				\RecursiveIteratorIterator::SELF_FIRST
 			);
 			foreach ( $iterator as $file ) {
+				$scanned++;
+				if ( $scanned > $max_entries || microtime( true ) >= $deadline ) {
+					break;
+				}
 				if ( $file->isDir() ) { continue; }
 				$relative_path = \Simply_Static\Util::safe_relative_path( $dir, $file->getPathname() );
 				$skip = false;

--- a/src/crawler/class-ss-elementor-crawler.php
+++ b/src/crawler/class-ss-elementor-crawler.php
@@ -36,105 +36,178 @@ class Elementor_Crawler extends Crawler {
 	 * @return int Number of URLs added
 	 */
 	public function add_urls_to_queue(): int {
-		$count     = 0;
-		$batch     = [];
-		$batch_sz  = (int) apply_filters( 'simply_static_crawler_batch_size', 100 );
+		$signature = hash( 'sha256', serialize( array(
+			'archive_start_time' => \Simply_Static\Options::instance()->get( 'archive_start_time' ),
+			'site_url'           => site_url(),
+			'elementor_version'  => defined( 'ELEMENTOR_VERSION' ) ? ELEMENTOR_VERSION : '',
+		) ) );
+		$state     = $this->load_elementor_state( $signature );
+		$added_now = 0;
 
-		$site_url = site_url();
-		$wp_path  = ABSPATH;
-
-		$directories = [
-			// Elementor uploads directory (recursive scan covers /css subdirectory)
-			'/wp-content/uploads/elementor'        => $wp_path . 'wp-content/uploads/elementor',
-			// Elementor plugin assets (recursive scan covers js/, css/, lib/ subdirectories)
-			'/wp-content/plugins/elementor/assets' => $wp_path . 'wp-content/plugins/elementor/assets',
-			// Core jQuery (Elementor relies on this)
-			'/wp-includes/js/jquery'               => $wp_path . 'wp-includes/js/jquery',
-		];
-
-		// Stream files from the directories
-		foreach ( $directories as $url_path => $dir_path ) {
-			if ( ! is_dir( $dir_path ) ) {
-				\Simply_Static\Util::debug_log( "Directory does not exist: $dir_path" );
-				continue;
+		if ( 'directories' === $state['stage'] ) {
+			$added_now += $this->enqueue_directory_batch(
+				'elementor_directory_crawler_state',
+				$this->get_elementor_scan_directories(),
+				array(),
+				(array) apply_filters( 'ss_skip_crawl_elementor_directories', array( '.git', 'node_modules', 'cache', 'tmp', 'temp' ) ),
+				'simply_static_elementor_crawler_max_entries_per_batch',
+				'simply_static_elementor_crawler_max_batch_seconds'
+			);
+			if ( ! $this->is_complete() ) {
+				return $added_now;
 			}
-			try {
-				$it = new \RecursiveIteratorIterator(
-					new \RecursiveDirectoryIterator( $dir_path, \RecursiveDirectoryIterator::SKIP_DOTS ),
-					\RecursiveIteratorIterator::SELF_FIRST
-				);
- 			foreach ( $it as $file ) {
- 				if ( $file->isDir() ) { continue; }
- 				// Skip PHP files — they are never served as static assets
- 				if ( strtolower( $file->getExtension() ) === 'php' ) { continue; }
- 				// Build a safe relative path from the directory prefix
- 				$rel = \Simply_Static\Util::safe_relative_path( $dir_path, $file->getPathname() );
- 				$batch[] = \Simply_Static\Util::safe_join_url( $site_url . $url_path, $rel );
-					if ( count( $batch ) >= $batch_sz ) {
-						$count += $this->enqueue_urls_batch( $batch );
-						$batch = [];
-						usleep( 100000 );
-					}
-				}
-			} catch ( \Exception $e ) {
-				\Simply_Static\Util::debug_log( 'Error streaming Elementor directory crawl: ' . $e->getMessage() );
-			}
+
+			$directory_progress = $this->get_progress();
+			$state['stage']      = 'lottie';
+			$state['added']      = (int) ( $directory_progress['added'] ?? 0 );
+			$state['scanned']    = (int) ( $directory_progress['scanned'] ?? 0 );
+			$this->save_crawler_state( 'elementor_crawler_state', $state );
 		}
 
-		// Add specific imagesloaded.min.js
-		$batch[] = $site_url . '/wp-includes/js/imagesloaded.min.js';
-		if ( count( $batch ) >= $batch_sz ) {
-			$count += $this->enqueue_urls_batch( $batch );
-			$batch = [];
+		if ( empty( $state['imagesloaded_added'] ) ) {
+			$added                        = $this->enqueue_urls( array( site_url( '/wp-includes/js/imagesloaded.min.js' ) ) );
+			$added_now                   += $added;
+			$state['added']               += $added;
+			$state['imagesloaded_added'] = true;
+			$this->save_crawler_state( 'elementor_crawler_state', $state );
 		}
 
-		// Stream Lottie URLs if Elementor Pro is active.
-		if ( $this->is_elementor_pro_active() ) {
-			foreach ( $this->detect_lottie_files() as $lottie_url ) {
-				$batch[] = $lottie_url;
-
-				if ( count( $batch ) >= $batch_sz ) {
-					$count += $this->enqueue_urls_batch( $batch );
-					$batch = [];
-					usleep( 100000 );
-				}
-			}
+		if ( ! $this->is_elementor_pro_active() ) {
+			$this->finish_elementor_crawl( $state );
+			return $added_now;
 		}
 
-		// Flush remaining
-		if ( ! empty( $batch ) ) {
-			$count += $this->enqueue_urls_batch( $batch );
+		$added_now += $this->enqueue_lottie_batch( $state );
+		if ( $this->is_complete() ) {
+			$this->finish_elementor_crawl( $state );
+		} else {
+			$this->save_crawler_state( 'elementor_crawler_state', $state );
 		}
 
-		\Simply_Static\Util::debug_log( sprintf( 'Elementor crawler added %d URLs (streamed)', $count ) );
-		return $count;
+		return $added_now;
+	}
+
+	/** @return array<int,array{basedir:string,baseurl:string}> */
+	protected function get_elementor_scan_directories() : array {
+		return array(
+			array(
+				'basedir' => ABSPATH . 'wp-content/uploads/elementor',
+				'baseurl' => site_url( '/wp-content/uploads/elementor' ),
+			),
+			array(
+				'basedir' => ABSPATH . 'wp-content/plugins/elementor/assets',
+				'baseurl' => site_url( '/wp-content/plugins/elementor/assets' ),
+			),
+			array(
+				'basedir' => ABSPATH . 'wp-includes/js/jquery',
+				'baseurl' => site_url( '/wp-includes/js/jquery' ),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private function load_elementor_state( $signature ) : array {
+		$state = \Simply_Static\Options::instance()->get( 'elementor_crawler_state' );
+		if ( ! is_array( $state )
+			|| 1 !== ( $state['version'] ?? null )
+			|| $signature !== ( $state['signature'] ?? null )
+			|| ! in_array( $state['stage'] ?? null, array( 'directories', 'lottie' ), true )
+			|| ! is_int( $state['last_meta_id'] ?? null )
+			|| $state['last_meta_id'] < 0
+			|| ! is_int( $state['added'] ?? null )
+			|| $state['added'] < 0
+			|| ! is_int( $state['scanned'] ?? null )
+			|| $state['scanned'] < 0
+		) {
+			return array(
+				'version'            => 1,
+				'signature'          => $signature,
+				'stage'              => 'directories',
+				'last_meta_id'       => 0,
+				'imagesloaded_added' => false,
+				'added'              => 0,
+				'scanned'            => 0,
+			);
+		}
+
+		return $state;
 	}
 
 	/**
-	 * Enqueue a batch of URLs and return how many were added.
+	 * Process a bounded set of Elementor JSON rows for Lottie URLs.
 	 *
-	 * @param array $urls
-	 * @return int
+	 * @param array<string,mixed> $state Mutable crawler state.
+	 *
+	 * @return int URLs added by this invocation.
 	 */
-	private function enqueue_urls_batch( array $urls ): int {
+	private function enqueue_lottie_batch( array &$state ) : int {
 		global $wpdb;
-		$count = 0;
-		\Simply_Static\Util::debug_log( sprintf( 'Processing batch of %d URLs for %s crawler', count( $urls ), $this->name ) );
-		foreach ( $urls as $url ) {
-			// Skip URLs that are excluded by settings/patterns
-			if ( \Simply_Static\Util::is_url_excluded( $url ) ) {
-				\Simply_Static\Util::debug_log( sprintf( 'Elementor crawler skipping excluded URL: %s', $url ) );
-				continue;
+
+		$this->complete = false;
+		$batch_size     = max( 1, min( 50, (int) apply_filters( 'simply_static_elementor_meta_batch_size', 5 ) ) );
+		$row_limit      = max( 1024, min( 10 * 1024 * 1024, (int) apply_filters( 'simply_static_elementor_meta_max_bytes', 5 * 1024 * 1024 ) ) );
+		$entry_limit    = max( $batch_size, min( 1000, (int) apply_filters( 'simply_static_elementor_meta_max_entries_per_batch', 50 ) ) );
+		$seconds        = (float) apply_filters( 'simply_static_elementor_meta_max_batch_seconds', 10 );
+		$deadline       = microtime( true ) + max( 0.5, min( 15, $seconds ) );
+		$processed      = 0;
+		$added_now      = 0;
+
+		do {
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT meta_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_elementor_data' AND meta_id > %d AND OCTET_LENGTH(meta_value) <= %d ORDER BY meta_id ASC LIMIT %d",
+					$state['last_meta_id'],
+					$row_limit,
+					$batch_size
+				),
+				ARRAY_A
+			);
+
+			if ( ! is_array( $rows ) || empty( $rows ) ) {
+				$this->complete = true;
+				break;
 			}
-			$static_page = \Simply_Static\Page::query()->find_or_initialize_by( 'url', $url );
-			$static_page->set_status_message( sprintf( __( 'Added by %s Crawler', 'simply-static' ), $this->name ) );
-			$static_page->found_on_id = 0;
-			$static_page->save();
-			$count++;
-		}
-		// Free wpdb cached query results to prevent memory accumulation across batches
-		$wpdb->flush();
-		return $count;
+
+			foreach ( $rows as $row ) {
+				if ( ! is_array( $row ) || ! isset( $row['meta_id'] ) ) {
+					continue;
+				}
+				$state['last_meta_id'] = max( $state['last_meta_id'], (int) $row['meta_id'] );
+				$state['scanned']++;
+				$processed++;
+				$urls            = $this->extract_lottie_urls_from_json( $row['meta_value'] ?? '' );
+				$added           = empty( $urls ) ? 0 : $this->enqueue_urls( $urls );
+				$added_now      += $added;
+				$state['added'] += $added;
+			}
+
+			if ( method_exists( $wpdb, 'flush' ) ) {
+				$wpdb->flush();
+			}
+
+			if ( count( $rows ) < $batch_size ) {
+				$this->complete = true;
+				break;
+			}
+		} while ( $processed < $entry_limit && microtime( true ) < $deadline );
+
+		$this->progress = array(
+			'added'   => $state['added'],
+			'scanned' => $state['scanned'],
+		);
+
+		return $added_now;
+	}
+
+	/** @param array<string,mixed> $state */
+	private function finish_elementor_crawl( array $state ) : void {
+		$this->complete = true;
+		$this->progress = array(
+			'added'   => $state['added'],
+			'scanned' => $state['scanned'],
+		);
+		$this->clear_crawler_state( 'elementor_crawler_state' );
+		\Simply_Static\Util::debug_log( sprintf( 'Elementor crawler added %d URLs across resumable batches.', $state['added'] ) );
 	}
 
 	/**
@@ -223,15 +296,21 @@ class Elementor_Crawler extends Crawler {
 		global $wpdb;
 		$lottie_urls = array();
 		$last_meta_id = 0;
-		$batch_size = (int) apply_filters( 'simply_static_elementor_meta_batch_size', 100 );
-		$batch_size = max( 1, min( 1000, $batch_size ) );
+		$batch_size = max( 1, min( 50, (int) apply_filters( 'simply_static_elementor_meta_batch_size', 5 ) ) );
+		$row_limit   = max( 1024, min( 10 * 1024 * 1024, (int) apply_filters( 'simply_static_elementor_meta_max_bytes', 5 * 1024 * 1024 ) ) );
+		$max_entries = max( 1, min( 10000, (int) apply_filters( 'simply_static_elementor_meta_detection_limit', 500 ) ) );
+		$seconds     = (float) apply_filters( 'simply_static_elementor_meta_detection_seconds', 10 );
+		$deadline    = microtime( true ) + max( 0.5, min( 15, $seconds ) );
+		$processed   = 0;
 
 		do {
+			$query_limit = min( $batch_size, $max_entries - $processed );
 			$rows = $wpdb->get_results(
 				$wpdb->prepare(
-					"SELECT meta_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_elementor_data' AND meta_id > %d ORDER BY meta_id ASC LIMIT %d",
+					"SELECT meta_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_elementor_data' AND meta_id > %d AND OCTET_LENGTH(meta_value) <= %d ORDER BY meta_id ASC LIMIT %d",
 					$last_meta_id,
-					$batch_size
+					$row_limit,
+					$query_limit
 				),
 				ARRAY_A
 			);
@@ -248,6 +327,7 @@ class Elementor_Crawler extends Crawler {
 				}
 
 				$next_meta_id = max( $next_meta_id, (int) $row['meta_id'] );
+				$processed++;
 
 				foreach ( $this->extract_lottie_urls_from_json( isset( $row['meta_value'] ) ? $row['meta_value'] : '' ) as $lottie_url ) {
 					$lottie_urls[ $lottie_url ] = $lottie_url;
@@ -258,7 +338,7 @@ class Elementor_Crawler extends Crawler {
 				$wpdb->flush();
 			}
 
-			if ( count( $rows ) < $batch_size || $next_meta_id <= $last_meta_id ) {
+			if ( count( $rows ) < $query_limit || $next_meta_id <= $last_meta_id || $processed >= $max_entries || microtime( true ) >= $deadline ) {
 				break;
 			}
 
@@ -290,22 +370,27 @@ class Elementor_Crawler extends Crawler {
 			return array();
 		}
 
-		$urls = array();
+		$urls  = array();
+		$stack = array( $decoded );
 
-		foreach ( $this->flatten_data( $decoded ) as $item ) {
-			if ( ! is_array( $item ) || ! isset( $item['widgetType'] ) || 'lottie' !== $item['widgetType'] ) {
+		while ( ! empty( $stack ) ) {
+			$item = array_pop( $stack );
+			if ( ! is_array( $item ) ) {
 				continue;
 			}
-
-			$source = isset( $item['settings']['source_json'] ) && is_array( $item['settings']['source_json'] )
-				? $item['settings']['source_json']
-				: array();
-
-			if ( 'library' !== ( isset( $source['source'] ) ? $source['source'] : '' ) || empty( $source['url'] ) || ! is_string( $source['url'] ) ) {
-				continue;
+			if ( isset( $item['widgetType'] ) && 'lottie' === $item['widgetType'] ) {
+				$source = isset( $item['settings']['source_json'] ) && is_array( $item['settings']['source_json'] )
+					? $item['settings']['source_json']
+					: array();
+				if ( 'library' === ( isset( $source['source'] ) ? $source['source'] : '' ) && ! empty( $source['url'] ) && is_string( $source['url'] ) ) {
+					$urls[ $source['url'] ] = $source['url'];
+				}
 			}
-
-			$urls[ $source['url'] ] = $source['url'];
+			foreach ( $item as $value ) {
+				if ( is_array( $value ) ) {
+					$stack[] = $value;
+				}
+			}
 		}
 
 		return array_values( $urls );
@@ -387,7 +472,11 @@ class Elementor_Crawler extends Crawler {
 	 * @return array List of asset URLs
 	 */
 	private function scan_directory_for_assets( $dir, $url_base ): array {
-		$urls = [];
+		$urls        = [];
+		$max_entries = max( 1, min( 100000, (int) apply_filters( 'simply_static_elementor_detection_max_entries', 5000 ) ) );
+		$seconds     = (float) apply_filters( 'simply_static_elementor_detection_max_seconds', 5 );
+		$deadline    = microtime( true ) + max( 0.5, min( 15, $seconds ) );
+		$scanned     = 0;
 
 		// Check if directory exists
 		if ( ! is_dir( $dir ) ) {
@@ -402,7 +491,11 @@ class Elementor_Crawler extends Crawler {
 				\RecursiveIteratorIterator::SELF_FIRST
 			);
 
- 		foreach ( $iterator as $file ) {
+			foreach ( $iterator as $file ) {
+				$scanned++;
+				if ( $scanned > $max_entries || microtime( true ) >= $deadline ) {
+					break;
+				}
 				// Skip directories
 				if ( $file->isDir() ) {
 					continue;
@@ -411,10 +504,10 @@ class Elementor_Crawler extends Crawler {
 				if ( strtolower( $file->getExtension() ) === 'php' ) {
 					continue;
 				}
-				
+
 				// Build the relative path safely
 				$relative_path = \Simply_Static\Util::safe_relative_path( $dir, $file->getPathname() );
-				
+
 				// Create the full URL with safe joining
 				$url = \Simply_Static\Util::safe_join_url( $url_base, $relative_path );
 				$urls[] = $url;

--- a/src/crawler/class-ss-plugin-assets-crawler.php
+++ b/src/crawler/class-ss-plugin-assets-crawler.php
@@ -56,6 +56,9 @@ class Plugin_Assets_Crawler extends Crawler {
 			}
 			// Get the plugin directory
 			$plugin_dir  = dirname( $plugin );
+			if ( '.' === $plugin_dir ) {
+				continue;
+			}
 			$plugin_path = $plugins_dir . '/' . $plugin_dir;
 
 			// Skip if the plugin directory doesn't exist
@@ -79,9 +82,6 @@ class Plugin_Assets_Crawler extends Crawler {
 	 * @return int
 	 */
 	public function add_urls_to_queue(): int {
-		$count      = 0;
-		$batch      = [];
-		$batch_sz   = (int) apply_filters( 'simply_static_crawler_batch_size', 100 );
 		$assets_ext = [
 			'css',
 			'js',
@@ -117,12 +117,12 @@ class Plugin_Assets_Crawler extends Crawler {
 		] );
 
 		$plugins_url    = plugins_url();
-		$plugins_dir    = WP_PLUGIN_DIR;
 		$active_plugins = \Simply_Static\Util::get_all_active_plugins();
 		$allowed        = (array) \Simply_Static\Options::instance()->get( 'plugins_to_include' );
 		$allowed        = is_array( $allowed ) ? array_filter( array_map( 'strval', $allowed ) ) : [];
 		$allowed        = apply_filters( 'ss_crawlable_plugins', $allowed );
 
+		$directories = array();
 		foreach ( $active_plugins as $plugin ) {
 			if ( ! empty( $allowed ) ) {
 				$slug = dirname( $plugin );
@@ -131,91 +131,26 @@ class Plugin_Assets_Crawler extends Crawler {
 				}
 			}
 			$plugin_dir  = dirname( $plugin );
-			$plugin_path = $plugins_dir . '/' . $plugin_dir;
+			if ( '.' === $plugin_dir ) {
+				continue;
+			}
+			$plugin_path = WP_PLUGIN_DIR . '/' . $plugin_dir;
 			$base_url    = $plugins_url . '/' . $plugin_dir;
-			if ( ! is_dir( $plugin_path ) ) {
-				continue;
-			}
-
-			try {
-				$it = new \RecursiveIteratorIterator(
-					new \RecursiveDirectoryIterator( $plugin_path, \RecursiveDirectoryIterator::SKIP_DOTS ),
-					\RecursiveIteratorIterator::SELF_FIRST
-				);
-				foreach ( $it as $file ) {
-					if ( $file->isDir() ) {
-						continue;
-					}
-					// Build a safe relative path from the plugin directory prefix
-					$rel = \Simply_Static\Util::safe_relative_path( $plugin_path, $file->getPathname() );
-					// Skip unwanted directories
-					$skip = false;
-					foreach ( (array) $skip_dirs as $sd ) {
-						if ( $sd && strpos( $rel, '/' . $sd . '/' ) !== false ) {
-							$skip = true;
-							break;
-						}
-					}
-					// Extra skips (languages JSON and composer.json)
-					$ext = strtolower( pathinfo( $rel, PATHINFO_EXTENSION ) );
-					if ( ! $skip && $ext === 'json' && strpos( $rel, '/languages/' ) !== false ) {
-						$skip = true;
-					}
-					if ( ! $skip && strtolower( basename( $rel ) ) === 'composer.json' ) {
-						$skip = true;
-					}
-					if ( $skip ) {
-						continue;
-					}
-					if ( ! in_array( $ext, $assets_ext, true ) ) {
-						continue;
-					}
-					// Join with exactly one slash between base and relative
-					$batch[] = \Simply_Static\Util::safe_join_url( $base_url, $rel );
-					if ( count( $batch ) >= $batch_sz ) {
-						$count += $this->enqueue_urls_batch( $batch );
-						$batch = [];
-						usleep( 100000 );
-					}
-				}
-			} catch ( \Exception $e ) {
-				\Simply_Static\Util::debug_log( 'Error streaming plugin assets crawl: ' . $e->getMessage() );
+			if ( is_dir( $plugin_path ) ) {
+				$directories[] = array( 'basedir' => $plugin_path, 'baseurl' => $base_url );
 			}
 		}
 
-		if ( ! empty( $batch ) ) {
-			$count += $this->enqueue_urls_batch( $batch );
-		}
+		$skip_dirs[] = 'composer.json';
 
-		\Simply_Static\Util::debug_log( sprintf( 'Plugin assets crawler added %d URLs (streamed)', $count ) );
-
-		return $count;
-	}
-
-	/**
-	 * Enqueue a batch of URLs.
-	 *
-	 * @param array $urls
-	 *
-	 * @return int
-	 */
-	private function enqueue_urls_batch( array $urls ): int {
-		$added = 0;
-		\Simply_Static\Util::debug_log( sprintf( 'Processing batch of %d URLs for %s crawler', count( $urls ), $this->name ) );
-		foreach ( $urls as $url ) {
-			// Skip URLs that are excluded by settings/patterns
-			if ( \Simply_Static\Util::is_url_excluded( $url ) ) {
-				\Simply_Static\Util::debug_log( sprintf( 'Plugin assets crawler skipping excluded URL: %s', $url ) );
-				continue;
-			}
-			$static_page = \Simply_Static\Page::query()->find_or_initialize_by( 'url', $url );
-			$static_page->set_status_message( sprintf( __( 'Added by %s Crawler', 'simply-static' ), $this->name ) );
-			$static_page->found_on_id = 0;
-			$static_page->save();
-			$added ++;
-		}
-
-		return $added;
+		return $this->enqueue_directory_batch(
+			'plugin_assets_crawler_state',
+			$directories,
+			$assets_ext,
+			(array) $skip_dirs,
+			'simply_static_plugin_assets_crawler_max_entries_per_batch',
+			'simply_static_plugin_assets_crawler_max_batch_seconds'
+		);
 	}
 
 	/**
@@ -227,7 +162,10 @@ class Plugin_Assets_Crawler extends Crawler {
 	 * @return array List of asset URLs
 	 */
 	private function scan_directory_for_assets( $dir, $url_base ): array {
-		$urls = [];
+		$urls            = [];
+		$max_entries     = max( 1, min( 100000, (int) apply_filters( 'simply_static_plugin_assets_detection_max_entries', 5000 ) ) );
+		$deadline        = microtime( true ) + max( 0.5, min( 15, (float) apply_filters( 'simply_static_plugin_assets_detection_max_seconds', 5 ) ) );
+		$entries_scanned = 0;
 
 		// Asset file extensions to look for
 		$asset_extensions = [
@@ -287,6 +225,10 @@ class Plugin_Assets_Crawler extends Crawler {
 			$file_batch  = [];
 
 			foreach ( $iterator as $file ) {
+				$entries_scanned++;
+				if ( $entries_scanned > $max_entries || microtime( true ) >= $deadline ) {
+					break;
+				}
 				// Skip directories
 				if ( $file->isDir() ) {
 					continue;

--- a/src/crawler/class-ss-post-type-crawler.php
+++ b/src/crawler/class-ss-post-type-crawler.php
@@ -35,6 +35,7 @@ class Post_Type_Crawler extends Crawler {
 	 */
 	public function detect(): array {
 		$post_urls = [];
+		$max_posts = max( 1, min( 100000, (int) apply_filters( 'simply_static_post_type_detection_limit', 1000 ) ) );
 
 		// Get all public post types
 		$post_types = get_post_types( [ 'public' => true ], 'names' );
@@ -61,6 +62,9 @@ class Post_Type_Crawler extends Crawler {
 		}
 
 		foreach ( $post_types as $post_type ) {
+			if ( count( $post_urls ) >= $max_posts ) {
+				break;
+			}
 			// Skip attachments as they're handled differently
 			if ( $post_type === 'attachment' ) {
 				continue;
@@ -69,7 +73,7 @@ class Post_Type_Crawler extends Crawler {
 			// Get all published posts of this type
 			$posts = get_posts( [
 				'post_type'      => $post_type,
-				'posts_per_page' => - 1,
+				'posts_per_page' => $max_posts - count( $post_urls ),
 				'post_status'    => 'publish',
 			] );
 
@@ -84,41 +88,158 @@ class Post_Type_Crawler extends Crawler {
 			}
 		}
 
-		// Remove stale pages table entries for posts that are no longer publicly
-		$this->cleanup_non_published_pages();
-
 		return $post_urls;
 	}
 
 	/**
-	 * Remove pages table entries whose post_id refers to a post that is no longer publicly visible.
+	 * Traverse public posts and stale-page cleanup across bounded requests.
+	 *
+	 * @return int Number of URLs added by this invocation.
 	 */
-	private function cleanup_non_published_pages(): void {
+	public function add_urls_to_queue() : int {
 		global $wpdb;
-		$table               = $wpdb->prefix . 'simply_static_pages';
-		$non_public_statuses = "'trash','draft','pending','private','auto-draft'";
 
-		$stale_rows = $wpdb->get_results(
-			"SELECT p.id, p.post_id, p.file_path, p.url
-			 FROM {$table} p
-			 LEFT JOIN {$wpdb->posts} wp ON p.post_id = wp.ID
-			 WHERE p.post_id IS NOT NULL AND p.post_id > 0
-			   AND ( wp.ID IS NULL OR wp.post_status IN ({$non_public_statuses}) )"
-		);
+		$post_types = $this->get_crawl_post_types();
+		$signature  = hash( 'sha256', serialize( array(
+			'archive_start_time' => \Simply_Static\Options::instance()->get( 'archive_start_time' ),
+			'post_types'         => $post_types,
+		) ) );
+		$state       = $this->load_post_type_state( $signature );
+		$batch_size  = max( 1, min( 500, (int) apply_filters( 'simply_static_post_type_crawler_batch_size', 100 ) ) );
+		$entry_limit = max( $batch_size, min( 2000, (int) apply_filters( 'simply_static_post_type_crawler_max_entries_per_batch', 500 ) ) );
+		$seconds     = (float) apply_filters( 'simply_static_post_type_crawler_max_batch_seconds', 10 );
+		$deadline    = microtime( true ) + max( 0.5, min( 15, $seconds ) );
+		$processed   = 0;
+		$added_now   = 0;
+		$this->complete = false;
 
-		if ( empty( $stale_rows ) ) {
-			return;
+		while ( 'posts' === $state['stage'] && $state['post_type_index'] < count( $post_types ) ) {
+			$post_type   = $post_types[ $state['post_type_index'] ];
+			$query_limit = min( $batch_size, $entry_limit - $processed );
+			$ids = $wpdb->get_col( $wpdb->prepare(
+				"SELECT ID FROM {$wpdb->posts} WHERE post_type = %s AND post_status = 'publish' AND ID > %d ORDER BY ID ASC LIMIT %d",
+				$post_type,
+				$state['last_post_id'],
+				$query_limit
+			) );
+			$ids = is_array( $ids ) ? array_map( 'intval', $ids ) : array();
+			$urls = array();
+			foreach ( $ids as $post_id ) {
+				$state['last_post_id'] = max( $state['last_post_id'], $post_id );
+				$url = get_permalink( $post_id );
+				if ( is_string( $url ) ) {
+					$urls[] = $url;
+				}
+			}
+			$added             = $this->enqueue_urls( $urls );
+			$added_now        += $added;
+			$state['added']   += $added;
+			$state['scanned'] += count( $ids );
+			$processed        += count( $ids );
+
+			if ( count( $ids ) < $query_limit ) {
+				$state['post_type_index']++;
+				$state['last_post_id'] = 0;
+			}
+			if ( $processed >= $entry_limit || microtime( true ) >= $deadline ) {
+				return $this->checkpoint_post_type_crawler( $state, $added_now );
+			}
 		}
 
-		// Queue stale pages for deletion on the destination (all delivery methods).
-		$this->queue_stale_pages_for_deletion( $stale_rows );
+		if ( 'posts' === $state['stage'] ) {
+			$state['stage'] = 'cleanup';
+		}
 
-		// Remove the stale rows from the pages table.
-		$stale_ids       = array_map( function ( $row ) {
-			return (int) $row->id;
-		}, $stale_rows );
-		$ids_placeholder = implode( ',', $stale_ids );
-		$wpdb->query( "DELETE FROM {$table} WHERE id IN ({$ids_placeholder})" );
+		if ( 'cleanup' === $state['stage'] ) {
+			$table = $wpdb->prefix . 'simply_static_pages';
+			$remaining = max( 1, $entry_limit - $processed );
+			$stale_rows = $wpdb->get_results( $wpdb->prepare(
+				"SELECT p.id, p.post_id, p.file_path, p.url
+				 FROM {$table} p
+				 LEFT JOIN {$wpdb->posts} wp ON p.post_id = wp.ID
+				 WHERE p.id > %d AND p.post_id IS NOT NULL AND p.post_id > 0
+				   AND ( wp.ID IS NULL OR wp.post_status IN ('trash','draft','pending','private','auto-draft') )
+				 ORDER BY p.id ASC
+				 LIMIT %d",
+				$state['last_stale_id'],
+				min( $batch_size, $remaining )
+			) );
+			$stale_rows = is_array( $stale_rows ) ? $stale_rows : array();
+			if ( ! empty( $stale_rows ) ) {
+				$this->queue_stale_pages_for_deletion( $stale_rows );
+				$stale_ids = array_map( static function ( $row ) {
+					return (int) $row->id;
+				}, $stale_rows );
+				$state['last_stale_id'] = max( $stale_ids );
+				$state['scanned']      += count( $stale_ids );
+				$wpdb->query( "DELETE FROM {$table} WHERE id IN (" . implode( ',', $stale_ids ) . ')' );
+			}
+			if ( count( $stale_rows ) >= min( $batch_size, $remaining ) ) {
+				return $this->checkpoint_post_type_crawler( $state, $added_now );
+			}
+		}
+
+		$this->complete = true;
+		$this->progress = array( 'added' => $state['added'], 'scanned' => $state['scanned'] );
+		$this->clear_crawler_state( 'post_type_crawler_state' );
+
+		return $added_now;
+	}
+
+	/** @return string[] */
+	private function get_crawl_post_types() : array {
+		$post_types = get_post_types( array( 'public' => true ), 'names' );
+		$post_types = apply_filters( 'simply_static_post_types_to_crawl', $post_types );
+		$post_types = array_values( array_diff( (array) $post_types, array( 'attachment', 'elementor_library', 'ssp-form' ) ) );
+		$options = get_option( 'simply-static' );
+		$has_selection = isset( $options['post_types'] ) && is_array( $options['post_types'] ) && ( ! empty( $options['post_types_configured'] ) || ! empty( $options['post_types'] ) );
+		if ( $has_selection ) {
+			$post_types = array_values( array_intersect( $post_types, $options['post_types'] ) );
+		}
+
+		return array_values( array_filter( $post_types, 'is_string' ) );
+	}
+
+	/** @return array<string,mixed> */
+	private function load_post_type_state( $signature ) : array {
+		$state = \Simply_Static\Options::instance()->get( 'post_type_crawler_state' );
+		if ( ! is_array( $state )
+			|| 1 !== ( $state['version'] ?? null )
+			|| $signature !== ( $state['signature'] ?? null )
+			|| ! in_array( $state['stage'] ?? null, array( 'posts', 'cleanup' ), true )
+			|| ! is_int( $state['post_type_index'] ?? null )
+			|| $state['post_type_index'] < 0
+			|| ! is_int( $state['last_post_id'] ?? null )
+			|| $state['last_post_id'] < 0
+			|| ! is_int( $state['last_stale_id'] ?? null )
+			|| $state['last_stale_id'] < 0
+			|| ! is_int( $state['added'] ?? null )
+			|| $state['added'] < 0
+			|| ! is_int( $state['scanned'] ?? null )
+			|| $state['scanned'] < 0
+		) {
+			return array(
+				'version'         => 1,
+				'signature'       => $signature,
+				'stage'           => 'posts',
+				'post_type_index' => 0,
+				'last_post_id'    => 0,
+				'last_stale_id'   => 0,
+				'added'           => 0,
+				'scanned'         => 0,
+			);
+		}
+
+		return $state;
+	}
+
+	/** @param array<string,mixed> $state */
+	private function checkpoint_post_type_crawler( array $state, $added_now ) : int {
+		$this->complete = false;
+		$this->progress = array( 'added' => $state['added'], 'scanned' => $state['scanned'] );
+		$this->save_crawler_state( 'post_type_crawler_state', $state );
+
+		return (int) $added_now;
 	}
 
 	/**

--- a/src/crawler/class-ss-rest-api-crawler.php
+++ b/src/crawler/class-ss-rest-api-crawler.php
@@ -64,9 +64,14 @@ class Rest_Api_Crawler extends Crawler {
 		// Get all registered REST routes
 		$rest_server = rest_get_server();
 		$routes = $rest_server->get_routes();
+		$max_routes = max( 1, min( 50000, (int) apply_filters( 'simply_static_rest_api_max_routes', 5000 ) ) );
 
 		// Add URLs for each route
 		foreach ( $routes as $route => $handlers ) {
+			if ( count( $rest_urls ) >= $max_routes ) {
+				\Simply_Static\Util::debug_log( sprintf( 'REST API crawler stopped at its %d-route safety limit.', $max_routes ) );
+				break;
+			}
 			// Skip internal WordPress routes that aren't typically needed
 			if ( $this->should_skip_route( $route ) ) {
 				continue;

--- a/src/crawler/class-ss-rss-feeds-crawler.php
+++ b/src/crawler/class-ss-rss-feeds-crawler.php
@@ -54,6 +54,7 @@ class Rss_Feeds_Crawler extends Crawler {
 	 */
 	public function detect(): array {
 		$feed_urls = [];
+		$max_objects = max( 1, min( 100000, (int) apply_filters( 'simply_static_rss_feed_detection_limit', 1000 ) ) );
 
 		$options                 = get_option( 'simply-static' );
 		$has_post_type_selection = isset( $options['post_types'] ) && is_array( $options['post_types'] ) && ( ! empty( $options['post_types_configured'] ) || ! empty( $options['post_types'] ) );
@@ -73,19 +74,19 @@ class Rss_Feeds_Crawler extends Crawler {
 			$feed_urls[] = get_feed_link( 'comments_' );
 
 			// Add category feeds
-			$categories = get_categories( [ 'hide_empty' => true ] );
+			$categories = get_categories( [ 'hide_empty' => true, 'number' => $max_objects ] );
 			foreach ( $categories as $category ) {
 				$feed_urls[] = get_category_feed_link( $category->term_id );
 			}
 
 			// Add tag feeds
-			$tags = get_tags( [ 'hide_empty' => true ] );
+			$tags = get_tags( [ 'hide_empty' => true, 'number' => $max_objects ] );
 			foreach ( $tags as $tag ) {
 				$feed_urls[] = get_tag_feed_link( $tag->term_id );
 			}
 
 			// Add author feeds
-			$users = get_users();
+			$users = get_users( array( 'number' => $max_objects, 'orderby' => 'ID', 'order' => 'ASC' ) );
 			foreach ( $users as $user ) {
 				$feed_urls[] = get_author_feed_link( $user->ID );
 			}
@@ -120,5 +121,118 @@ class Rss_Feeds_Crawler extends Crawler {
 		} );
 
 		return array_unique( $feed_urls );
+	}
+
+	/**
+	 * Traverse term and author feeds across bounded background requests.
+	 *
+	 * @return int Number of URLs added by this invocation.
+	 */
+	public function add_urls_to_queue() : int {
+		$options                 = get_option( 'simply-static' );
+		$has_post_type_selection = isset( $options['post_types'] ) && is_array( $options['post_types'] ) && ( ! empty( $options['post_types_configured'] ) || ! empty( $options['post_types'] ) );
+		$selected_post_types     = $has_post_type_selection ? $options['post_types'] : array();
+		if ( $has_post_type_selection && empty( $selected_post_types ) ) {
+			$this->complete = true;
+			$this->clear_crawler_state( 'rss_feeds_crawler_state' );
+			return 0;
+		}
+
+		$include_post_feeds = ! $has_post_type_selection || in_array( 'post', $selected_post_types, true );
+		$post_types = get_post_types( array( 'public' => true ), 'names' );
+		$post_types = array_values( array_diff( $post_types, array( 'attachment', 'elementor_library', 'ssp-form', 'post' ) ) );
+		if ( $has_post_type_selection ) {
+			$post_types = array_values( array_intersect( $post_types, $selected_post_types ) );
+		}
+		$signature = hash( 'sha256', serialize( array(
+			'archive_start_time' => \Simply_Static\Options::instance()->get( 'archive_start_time' ),
+			'include_posts'      => $include_post_feeds,
+			'post_types'         => $post_types,
+		) ) );
+		$state = \Simply_Static\Options::instance()->get( 'rss_feeds_crawler_state' );
+		if ( ! is_array( $state ) || 1 !== ( $state['version'] ?? null ) || $signature !== ( $state['signature'] ?? null ) || ! in_array( $state['stage'] ?? null, array( 'categories', 'tags', 'authors' ), true ) || ! is_int( $state['offset'] ?? null ) || $state['offset'] < 0 ) {
+			$state = array( 'version' => 1, 'signature' => $signature, 'stage' => 'categories', 'offset' => 0, 'base_added' => false, 'added' => 0, 'scanned' => 0 );
+		}
+
+		$added_now = 0;
+		if ( empty( $state['base_added'] ) ) {
+			$base_urls = array();
+			if ( $include_post_feeds ) {
+				$base_urls[] = get_feed_link();
+				$base_urls[] = get_feed_link( 'comments_' );
+				$base_urls[] = add_query_arg( array( 's' => 'example', 'feed' => 'rss2' ), home_url() );
+			}
+			foreach ( $post_types as $post_type ) {
+				$base_urls[] = add_query_arg( 'post_type', $post_type, get_feed_link() );
+			}
+			$base_urls = array_values( array_unique( array_filter( $base_urls, static function ( $url ) {
+				return is_string( $url ) && false !== filter_var( $url, FILTER_VALIDATE_URL );
+			} ) ) );
+			$added                 = $this->enqueue_urls( $base_urls );
+			$added_now            += $added;
+			$state['added']        += $added;
+			$state['base_added']    = true;
+			$this->save_crawler_state( 'rss_feeds_crawler_state', $state );
+		}
+
+		if ( ! $include_post_feeds ) {
+			$this->complete = true;
+			$this->progress = array( 'added' => $state['added'], 'scanned' => $state['scanned'] );
+			$this->clear_crawler_state( 'rss_feeds_crawler_state' );
+			return $added_now;
+		}
+
+		$batch_size = max( 1, min( 500, (int) apply_filters( 'simply_static_rss_feeds_crawler_batch_size', 100 ) ) );
+		$this->complete = true;
+		while ( true ) {
+			$urls = array();
+			if ( 'authors' === $state['stage'] ) {
+				$ids = get_users( array( 'fields' => 'ID', 'number' => $batch_size, 'offset' => $state['offset'], 'orderby' => 'ID', 'order' => 'ASC' ) );
+				$ids = is_array( $ids ) ? $ids : array();
+				foreach ( $ids as $id ) {
+					$urls[] = get_author_feed_link( (int) $id );
+				}
+			} else {
+				$taxonomy = 'categories' === $state['stage'] ? 'category' : 'post_tag';
+				$ids = get_terms( array( 'taxonomy' => $taxonomy, 'hide_empty' => true, 'fields' => 'ids', 'number' => $batch_size, 'offset' => $state['offset'], 'orderby' => 'term_id', 'order' => 'ASC' ) );
+				$ids = is_wp_error( $ids ) || ! is_array( $ids ) ? array() : $ids;
+				foreach ( $ids as $id ) {
+					$urls[] = 'category' === $taxonomy ? get_category_feed_link( (int) $id ) : get_tag_feed_link( (int) $id );
+				}
+			}
+
+			$urls = array_values( array_filter( $urls, static function ( $url ) {
+				return is_string( $url ) && false !== filter_var( $url, FILTER_VALIDATE_URL );
+			} ) );
+			$added                = $this->enqueue_urls( $urls );
+			$added_now           += $added;
+			$state['added']       += $added;
+			$state['scanned']     += count( $ids );
+			$state['offset']      += count( $ids );
+			if ( count( $ids ) >= $batch_size ) {
+				$this->complete = false;
+				break;
+			}
+			if ( 'categories' === $state['stage'] ) {
+				$state['stage'] = 'tags';
+				$state['offset'] = 0;
+				continue;
+			}
+			if ( 'tags' === $state['stage'] ) {
+				$state['stage'] = 'authors';
+				$state['offset'] = 0;
+				continue;
+			}
+			break;
+		}
+
+		$this->progress = array( 'added' => $state['added'], 'scanned' => $state['scanned'] );
+		if ( $this->complete ) {
+			$this->clear_crawler_state( 'rss_feeds_crawler_state' );
+		} else {
+			$this->save_crawler_state( 'rss_feeds_crawler_state', $state );
+		}
+
+		return $added_now;
 	}
 }

--- a/src/crawler/class-ss-taxonomy-crawler.php
+++ b/src/crawler/class-ss-taxonomy-crawler.php
@@ -35,15 +35,20 @@ class Taxonomy_Crawler extends Crawler {
 	 */
 	public function detect() : array {
 		$taxonomy_urls = [];
+		$max_terms = max( 1, min( 100000, (int) apply_filters( 'simply_static_taxonomy_detection_limit', 1000 ) ) );
 		
 		// Get all public taxonomies
 		$taxonomies = get_taxonomies( [ 'public' => true ], 'names' );
 		
 		foreach ( $taxonomies as $taxonomy ) {
+			if ( count( $taxonomy_urls ) >= $max_terms ) {
+				break;
+			}
 			// Get all terms for this taxonomy
 			$terms = get_terms( [
 				'taxonomy'   => $taxonomy,
 				'hide_empty' => true,
+				'number'     => $max_terms - count( $taxonomy_urls ),
 			] );
 			
 			if ( is_wp_error( $terms ) ) {
@@ -62,5 +67,70 @@ class Taxonomy_Crawler extends Crawler {
 		}
 		
 		return $taxonomy_urls;
+	}
+
+	/**
+	 * Traverse public terms across bounded background requests.
+	 *
+	 * @return int Number of URLs added by this invocation.
+	 */
+	public function add_urls_to_queue() : int {
+		$taxonomies = array_values( (array) get_taxonomies( array( 'public' => true ), 'names' ) );
+		$signature  = hash( 'sha256', serialize( array(
+			'archive_start_time' => \Simply_Static\Options::instance()->get( 'archive_start_time' ),
+			'taxonomies'         => $taxonomies,
+		) ) );
+		$state = \Simply_Static\Options::instance()->get( 'taxonomy_crawler_state' );
+		if ( ! is_array( $state ) || 1 !== ( $state['version'] ?? null ) || $signature !== ( $state['signature'] ?? null ) || ! is_int( $state['taxonomy_index'] ?? null ) || $state['taxonomy_index'] < 0 || ! is_int( $state['offset'] ?? null ) || $state['offset'] < 0 ) {
+			$state = array( 'version' => 1, 'signature' => $signature, 'taxonomy_index' => 0, 'offset' => 0, 'added' => 0, 'scanned' => 0 );
+		}
+
+		$batch_size = max( 1, min( 500, (int) apply_filters( 'simply_static_taxonomy_crawler_batch_size', 100 ) ) );
+		$added_now  = 0;
+		$this->complete = true;
+		while ( $state['taxonomy_index'] < count( $taxonomies ) ) {
+			$taxonomy = $taxonomies[ $state['taxonomy_index'] ];
+			$term_ids = get_terms( array(
+				'taxonomy'   => $taxonomy,
+				'hide_empty' => true,
+				'fields'     => 'ids',
+				'number'     => $batch_size,
+				'offset'     => $state['offset'],
+				'orderby'    => 'term_id',
+				'order'      => 'ASC',
+			) );
+			if ( is_wp_error( $term_ids ) ) {
+				$term_ids = array();
+			}
+			$term_ids = is_array( $term_ids ) ? $term_ids : array();
+			$urls     = array();
+			foreach ( $term_ids as $term_id ) {
+				$url = get_term_link( (int) $term_id, $taxonomy );
+				if ( ! is_wp_error( $url ) && is_string( $url ) ) {
+					$urls[] = $url;
+				}
+			}
+
+			$added               = $this->enqueue_urls( $urls );
+			$added_now          += $added;
+			$state['added']     += $added;
+			$state['scanned']   += count( $term_ids );
+			$state['offset']    += count( $term_ids );
+			if ( count( $term_ids ) >= $batch_size ) {
+				$this->complete = false;
+				break;
+			}
+			$state['taxonomy_index']++;
+			$state['offset'] = 0;
+		}
+
+		$this->progress = array( 'added' => $state['added'], 'scanned' => $state['scanned'] );
+		if ( $this->complete ) {
+			$this->clear_crawler_state( 'taxonomy_crawler_state' );
+		} else {
+			$this->save_crawler_state( 'taxonomy_crawler_state', $state );
+		}
+
+		return $added_now;
 	}
 }

--- a/src/crawler/class-ss-theme-assets-crawler.php
+++ b/src/crawler/class-ss-theme-assets-crawler.php
@@ -65,9 +65,6 @@ class Theme_Assets_Crawler extends Crawler {
 	 * @return int
 	 */
 	public function add_urls_to_queue(): int {
-		$count      = 0;
-		$batch      = [];
-		$batch_sz   = (int) apply_filters( 'simply_static_crawler_batch_size', 100 );
 		$extensions = [
 			'css',
 			'js',
@@ -106,7 +103,7 @@ class Theme_Assets_Crawler extends Crawler {
 			$themes[] = [ get_stylesheet_directory(), get_stylesheet_directory_uri() ];
 		}
 		$parent_slug = get_template();
-		if ( $p = wp_get_theme()->parent() ) {
+		if ( wp_get_theme()->parent() ) {
 			$parent_dir = get_template_directory();
 			$parent_url = get_template_directory_uri();
 			if ( $parent_dir !== ( $themes[0][0] ?? '' ) ) {
@@ -116,91 +113,18 @@ class Theme_Assets_Crawler extends Crawler {
 			}
 		}
 
-		foreach ( $themes as [$dir, $url_base] ) {
-			if ( ! is_dir( $dir ) ) {
-				\Simply_Static\Util::debug_log( "Theme directory does not exist: $dir" );
-				continue;
-			}
+		$directories = array_map( static function ( $theme ) {
+			return array( 'basedir' => $theme[0], 'baseurl' => $theme[1] );
+		}, $themes );
 
-			try {
-				$it = new \RecursiveIteratorIterator(
-					new \RecursiveDirectoryIterator( $dir, \RecursiveDirectoryIterator::SKIP_DOTS ),
-					\RecursiveIteratorIterator::SELF_FIRST
-				);
-				foreach ( $it as $file ) {
-					if ( $file->isDir() ) {
-						continue;
-					}
-					// Build a safe relative path from the theme directory prefix
-					$rel  = \Simply_Static\Util::safe_relative_path( $dir, $file->getPathname() );
-					$skip = false;
-					foreach ( (array) $skip_dirs as $sd ) {
-						$sd = trim( $sd, "/" );
-						if ( $sd === '' ) {
-							continue;
-						}
-						if (
-							strpos( $rel, '/' . $sd . '/' ) !== false ||
-							strpos( $rel, $sd . '/' ) === 0 ||
-							substr( $rel, - ( strlen( $sd ) + 1 ) ) === '/' . $sd
-						) {
-							$skip = true;
-							break;
-						}
-					}
-					if ( $skip ) {
-						continue;
-					}
-					$ext = strtolower( pathinfo( $rel, PATHINFO_EXTENSION ) );
-					if ( ! in_array( $ext, $extensions, true ) ) {
-						continue;
-					}
-					// Join with exactly one slash between base and relative
-					$batch[] = \Simply_Static\Util::safe_join_url( $url_base, $rel );
-					if ( count( $batch ) >= $batch_sz ) {
-						$count += $this->enqueue_urls_batch( $batch );
-						$batch = [];
-						usleep( 100000 );
-					}
-				}
-			} catch ( \Exception $e ) {
-				\Simply_Static\Util::debug_log( 'Error streaming theme crawl: ' . $e->getMessage() );
-			}
-		}
-
-		if ( ! empty( $batch ) ) {
-			$count += $this->enqueue_urls_batch( $batch );
-		}
-
-		\Simply_Static\Util::debug_log( sprintf( 'Theme assets crawler added %d URLs (streamed)', $count ) );
-
-		return $count;
-	}
-
-	/**
-	 * Enqueue a batch of URLs.
-	 *
-	 * @param array $urls
-	 *
-	 * @return int
-	 */
-	private function enqueue_urls_batch( array $urls ): int {
-		$added = 0;
-		\Simply_Static\Util::debug_log( sprintf( 'Processing batch of %d URLs for %s crawler', count( $urls ), $this->name ) );
-		foreach ( $urls as $url ) {
-			// Skip URLs that are excluded by settings/patterns
-			if ( \Simply_Static\Util::is_url_excluded( $url ) ) {
-				\Simply_Static\Util::debug_log( sprintf( 'Theme assets crawler skipping excluded URL: %s', $url ) );
-				continue;
-			}
-			$static_page = \Simply_Static\Page::query()->find_or_initialize_by( 'url', $url );
-			$static_page->set_status_message( sprintf( __( 'Added by %s Crawler', 'simply-static' ), $this->name ) );
-			$static_page->found_on_id = 0;
-			$static_page->save();
-			$added ++;
-		}
-
-		return $added;
+		return $this->enqueue_directory_batch(
+			'theme_assets_crawler_state',
+			$directories,
+			$extensions,
+			(array) $skip_dirs,
+			'simply_static_theme_assets_crawler_max_entries_per_batch',
+			'simply_static_theme_assets_crawler_max_batch_seconds'
+		);
 	}
 
 	/**
@@ -212,7 +136,10 @@ class Theme_Assets_Crawler extends Crawler {
 	 * @return array List of asset URLs
 	 */
 	private function scan_directory_for_assets( $dir, $url_base ): array {
-		$urls = [];
+		$urls        = [];
+		$max_entries = max( 1, min( 100000, (int) apply_filters( 'simply_static_theme_detection_max_entries', 5000 ) ) );
+		$deadline    = microtime( true ) + max( 0.5, min( 15, (float) apply_filters( 'simply_static_theme_detection_max_seconds', 5 ) ) );
+		$scanned     = 0;
 
 		// Asset file extensions to look for
 		$asset_extensions = [
@@ -252,6 +179,10 @@ class Theme_Assets_Crawler extends Crawler {
 		);
 
 		foreach ( $files as $file ) {
+			$scanned++;
+			if ( $scanned > $max_entries || microtime( true ) >= $deadline ) {
+				break;
+			}
 			// Skip directories
 			if ( $file->isDir() ) {
 				continue;

--- a/src/crawler/class-ss-uploads-crawler.php
+++ b/src/crawler/class-ss-uploads-crawler.php
@@ -438,7 +438,10 @@ class Uploads_Crawler extends Crawler {
 	 * @return array List of media file URLs
 	 */
 	private function scan_directory_for_media_files( $dir, $url_base ): array {
-		$urls = [];
+		$urls            = [];
+		$max_entries     = max( 1, min( 100000, (int) apply_filters( 'simply_static_uploads_detection_max_entries', 5000 ) ) );
+		$deadline        = microtime( true ) + max( 0.5, min( 15, (float) apply_filters( 'simply_static_uploads_detection_max_seconds', 5 ) ) );
+		$entries_scanned = 0;
 
 		// Media file extensions to look for
 		$media_extensions = [
@@ -508,6 +511,10 @@ class Uploads_Crawler extends Crawler {
 			$file_batch  = [];
 
 			foreach ( $iterator as $file ) {
+				$entries_scanned++;
+				if ( $entries_scanned > $max_entries || microtime( true ) >= $deadline ) {
+					break;
+				}
 				// Skip directories
 				if ( $file->isDir() ) {
 					continue;

--- a/src/crawler/class-ss-vendor-files-crawler.php
+++ b/src/crawler/class-ss-vendor-files-crawler.php
@@ -58,6 +58,56 @@ class Vendor_Files_Crawler extends Crawler {
 	}
 
 	/**
+	 * Traverse vendor roots across bounded background requests.
+	 *
+	 * @return int Number of URLs added by this invocation.
+	 */
+	public function add_urls_to_queue() : int {
+		return $this->enqueue_directory_batch(
+			'vendor_files_crawler_state',
+			$this->get_vendor_scan_directories(),
+			array( 'js', 'css', 'woff', 'woff2', 'ttf', 'eot', 'otf', 'svg', 'json' ),
+			(array) apply_filters( 'ss_skip_crawl_vendor_directories', array( '.git', 'node_modules', 'tests', 'docs', 'examples' ) ),
+			'simply_static_vendor_files_crawler_max_entries_per_batch',
+			'simply_static_vendor_files_crawler_max_batch_seconds'
+		);
+	}
+
+	/** @return array<int,array{basedir:string,baseurl:string}> */
+	private function get_vendor_scan_directories() : array {
+		$directories = array();
+		$vendor_dirs = array( 'vendor', 'vendors', 'lib', 'libs', 'library', 'libraries', 'assets/vendor', 'assets/vendors', 'assets/lib', 'assets/libs', 'includes/vendor', 'includes/vendors', 'includes/lib', 'includes/libs' );
+
+		foreach ( \Simply_Static\Util::get_all_active_plugins() as $plugin ) {
+			$plugin_dir = dirname( $plugin );
+			if ( '.' === $plugin_dir ) {
+				continue;
+			}
+			foreach ( $vendor_dirs as $vendor_dir ) {
+				$directories[] = array(
+					'basedir' => WP_PLUGIN_DIR . '/' . $plugin_dir . '/' . $vendor_dir,
+					'baseurl' => trailingslashit( plugins_url() ) . $plugin_dir . '/' . $vendor_dir,
+				);
+			}
+		}
+
+		$themes = array( array( get_stylesheet_directory(), get_stylesheet_directory_uri() ) );
+		if ( get_template_directory() !== get_stylesheet_directory() ) {
+			$themes[] = array( get_template_directory(), get_template_directory_uri() );
+		}
+		foreach ( $themes as $theme ) {
+			foreach ( $vendor_dirs as $vendor_dir ) {
+				$directories[] = array(
+					'basedir' => trailingslashit( $theme[0] ) . $vendor_dir,
+					'baseurl' => trailingslashit( $theme[1] ) . $vendor_dir,
+				);
+			}
+		}
+
+		return $directories;
+	}
+
+	/**
 	 * Scan plugins for vendor files
 	 *
 	 * @return array List of vendor file URLs
@@ -219,7 +269,10 @@ class Vendor_Files_Crawler extends Crawler {
 	 * @return array List of vendor file URLs
 	 */
 	private function scan_directory_for_vendor_files($dir, $url_base, $extensions) : array {
-		$urls = [];
+		$urls            = [];
+		$max_entries     = max( 1, min( 100000, (int) apply_filters( 'simply_static_vendor_detection_max_entries', 5000 ) ) );
+		$deadline        = microtime( true ) + max( 0.5, min( 15, (float) apply_filters( 'simply_static_vendor_detection_max_seconds', 5 ) ) );
+		$entries_scanned = 0;
 
 		// Skip these directories
 		$skip_dirs = ['.git', 'node_modules', 'tests', 'docs', 'examples'];
@@ -244,6 +297,10 @@ class Vendor_Files_Crawler extends Crawler {
 			$file_batch = [];
 
 			foreach ( $iterator as $file ) {
+				$entries_scanned++;
+				if ( $entries_scanned > $max_entries || microtime( true ) >= $deadline ) {
+					break;
+				}
 				// Skip directories
 				if ( $file->isDir() ) {
 					continue;

--- a/src/crawler/class-ss-wp-includes-crawler.php
+++ b/src/crawler/class-ss-wp-includes-crawler.php
@@ -79,6 +79,9 @@ class Wp_Includes_Crawler extends Crawler {
 
 		$dirs = [ 'css/', 'js/', 'fonts/', 'images/', 'blocks/' ];
 		$exts = [ 'css', 'js', 'json', 'woff', 'woff2', 'ttf', 'eot', 'otf', 'png', 'jpg', 'jpeg', 'gif', 'svg', 'ico' ];
+		$max_entries = max( 1, min( 100000, (int) apply_filters( 'simply_static_wp_includes_detection_max_entries', 5000 ) ) );
+		$deadline    = microtime( true ) + max( 0.5, min( 15, (float) apply_filters( 'simply_static_wp_includes_detection_max_seconds', 5 ) ) );
+		$scanned     = 0;
 
 		foreach ( $dirs as $dir ) {
 			$full_path = $wp_inc_dir . $dir;
@@ -87,6 +90,10 @@ class Wp_Includes_Crawler extends Crawler {
 
 			$it = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $full_path, \RecursiveDirectoryIterator::SKIP_DOTS ) );
 			foreach ( $it as $file ) {
+				$scanned++;
+				if ( $scanned > $max_entries || microtime( true ) >= $deadline ) {
+					break 2;
+				}
 				if ( $file->isDir() ) continue;
 				// WordPress keeps removed core assets as empty placeholders for some releases.
 				if ( 0 === $file->getSize() ) continue;
@@ -97,5 +104,46 @@ class Wp_Includes_Crawler extends Crawler {
 			}
 		}
 		return array_unique( $urls );
+	}
+
+	/**
+	 * Traverse wp-includes assets across bounded background requests.
+	 *
+	 * @return int Number of URLs added by this invocation.
+	 */
+	public function add_urls_to_queue() : int {
+		$wp_inc       = defined( 'WPINC' ) ? WPINC : 'wp-includes';
+		$origin_url   = \Simply_Static\Util::origin_url();
+		$origin_parts = wp_parse_url( $origin_url );
+		$inc_path     = wp_parse_url( includes_url(), PHP_URL_PATH );
+		$inc_path     = is_string( $inc_path ) && '' !== $inc_path ? $inc_path : '/' . $wp_inc;
+		$origin_path  = isset( $origin_parts['path'] ) ? '/' . trim( $origin_parts['path'], '/' ) : '';
+
+		if ( '' !== $origin_path && '/' !== $origin_path ) {
+			$inc_path = '/' . ltrim( $inc_path, '/' );
+			if ( $inc_path === $origin_path ) {
+				$inc_path = '/';
+			} elseif ( 0 === strpos( $inc_path . '/', trailingslashit( $origin_path ) ) ) {
+				$inc_path = substr( $inc_path, strlen( $origin_path ) );
+			}
+		}
+
+		$includes_url = trailingslashit( \Simply_Static\Util::safe_join_url( $origin_url, $inc_path ) );
+		$directories  = array();
+		foreach ( array( 'css', 'js', 'fonts', 'images', 'blocks' ) as $directory ) {
+			$directories[] = array(
+				'basedir' => trailingslashit( ABSPATH . $wp_inc ) . $directory,
+				'baseurl' => \Simply_Static\Util::safe_join_url( $includes_url, $directory ),
+			);
+		}
+
+		return $this->enqueue_directory_batch(
+			'wp_includes_crawler_state',
+			$directories,
+			array( 'css', 'js', 'json', 'woff', 'woff2', 'ttf', 'eot', 'otf', 'png', 'jpg', 'jpeg', 'gif', 'svg', 'ico' ),
+			array(),
+			'simply_static_wp_includes_crawler_max_entries_per_batch',
+			'simply_static_wp_includes_crawler_max_batch_seconds'
+		);
 	}
 }

--- a/src/tasks/class-ss-discover-urls-task.php
+++ b/src/tasks/class-ss-discover-urls-task.php
@@ -212,6 +212,24 @@ class Discover_Urls_Task extends Task {
 		$this->options->destroy( $this->crawler_index_option );
 		$this->options->destroy( $this->initial_count_option );
 		$this->options->destroy( $this->total_added_option );
+		foreach ( array(
+			'archive_crawler_state',
+			'author_crawler_state',
+			'beaver_builder_crawler_state',
+			'divi_crawler_state',
+			'elementor_crawler_state',
+			'elementor_directory_crawler_state',
+			'plugin_assets_crawler_state',
+			'post_type_crawler_state',
+			'rss_feeds_crawler_state',
+			'taxonomy_crawler_state',
+			'theme_assets_crawler_state',
+			'uploads_crawler_state',
+			'vendor_files_crawler_state',
+			'wp_includes_crawler_state',
+		) as $crawler_state ) {
+			$this->options->destroy( $crawler_state );
+		}
 
 		$this->options->save();
 	}

--- a/tests/Unit/ElementorCrawlerResumeTest.php
+++ b/tests/Unit/ElementorCrawlerResumeTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Simply_Static\Tests\Unit;
+
+use Simply_Static\Crawler\Elementor_Crawler;
+use Simply_Static\Options;
+use Simply_Static\Tests\Support\UnitTestCase;
+
+final class ElementorCrawlerResumeWpdb {
+
+	/** @var string */
+	public $postmeta = 'wp_postmeta';
+
+	/** @var int */
+	public $insert_id = 1;
+
+	/** @var array<int,array<string,mixed>> */
+	public $inserts = array();
+
+	/** @var array<int,string> */
+	public $queries = array();
+
+	/** @var array<int,array<string,mixed>> */
+	private $meta_rows;
+
+	/** @param array<int,array<string,mixed>> $meta_rows */
+	public function __construct( array $meta_rows ) {
+		$this->meta_rows = $meta_rows;
+	}
+
+	public function get_blog_prefix(): string {
+		return 'wp_';
+	}
+
+	/** @param mixed ...$arguments */
+	public function prepare( string $query, ...$arguments ): string {
+		return vsprintf( $query, $arguments );
+	}
+
+	/** @return null */
+	public function get_row( string $query, $output = null ) {
+		return null;
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	public function get_results( string $query, string $output ): array {
+		$this->queries[] = $query;
+		preg_match( '/meta_id > (\d+).*OCTET_LENGTH\(meta_value\) <= (\d+).*LIMIT (\d+)/', $query, $matches );
+		$last_meta_id = isset( $matches[1] ) ? (int) $matches[1] : 0;
+		$max_bytes    = isset( $matches[2] ) ? (int) $matches[2] : PHP_INT_MAX;
+		$limit        = isset( $matches[3] ) ? (int) $matches[3] : 10;
+		$rows         = array_values( array_filter( $this->meta_rows, static function ( array $row ) use ( $last_meta_id, $max_bytes ): bool {
+			return (int) $row['meta_id'] > $last_meta_id && strlen( (string) $row['meta_value'] ) <= $max_bytes;
+		} ) );
+		usort( $rows, static function ( array $left, array $right ): int {
+			return (int) $left['meta_id'] <=> (int) $right['meta_id'];
+		} );
+
+		return array_slice( $rows, 0, $limit );
+	}
+
+	/** @param array<string,mixed> $data */
+	public function insert( string $table, array $data ): int {
+		$this->inserts[] = array( 'table' => $table, 'data' => $data );
+		++$this->insert_id;
+
+		return 1;
+	}
+
+	public function flush(): void {
+	}
+}
+
+final class ElementorCrawlerResumeTest extends UnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->requireSource( 'src/class-ss-plugin.php' );
+		$this->requireSource( 'src/class-ss-options.php' );
+		$this->requireSource( 'src/class-ss-util.php' );
+		$this->requireSource( 'src/class-ss-query.php' );
+		$this->requireSource( 'src/models/class-ss-model.php' );
+		$this->requireSource( 'src/models/class-ss-page.php' );
+		$this->requireSource( 'src/crawler/class-ss-crawler.php' );
+		$this->requireSource( 'src/crawler/class-ss-elementor-crawler.php' );
+	}
+
+	public function test_files_and_lottie_rows_resume_from_small_checkpoints(): void {
+		$root = sys_get_temp_dir() . '/ss-elementor-resume-' . bin2hex( random_bytes( 8 ) );
+		wp_mkdir_p( $root . '/assets/deep' );
+		file_put_contents( $root . '/assets/one.css', 'one' );
+		file_put_contents( $root . '/assets/two.js', 'two' );
+		file_put_contents( $root . '/assets/deep/three.svg', 'three' );
+		file_put_contents( $root . '/assets/skip.php', '<?php' );
+
+		$database = new ElementorCrawlerResumeWpdb( array(
+			array( 'meta_id' => 3, 'meta_value' => '{invalid' ),
+			array( 'meta_id' => 9, 'meta_value' => $this->lottieJson( 'https://example.test/first.json' ) ),
+			array( 'meta_id' => 15, 'meta_value' => $this->lottieJson( 'https://example.test/second.json' ) ),
+		) );
+		$GLOBALS['wpdb'] = $database;
+		Options::instance()->set( 'archive_start_time', '2026-08-19 12:00:00' )->save();
+		add_filter( 'simply_static_elementor_crawler_max_entries_per_batch', static function () {
+			return 2;
+		} );
+		add_filter( 'simply_static_elementor_meta_batch_size', static function () {
+			return 1;
+		} );
+		add_filter( 'simply_static_elementor_meta_max_entries_per_batch', static function () {
+			return 1;
+		} );
+
+		$total_added = 0;
+		$complete    = false;
+		$progress    = array();
+
+		try {
+			for ( $attempt = 0; $attempt < 20; $attempt++ ) {
+				$crawler      = new ResumableElementorCrawler( $root );
+				$total_added += $crawler->add_urls_to_queue();
+				$complete     = $crawler->is_complete();
+				$progress     = $crawler->get_progress();
+				if ( $complete ) {
+					break;
+				}
+				self::assertTrue(
+					is_array( Options::instance()->get( 'elementor_directory_crawler_state' ) )
+					|| is_array( Options::instance()->get( 'elementor_crawler_state' ) )
+				);
+			}
+
+			self::assertTrue( $complete );
+			self::assertSame( 6, $total_added );
+			self::assertSame( 6, $progress['added'] );
+			self::assertGreaterThanOrEqual( 7, $progress['scanned'] );
+			self::assertNull( Options::instance()->get( 'elementor_directory_crawler_state' ) );
+			self::assertNull( Options::instance()->get( 'elementor_crawler_state' ) );
+			self::assertNotEmpty( $database->queries );
+			self::assertStringContainsString( 'OCTET_LENGTH(meta_value) <= 5242880', implode( ' ', $database->queries ) );
+
+			$urls = array_column( array_column( $database->inserts, 'data' ), 'url' );
+			sort( $urls );
+			self::assertSame(
+				array(
+					'https://example.test/first.json',
+					'https://example.test/second.json',
+					'https://example.test/wp-content/elementor/deep/three.svg',
+					'https://example.test/wp-content/elementor/one.css',
+					'https://example.test/wp-content/elementor/two.js',
+					'https://example.test/wp-includes/js/imagesloaded.min.js',
+				),
+				$urls
+			);
+		} finally {
+			$this->removeTree( $root );
+		}
+	}
+
+	private function lottieJson( string $url ): string {
+		return (string) json_encode( array(
+			array(
+				'widgetType' => 'lottie',
+				'settings'   => array(
+					'source_json' => array( 'source' => 'library', 'url' => $url ),
+				),
+			),
+		) );
+	}
+
+	private function removeTree( string $root ): void {
+		if ( ! is_dir( $root ) ) {
+			return;
+		}
+		$iterator = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $root, \FilesystemIterator::SKIP_DOTS ),
+			\RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ( $iterator as $item ) {
+			$item->isDir() && ! $item->isLink() ? @rmdir( $item->getPathname() ) : @unlink( $item->getPathname() );
+		}
+		@rmdir( $root );
+	}
+}
+
+final class ResumableElementorCrawler extends Elementor_Crawler {
+
+	/** @var string */
+	private $root;
+
+	public function __construct( string $root ) {
+		parent::__construct();
+		$this->root = $root;
+	}
+
+	public function is_elementor_pro_active() {
+		return true;
+	}
+
+	/** @return array<int,array{basedir:string,baseurl:string}> */
+	protected function get_elementor_scan_directories() : array {
+		return array(
+			array(
+				'basedir' => $this->root . '/assets',
+				'baseurl' => 'https://example.test/wp-content/elementor',
+			),
+		);
+	}
+}

--- a/tests/Unit/PostTypeCrawlerResumeTest.php
+++ b/tests/Unit/PostTypeCrawlerResumeTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Simply_Static\Tests\Unit;
+
+use Simply_Static\Crawler\Post_Type_Crawler;
+use Simply_Static\Options;
+use Simply_Static\Tests\Support\UnitTestCase;
+use Simply_Static\Tests\Support\WpTestEnvironment as WpEnv;
+
+final class PostTypeCrawlerResumeWpdb {
+
+	/** @var string */
+	public $prefix = 'wp_';
+
+	/** @var string */
+	public $posts = 'wp_posts';
+
+	/** @var int */
+	public $insert_id = 1;
+
+	/** @var array<int,array<string,mixed>> */
+	public $inserts = array();
+
+	/** @var string[] */
+	public $queries = array();
+
+	/** @var array<string,int[]> */
+	private $post_ids;
+
+	/** @param array<string,int[]> $post_ids */
+	public function __construct( array $post_ids ) {
+		$this->post_ids = $post_ids;
+	}
+
+	public function get_blog_prefix(): string {
+		return 'wp_';
+	}
+
+	/** @param mixed ...$arguments */
+	public function prepare( string $query, ...$arguments ): string {
+		$values = array_map( static function ( $value ) {
+			return is_string( $value ) ? "'" . addslashes( $value ) . "'" : $value;
+		}, $arguments );
+
+		return vsprintf( $query, $values );
+	}
+
+	/** @return null */
+	public function get_row( string $query, $output = null ) {
+		return null;
+	}
+
+	/** @return int[] */
+	public function get_col( string $query ): array {
+		$this->queries[] = $query;
+		preg_match( "/post_type = '([^']+)'.*ID > (\d+).*LIMIT (\d+)/", $query, $matches );
+		$post_type = $matches[1] ?? '';
+		$last_id   = isset( $matches[2] ) ? (int) $matches[2] : 0;
+		$limit     = isset( $matches[3] ) ? (int) $matches[3] : 100;
+		$ids       = array_values( array_filter( $this->post_ids[ $post_type ] ?? array(), static function ( int $id ) use ( $last_id ): bool {
+			return $id > $last_id;
+		} ) );
+
+		return array_slice( $ids, 0, $limit );
+	}
+
+	/** @return array<int,object> */
+	public function get_results( string $query ): array {
+		$this->queries[] = $query;
+		return array();
+	}
+
+	/** @param array<string,mixed> $data */
+	public function insert( string $table, array $data ): int {
+		$this->inserts[] = array( 'table' => $table, 'data' => $data );
+		++$this->insert_id;
+
+		return 1;
+	}
+
+	public function query( string $query ): int {
+		$this->queries[] = $query;
+		return 0;
+	}
+}
+
+final class PostTypeCrawlerResumeTest extends UnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->requireSource( 'src/class-ss-plugin.php' );
+		$this->requireSource( 'src/class-ss-options.php' );
+		$this->requireSource( 'src/class-ss-util.php' );
+		$this->requireSource( 'src/class-ss-query.php' );
+		$this->requireSource( 'src/models/class-ss-model.php' );
+		$this->requireSource( 'src/models/class-ss-page.php' );
+		$this->requireSource( 'src/crawler/class-ss-crawler.php' );
+		$this->requireSource( 'src/crawler/class-ss-post-type-crawler.php' );
+
+		WpEnv::$post_types = array( 'post' => 'post', 'page' => 'page', 'attachment' => 'attachment' );
+		WpEnv::$options['simply-static'] = array(
+			'post_types'            => array( 'post', 'page' ),
+			'post_types_configured' => true,
+		);
+		Options::instance()->set( 'archive_start_time', '2026-08-19 12:00:00' )->save();
+	}
+
+	protected function tearDown(): void {
+		WpEnv::$post_types = null;
+		unset( $GLOBALS['wpdb'] );
+		parent::tearDown();
+	}
+
+	public function test_public_posts_resume_with_a_keyset_and_bounded_queries(): void {
+		$database = new PostTypeCrawlerResumeWpdb( array(
+			'post' => array( 2, 7, 11 ),
+			'page' => array( 3, 9 ),
+		) );
+		$GLOBALS['wpdb'] = $database;
+		add_filter( 'simply_static_post_type_crawler_batch_size', static function (): int {
+			return 2;
+		} );
+		add_filter( 'simply_static_post_type_crawler_max_entries_per_batch', static function (): int {
+			return 2;
+		} );
+
+		$total_added = 0;
+		$complete    = false;
+		$progress    = array();
+		for ( $attempt = 0; $attempt < 10; ++$attempt ) {
+			$crawler      = new Post_Type_Crawler();
+			$total_added += $crawler->add_urls_to_queue();
+			$complete     = $crawler->is_complete();
+			$progress     = $crawler->get_progress();
+			if ( $complete ) {
+				break;
+			}
+			self::assertIsArray( Options::instance()->get( 'post_type_crawler_state' ) );
+		}
+
+		self::assertTrue( $complete );
+		self::assertSame( 5, $total_added );
+		self::assertSame( 5, $progress['added'] );
+		self::assertSame( 5, $progress['scanned'] );
+		self::assertNull( Options::instance()->get( 'post_type_crawler_state' ) );
+		self::assertStringContainsString( 'ID > 0', $database->queries[0] );
+		self::assertStringContainsString( 'ID > 7', $database->queries[1] );
+		self::assertStringNotContainsString( 'OFFSET', implode( ' ', $database->queries ) );
+
+		$urls = array_column( array_column( $database->inserts, 'data' ), 'url' );
+		self::assertSame(
+			array(
+				'https://example.test/post-2/',
+				'https://example.test/post-7/',
+				'https://example.test/post-11/',
+				'https://example.test/post-3/',
+				'https://example.test/post-9/',
+			),
+			$urls
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- checkpoint filesystem crawlers so large trees resume across background requests
- bound Elementor postmeta processing and make post, term, author, feed, and archive discovery resumable
- add safety limits to synchronous detection paths and clear crawler checkpoints with discovery cleanup

## Verification
- composer test (382 tests, 4648 assertions)
- PHP lint across crawler and task sources
- git diff --check
- site 2226 completed its 5,946-file export with the temporary Elementor bridge

No plugin version bump or release is included.