### PR TITLE
Preserve extensionless additional file paths

### DIFF
--- a/src/class-ss-url-fetcher.php
+++ b/src/class-ss-url-fetcher.php
@@ -467,14 +467,19 @@ class Url_Fetcher {
 			$path = $local_path;
 		}
 
-		$path_info = Util::url_path_info( $path );
+		$path_info    = Util::url_path_info( $path );
+		$page_handler = $static_page->get_handler();
 
 		$relative_file_dir = $path_info['dirname'];
 		$relative_file_dir = Util::remove_leading_directory_separator( $relative_file_dir );
 
-		// If there's no extension, we're going to create a directory with the
-		// filename and place an index.html/xml file in there.
-		if ( $path_info['extension'] === '' && ! $static_page->is_binary_file() ) {
+		// If there's no extension, create a directory with the filename and place
+		// an index.html/xml file in it unless the page handler represents a file.
+		if (
+			$path_info['extension'] === ''
+			&& ! $static_page->is_binary_file()
+			&& ! $page_handler->should_preserve_extensionless_filename()
+		) {
 			if ( $path_info['filename'] !== '' ) {
 				// the filename would be blank for the root url, in that
 				// instance we don't want to add an extra slash
@@ -541,8 +546,6 @@ class Url_Fetcher {
 				Util::debug_log( '[SS][SEARCH_QS] Using non-hashed __qs/ directory for URL: ' . $static_page->url );
 			}
 		}
-
-		$page_handler = $static_page->get_handler();
 
 		$path_info         = apply_filters( 'simply_static_page_path_info', $page_handler->get_path_info( $path_info ), $static_page );
 		$relative_file_dir = apply_filters( 'simple_static_page_relative_file_dir', $page_handler->get_relative_dir( $relative_file_dir ), $static_page );

--- a/src/handlers/class-ss-additional-file-handler.php
+++ b/src/handlers/class-ss-additional-file-handler.php
@@ -2,4 +2,13 @@
 
 namespace Simply_Static;
 
-class Additional_File_Handler extends Page_Handler {}
+class Additional_File_Handler extends Page_Handler {
+	/**
+	 * Additional files must retain their source filename even without an extension.
+	 *
+	 * @return bool
+	 */
+	public function should_preserve_extensionless_filename() {
+		return true;
+	}
+}

--- a/src/handlers/class-ss-page-handler.php
+++ b/src/handlers/class-ss-page-handler.php
@@ -81,6 +81,19 @@ class Page_Handler {
 
 	public function after_file_fetch( $destination_dir ) {}
 
+	/**
+	 * Whether an extensionless URL represents a file whose name must be kept.
+	 *
+	 * Normal pages without extensions are written to an index file in a
+	 * directory. File handlers can opt out so deployment control files such as
+	 * _headers and _redirects do not become _headers/index.html.
+	 *
+	 * @return bool
+	 */
+	public function should_preserve_extensionless_filename() {
+		return false;
+	}
+
     public function get_path_info( $path_info ) { return $path_info; }
     public function get_relative_dir( $relative_dir ) { return $relative_dir; }
 }

--- a/src/handlers/class-ss-text-file-handler.php
+++ b/src/handlers/class-ss-text-file-handler.php
@@ -9,6 +9,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Text_File_Handler extends Page_Handler {
 	/**
+	 * Rule files such as _headers and _redirects must remain extensionless.
+	 *
+	 * @return bool
+	 */
+	public function should_preserve_extensionless_filename() {
+		return true;
+	}
+
+	/**
 	 * After the file is fetched into the archive directory, replace any origin URLs
 	 * with the destination URL in plain-text files like robots.txt, llms.txt, _redirects, and _headers.
 	 *

--- a/tests/Unit/ExtensionlessFilePathTest.php
+++ b/tests/Unit/ExtensionlessFilePathTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Simply_Static\Tests\Unit;
+
+use ReflectionClass;
+use Simply_Static\Additional_File_Handler;
+use Simply_Static\Options;
+use Simply_Static\Page;
+use Simply_Static\Tests\Support\UnitTestCase;
+use Simply_Static\Text_File_Handler;
+use Simply_Static\Url_Fetcher;
+
+final class ExtensionlessFilePathTest extends UnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->requireSource( 'src/class-ss-plugin.php' );
+		$this->requireSource( 'src/class-ss-options.php' );
+		$this->requireSource( 'src/class-ss-phpuri.php' );
+		$this->requireSource( 'src/class-ss-util.php' );
+		$this->requireSource( 'src/class-ss-query.php' );
+		$this->requireSource( 'src/models/class-ss-model.php' );
+		$this->requireSource( 'src/handlers/class-ss-page-handler.php' );
+		$this->requireSource( 'src/handlers/class-ss-additional-file-handler.php' );
+		$this->requireSource( 'src/handlers/class-ss-text-file-handler.php' );
+		$this->requireSource( 'src/models/class-ss-page.php' );
+		$this->requireSource( 'src/class-ss-url-fetcher.php' );
+
+		Options::reinstance();
+	}
+
+	/**
+	 * @dataProvider extensionlessFileProvider
+	 */
+	public function test_file_handlers_preserve_extensionless_paths( string $url, string $handler, string $expected ): void {
+		$page = Page::initialize(
+			array(
+				'url'           => $url,
+				'content_type'  => 'text/plain',
+				'handler'       => $handler,
+			)
+		);
+
+		self::assertSame( $expected, $this->fetcher()->get_expected_file_path_for_static_page( $page ) );
+	}
+
+	/** @return array<string,array{string,string,string}> */
+	public function extensionlessFileProvider(): array {
+		return array(
+			'headers rule file' => array(
+				'https://example.test/_headers',
+				Text_File_Handler::class,
+				'_headers',
+			),
+			'redirects rule file' => array(
+				'https://example.test/_redirects',
+				Text_File_Handler::class,
+				'_redirects',
+			),
+			'nested rule file' => array(
+				'https://example.test/config/_headers',
+				Text_File_Handler::class,
+				'config/_headers',
+			),
+			'custom additional file' => array(
+				'https://example.test/CNAME',
+				Additional_File_Handler::class,
+				'CNAME',
+			),
+		);
+	}
+
+	public function test_regular_extensionless_pages_still_use_directory_indexes(): void {
+		$page = Page::initialize(
+			array(
+				'url'          => 'https://example.test/about',
+				'content_type' => 'text/html; charset=UTF-8',
+			)
+		);
+
+		self::assertSame( 'about/index.html', $this->fetcher()->get_expected_file_path_for_static_page( $page ) );
+	}
+
+	private function fetcher(): Url_Fetcher {
+		$reflection = new ReflectionClass( Url_Fetcher::class );
+
+		return $reflection->newInstanceWithoutConstructor();
+	}
+}


### PR DESCRIPTION
## Summary
- preserve extensionless filenames for additional-file and text-file handlers
- keep deployment control files such as `_headers` and `_redirects` at their intended paths
- add regression coverage for `_headers`, `_redirects`, nested rule files, `CNAME`, and regular page URLs

## Problem
`_headers` was handled as a text file so origin URLs could be replaced, but the export path builder then treated it as a normal extensionless page and wrote `_headers/index.html`. A GitHub repository containing a root `_headers` blob cannot also contain a tree at `_headers`, causing `GitRPC::BadObjectState` during tree creation.

## Verification
- `composer test` — 387 tests, 4,653 assertions
- focused regression suite — 5 tests, 5 assertions
- PHP syntax checks and `git diff --check`